### PR TITLE
Remove force unwrap

### DIFF
--- a/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
@@ -34,11 +34,15 @@ class ChunkWorker {
     }
     
     func getTask() -> Task<Success, Error> {
-        if uploadTask == nil {
+
+        guard let uploadTask else {
             chunkStartTime = Date().timeIntervalSince1970
-            uploadTask = makeUploadTask()
+            let uploadTask = makeUploadTask()
+            self.uploadTask = uploadTask
+            return uploadTask
         }
-        return uploadTask!
+
+        return uploadTask
     }
     
     func cancel() {


### PR DESCRIPTION
The force unwrap here can potentially cause a crash if the `nil` check is ever accidentally removed. Replace with a `guard let` check that will trigger a build error instead.