### PR TITLE
Fix chunk request byte header math

### DIFF
--- a/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
@@ -170,7 +170,15 @@ fileprivate actor ChunkActor {
     let urlSession: URLSession
     
     func upload() async throws -> URLResponse {
-        let contentRangeValue = "bytes \(chunk.startByte)-\(chunk.endByte - 1)/\(chunk.totalFileSize)"
+        let startByte = "\(chunk.startByte)"
+        let endByte: String
+        if chunk.endByte == 0 {
+            endByte = "0"
+        } else {
+            endByte = "\(chunk.endByte - 1)"
+        }
+
+        let contentRangeValue = "bytes \(startByte)-\(endByte)/\(chunk.totalFileSize)"
         var request = URLRequest(url: uploadURL)
         request.httpMethod = "PUT"
         request.setValue("video/*", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
A crash from an arithmetic overflow happens when subtracting from `UInt` that is equal to zero.

This is a quick fix for the crash, there's still a remaining issue of how to handle an `endByte`. 

This is likely indicating there's some sort of issue reading the file and the chunk request associated with this content range will most likely fail. That will treated by the SDK as an error more gracefully than just crashing.