### PR TITLE
fix: Manually-paused uploads don't resume again

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -173,7 +173,7 @@ public final class MuxUpload : Hashable, Equatable {
             MuxUploadSDK.logger?.warning("start() called but upload is already in progress")
             fileWorker?.addDelegate(
                 withToken: id,
-                InternalUploaderDelegate { [weak self] state in self?.handleStateUpdate(state) }
+                InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
             )
             fileWorker?.start()
             return

--- a/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
@@ -140,7 +140,6 @@ public final class UploadManager {
         let manager: UploadManager
         
         func chunkedFileUploader(_ uploader: ChunkedFileUploader, stateUpdated state: ChunkedFileUploader.InternalUploadState) {
-            NSLog("UploadManager: uploaded some")
             Task.detached {
                 await manager.uploadActor.updateUpload(uploader.uploadInfo, withUpdate: state)
                 manager.notifyDelegates()

--- a/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
@@ -140,6 +140,7 @@ public final class UploadManager {
         let manager: UploadManager
         
         func chunkedFileUploader(_ uploader: ChunkedFileUploader, stateUpdated state: ChunkedFileUploader.InternalUploadState) {
+            NSLog("UploadManager: uploaded some")
             Task.detached {
                 await manager.uploadActor.updateUpload(uploader.uploadInfo, withUpdate: state)
                 manager.notifyDelegates()

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -120,17 +120,6 @@ class ChunkedFileUploader {
                 notifyStateFromWorker(.success(success))
             } catch {
                 file.close()
-                if case let .uploading(update) = self.currentState {
-                    //switch lastUpdate {
-                    //case .uploading(let update): do {
-//                        if lastReadCount > 0 {
-//                            lastReadCount = UInt64(update.progress.completedUnitCount)
-//                        }
-                    //}
-                    //default: break
-                    //}
-                }
-                
                 if error is CancellationError {
                     MuxUploadSDK.logger?.debug("Task finished due to cancellation in state \(String(describing: self.currentState))")
                     if case let .uploading(update) = self.currentState {

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -22,7 +22,6 @@ class ChunkedFileUploader {
     private var currentWorkTask: Task<(), Never>? = nil
     private var _currentState: InternalUploadState = .ready
     private var overallProgress: Progress = Progress()
-    private var lastSeenUpdate: InternalUploadState? = nil
     private var lastReadCount: UInt64 = 0
     private let reporter = Reporter()
     
@@ -121,20 +120,28 @@ class ChunkedFileUploader {
                 notifyStateFromWorker(.success(success))
             } catch {
                 file.close()
-                if let lastUpdate = lastSeenUpdate {
-                    switch lastUpdate {
-                    case .uploading(let update): do {
-                        if lastReadCount > 0 {
-                            lastReadCount = UInt64(update.progress.completedUnitCount)
-                        }
-                    }
-                    default: break
-                    }
+                if case let .uploading(update) = self.currentState {
+                    //switch lastUpdate {
+                    //case .uploading(let update): do {
+//                        if lastReadCount > 0 {
+//                            lastReadCount = UInt64(update.progress.completedUnitCount)
+//                        }
+                    //}
+                    //default: break
+                    //}
                 }
-                let uploadError = InternalUploaderError(reason: error, lastByte: lastReadCount)
-                notifyStateFromWorker(.failure(uploadError))
+                
+                if error is CancellationError {
+                    MuxUploadSDK.logger?.debug("Task finished due to cancellation in state \(String(describing: self.currentState))")
+                    if case let .uploading(update) = self.currentState {
+                        self._currentState = .paused(update)
+                    }
+                } else {
+                    MuxUploadSDK.logger?.debug("Task finished due to error in state \(String(describing: self.currentState))")
+                    let uploadError = InternalUploaderError(reason: error, lastByte: lastReadCount)
+                    notifyStateFromWorker(.failure(uploadError))
+                }
             }
-            
         }
         currentWorkTask = task
     }

--- a/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
+++ b/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
@@ -27,6 +27,7 @@ class UploadPersistence {
                 try remove(entryAtAbsUrl: upload.uploadURL)
             }
         } catch {
+            // This makes a lot of noise on the emulator, but might be worth logging if you're having issues around here
             //MuxUploadSDK.logger?.critical("Swallowed error writing to UploadPersistence! Error below:\n\(error.localizedDescription)")
         }
     }
@@ -81,8 +82,6 @@ class UploadPersistence {
     
     func maybeOpenCache() throws {
         if cache == nil {
-            //MuxUploadSDK.logger?.info("Had to populate write-through cache")
-            
             try self.uploadsFile.maybeOpenCache()
             self.cache = try uploadsFile.readContents().asDictionary()
             try cleanUpOldEntries() // Obligatory
@@ -207,7 +206,6 @@ fileprivate struct UploadsFileImpl : UploadsFile {
     func maybeOpenCache() throws {
         let dir = fileURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: dir.path) {
-            //MuxUploadSDK.logger?.info("Had to create temp dir")
             try FileManager.default.createDirectory(atPath: dir.path, withIntermediateDirectories: true)
         }
         

--- a/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
+++ b/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
@@ -27,7 +27,7 @@ class UploadPersistence {
                 try remove(entryAtAbsUrl: upload.uploadURL)
             }
         } catch {
-            MuxUploadSDK.logger?.critical("Swallowed error writing to UploadPersistence! Error below:\n\(error.localizedDescription)")
+            //MuxUploadSDK.logger?.critical("Swallowed error writing to UploadPersistence! Error below:\n\(error.localizedDescription)")
         }
     }
     
@@ -81,7 +81,7 @@ class UploadPersistence {
     
     func maybeOpenCache() throws {
         if cache == nil {
-            MuxUploadSDK.logger?.info("Had to populate write-through cache")
+            //MuxUploadSDK.logger?.info("Had to populate write-through cache")
             
             try self.uploadsFile.maybeOpenCache()
             self.cache = try uploadsFile.readContents().asDictionary()
@@ -207,7 +207,7 @@ fileprivate struct UploadsFileImpl : UploadsFile {
     func maybeOpenCache() throws {
         let dir = fileURL.deletingLastPathComponent()
         if !FileManager.default.fileExists(atPath: dir.path) {
-            MuxUploadSDK.logger?.info("Had to create temp dir")
+            //MuxUploadSDK.logger?.info("Had to create temp dir")
             try FileManager.default.createDirectory(atPath: dir.path, withIntermediateDirectories: true)
         }
         


### PR DESCRIPTION
Uploads wouldn't start because the internal `ChunkedFileUploader` was in the `failed` state improperly. `CancellationError` should send it to the `paused` state. This works for normal cancellation too