### PR TITLE
Input standardization 3

### DIFF
--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -27,14 +27,22 @@ class UploadInputStandardizationWorker {
 
     func standardize(
         sourceAsset: AVAsset,
+        maximumResolution: UploadOptions.InputStandardization.MaximumResolution,
         outputURL: URL,
         completion: @escaping (AVAsset, AVAsset?, URL?, Bool) -> ()
     ) {
 
         let availableExportPresets = AVAssetExportSession.allExportPresets()
 
+        let exportPreset: String
+        if maximumResolution == .preset1280x720 {
+            exportPreset = AVAssetExportPreset1280x720
+        } else {
+            exportPreset = AVAssetExportPreset1920x1080
+        }
+
         guard availableExportPresets.contains(where: {
-            $0 == AVAssetExportPreset1280x720
+            $0 == exportPreset
         }) else {
             // TODO: Use VideoToolbox if export preset unavailable
             completion(sourceAsset, nil, nil, false)
@@ -43,7 +51,7 @@ class UploadInputStandardizationWorker {
 
         guard let exportSession = AVAssetExportSession(
             asset: sourceAsset,
-            presetName: AVAssetExportPreset1280x720
+            presetName: exportPreset
         ) else {
             // TODO: Use VideoToolbox if export session fails to initialize
             completion(sourceAsset, nil, nil, false)

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -5,9 +5,64 @@
 import AVFoundation
 import Foundation
 
+protocol Standardizable { }
+
+extension AVAsset: Standardizable { }
+
+enum StandardizationResult {
+    case success(standardizedAsset: AVAsset)
+    case failure(error: Error)
+}
+
+enum StandardizationStrategy {
+    // Prefer using export session whenever possible
+    case exportSession
+}
+
 class UploadInputStandardizationWorker {
 
     var sourceInput: AVAsset?
 
     var standardizedInput: AVAsset?
+
+    func standardize(
+        sourceAsset: AVAsset,
+        outputURL: URL,
+        completion: @escaping (AVAsset, AVAsset?, URL?, Bool) -> ()
+    ) {
+
+        let availableExportPresets = AVAssetExportSession.allExportPresets()
+
+        guard availableExportPresets.contains(where: {
+            $0 == AVAssetExportPreset1280x720
+        }) else {
+            // TODO: Use VideoToolbox if export preset unavailable
+            completion(sourceAsset, nil, nil, false)
+            return
+        }
+
+        guard let exportSession = AVAssetExportSession(
+            asset: sourceAsset,
+            presetName: AVAssetExportPreset1280x720
+        ) else {
+            // TODO: Use VideoToolbox if export session fails to initialize
+            completion(sourceAsset, nil, nil, false)
+            return
+        }
+
+        exportSession.outputFileType = .mp4
+        exportSession.outputURL = outputURL
+
+        // TODO: Use Swift Concurrency
+        exportSession.exportAsynchronously {
+            if let exportError = exportSession.error {
+                completion(sourceAsset, nil, nil, false)
+            } else if let standardizedAssetURL = exportSession.outputURL {
+                let standardizedAsset = AVAsset(url: standardizedAssetURL)
+                completion(sourceAsset, standardizedAsset, outputURL, true)
+            } else {
+                completion(sourceAsset, nil, nil, false)
+            }
+        }
+    }
 }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -11,6 +11,7 @@ class UploadInputStandardizer {
     func standardize(
         id: String,
         sourceAsset: AVAsset,
+        maximumResolution: UploadOptions.InputStandardization.MaximumResolution,
         outputURL: URL,
         completion: @escaping (AVAsset, AVAsset?, URL?, Bool) -> ()
     ) {
@@ -18,6 +19,7 @@ class UploadInputStandardizer {
 
         worker.standardize(
             sourceAsset: sourceAsset,
+            maximumResolution: maximumResolution,
             outputURL: outputURL,
             completion: completion
         )

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -8,29 +8,28 @@ import Foundation
 class UploadInputStandardizer {
     var workers: [String: UploadInputStandardizationWorker] = [:]
 
-    var fileManager: FileManager = .default
-
     func standardize(
         id: String,
         sourceAsset: AVAsset,
+        outputURL: URL,
         completion: @escaping (AVAsset, AVAsset?, URL?, Bool) -> ()
     ) {
         let worker = UploadInputStandardizationWorker()
 
-        // TODO: inject Date() for testing purposes
-        let outputFileName = "upload-\(Date().timeIntervalSince1970)"
-
-        let temporaryDirectory = fileManager.temporaryDirectory
-        let temporaryOutputURL = URL(
-            fileURLWithPath: outputFileName,
-            relativeTo: temporaryDirectory
-        )
-
         worker.standardize(
             sourceAsset: sourceAsset,
-            outputURL: temporaryOutputURL,
+            outputURL: outputURL,
             completion: completion
         )
         workers[id] = worker
+    }
+
+    // Storing the worker might not be necessary if an
+    // alternative reference is in place outside the
+    // stack frame
+    func acknowledgeCompletion(
+        id: String
+    ) {
+        workers[id] = nil
     }
 }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -6,5 +6,31 @@ import AVFoundation
 import Foundation
 
 class UploadInputStandardizer {
-    
+    var workers: [String: UploadInputStandardizationWorker] = [:]
+
+    var fileManager: FileManager = .default
+
+    func standardize(
+        id: String,
+        sourceAsset: AVAsset,
+        completion: @escaping (AVAsset, AVAsset?, URL?, Bool) -> ()
+    ) {
+        let worker = UploadInputStandardizationWorker()
+
+        // TODO: inject Date() for testing purposes
+        let outputFileName = "upload-\(Date().timeIntervalSince1970)"
+
+        let temporaryDirectory = fileManager.temporaryDirectory
+        let temporaryOutputURL = URL(
+            fileURLWithPath: outputFileName,
+            relativeTo: temporaryDirectory
+        )
+
+        worker.standardize(
+            sourceAsset: sourceAsset,
+            outputURL: temporaryOutputURL,
+            completion: completion
+        )
+        workers[id] = worker
+    }
 }

--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -530,10 +530,16 @@ public final class MuxUpload : Hashable, Equatable {
                         fileURLWithPath: outputFileName,
                         relativeTo: outputDirectory
                     )
+                    let maximumResolution = self.input
+                        .uploadInfo
+                        .options
+                        .inputStandardization
+                        .maximumResolution
 
                     self.inputStandardizer.standardize(
                         id: self.id,
                         sourceAsset: AVAsset(url: videoFile),
+                        maximumResolution: maximumResolution,
                         outputURL: outputURL
                     ) { sourceAsset, standardizedAsset, outputURL, success in
 

--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -488,6 +488,26 @@ public final class MuxUpload : Hashable, Equatable {
                 case .inspectionFailure:
                     // TODO: Request upload confirmation
                     // before proceeding
+
+                    guard let nonStandardInputHandler = self.nonStandardInputHandler else {
+                        self.startNetworkTransport(
+                            videoFile: videoFile
+                        )
+                        return
+                    }
+
+                    let shouldCancelUpload = nonStandardInputHandler()
+
+                    if !shouldCancelUpload {
+                        self.startNetworkTransport(
+                            videoFile: videoFile
+                        )
+                    } else {
+                        self.fileWorker?.cancel()
+                        self.uploadManager.acknowledgeUpload(id: self.id)
+                        self.input.processUploadCancellation()
+                    }
+
                     self.startNetworkTransport(videoFile: videoFile)
                 case .standard:
                     self.startNetworkTransport(videoFile: videoFile)

--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -490,9 +490,19 @@ public final class MuxUpload : Hashable, Equatable {
                     """
                     )
 
+                    // TODO: inject Date() for testing purposes
+                    let outputFileName = "upload-\(Date().timeIntervalSince1970)"
+
+                    let outputDirectory = FileManager.default.temporaryDirectory
+                    let outputURL = URL(
+                        fileURLWithPath: outputFileName,
+                        relativeTo: outputDirectory
+                    )
+
                     self.inputStandardizer.standardize(
                         id: self.id,
-                        sourceAsset: AVAsset(url: videoFile)
+                        sourceAsset: AVAsset(url: videoFile),
+                        outputURL: outputURL
                     ) { sourceAsset, standardizedAsset, outputURL, success in
 
                         if let outputURL, success {

--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -474,6 +474,8 @@ public final class MuxUpload : Hashable, Equatable {
 
                 switch inspectionResult {
                 case .inspectionFailure:
+                    // TODO: Request upload confirmation
+                    // before proceeding
                     self.startNetworkTransport(videoFile: videoFile)
                 case .standard:
                     self.startNetworkTransport(videoFile: videoFile)
@@ -488,8 +490,21 @@ public final class MuxUpload : Hashable, Equatable {
                     """
                     )
 
-                    // Skip format standardization
-                    self.startNetworkTransport(videoFile: videoFile)
+                    self.inputStandardizer.standardize(
+                        id: self.id,
+                        sourceAsset: AVAsset(url: videoFile)
+                    ) { sourceAsset, standardizedAsset, outputURL, success in
+
+                        if let outputURL, success {
+                            self.startNetworkTransport(
+                                videoFile: outputURL
+                            )
+                        } else {
+                            self.startNetworkTransport(
+                                videoFile: videoFile
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/apps/Test App/Test App/Model/UploadListModel.swift
+++ b/apps/Test App/Test App/Model/UploadListModel.swift
@@ -35,7 +35,7 @@ class UploadListModel : ObservableObject {
                 self.lastKnownUploads = Array(uploadSet)
                     .sorted(
                         by: { lhs, rhs in
-                            lhs.uploadStatus.startTime >= rhs.uploadStatus.startTime
+                            (lhs.uploadStatus?.startTime ?? 0) >= (rhs.uploadStatus?.startTime ?? 0)
                         }
                     )
                 }

--- a/apps/Test App/Test App/Screens/UploadListView.swift
+++ b/apps/Test App/Test App/Screens/UploadListView.swift
@@ -125,11 +125,11 @@ fileprivate struct ListItem: View {
     }
     
     private func statusLine(status: MuxUpload.TransportStatus?) -> String {
-        guard let status = status, let progress = status.progress, status.startTime > 0 else {
+        guard let status = status, let progress = status.progress, let startTime = status.startTime, startTime > 0 else {
             return "missing status"
         }
         
-        let totalTimeSecs = status.updatedTime - status.startTime
+        let totalTimeSecs = status.updatedTime - (status.startTime ?? 0)
         let totalTimeMs = Int64((totalTimeSecs) * 1000)
         let kbytesPerSec = (progress.completedUnitCount) / totalTimeMs // bytes/milli = kb/sec
         let fourSigs = NumberFormatter()


### PR DESCRIPTION
This PR puts in place a very basic form of input standardization. Based on the result of the input inspection (added in previous PR) the SDK may elect to convert the input format for faster processing by the server-side ingestion pipeline.

This PR is draft because the implementation is incomplete, the following is missing:

- [x] API to notify SDK client if input standardization fails and cancel the upload if desired
- [x] Correctly handling the `maximumResolution` option
- Adjustments to example code to use the `PHAsset` based initializers to avoid exporting the input twice ( coming in separate PR)
- Event reporting (coming in separate PR)
