### PR TITLE
Remove stored file size property from ChunkedFile

### DIFF
--- a/Sources/MuxUploadSDK/Extensions/FileManager+FileOperations.swift
+++ b/Sources/MuxUploadSDK/Extensions/FileManager+FileOperations.swift
@@ -1,0 +1,17 @@
+//
+//  FileManager+FileOperations.swift
+//
+
+import Foundation
+
+extension FileManager {
+
+    // Work around Swift compiler not bridging Dictionary
+    // and NSDictionary properly when calling attributesOfItem
+    func fileSizeOfItem(
+        atPath path: String
+    ) throws -> UInt64 {
+        (try attributesOfItem(atPath: path) as NSDictionary)
+            .fileSize()
+    }
+}

--- a/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
@@ -13,18 +13,28 @@ import Foundation
 /// Buffers are allocated for each new chunk so they can safely escape to other threads
 /// Call  ``close`` when you're done with this object
 class ChunkedFile {
-    
-    static let SIZE_UNKNOWN: UInt64 = 0
-    /// The size of the file. Call ``open`` to populate this with a real value, otherwise it will be ``SIZE_UNKNOWN``
-    var fileSize: UInt64 {
-        return _fileSize
+
+    private struct State {
+        var fileHandle: FileHandle
+        var fileURL: URL
+        var filePosition: UInt64 = 0
     }
-    
+
     private let chunkSize: Int
-    
-    private var fileHandle: FileHandle?
-    private var filePos: UInt64 = 0
-    private var _fileSize: UInt64 = SIZE_UNKNOWN
+
+    var fileManager = FileManager.default
+
+    private var state: State?
+
+    private var fileHandle: FileHandle? {
+        state?.fileHandle
+    }
+    private var fileURL: URL? {
+        state?.fileURL
+    }
+    private var filePos: UInt64 {
+        state?.filePosition ?? 0
+    }
     
     /// Reads the next chunk from the file, advancing the file for the next read
     ///  This method does synchronous I/O, so call it in the background
@@ -39,20 +49,21 @@ class ChunkedFile {
             return Result.failure(ChunkedFileError.fileHandle(error))
         }
     }
-    
+
     /// Opens the internal file ahead of time. Calling this is optional, but it's available
     /// Calling this multiple times (on the same thread) will have no effect unless you also ``close`` it
     /// Throws if the file couldn't be opened
     func openFile(fileURL: URL) throws {
-        if fileHandle == nil {
+        if state == nil {
             do {
-                guard let fileSize = try FileManager.default.attributesOfItem(atPath: fileURL.path)[FileAttributeKey.size] as? UInt64 else {
+                guard let fileSize = try fileManager.attributesOfItem(atPath: fileURL.path)[FileAttributeKey.size] as? UInt64 else {
                     throw ChunkedFileError.invalidState("Cannot retrieve file size")
                 }
-                self._fileSize = fileSize
-                
-                let handle = try FileHandle(forReadingFrom: fileURL)
-                fileHandle = handle
+                let fileHandle = try FileHandle(forReadingFrom: fileURL)
+                state = State(
+                    fileHandle: fileHandle,
+                    fileURL: fileURL
+                )
                 MuxUploadSDK.logger?.info("Opened file with len \(String(describing: fileSize)) at path \(fileURL.path)")
             } catch {
                 throw ChunkedFileError.fileHandle(error)
@@ -68,23 +79,31 @@ class ChunkedFile {
         } catch {
             MuxUploadSDK.logger?.warning("Swallowed error closing file: \(error.localizedDescription)")
         }
-        fileHandle = nil
-        filePos = 0
-        _fileSize = ChunkedFile.SIZE_UNKNOWN
+        state = nil
     }
     
     func seekTo(byte: UInt64) throws {
         // Worst case: we start from the begining and there's a few very quick chunk successes
         try fileHandle?.seek(toOffset: byte)
-        filePos = byte
+        state?.filePosition = byte
     }
     
     private func doReadNextChunk() throws -> FileChunk {
         MuxUploadSDK.logger?.info("--doReadNextChunk")
-        guard let fileHandle = fileHandle else {
+        guard let fileHandle = fileHandle, let fileURL = fileURL else {
             throw ChunkedFileError.invalidState("doReadNextChunk called without file handle. Did you call open()?")
         }
         let data = try fileHandle.read(upToCount: chunkSize)
+
+        let fileAttributes = try fileManager.attributesOfItem(
+            atPath: fileURL.path
+        )
+        guard let fileSize = fileAttributes[
+            FileAttributeKey.size
+        ] as? UInt64 else {
+            throw ChunkedFileError.invalidState("Cannot retrieve file size")
+        }
+
         guard let data = data else {
             // Called while already at the end of the file. We read zero bytes, "ending" at the end of the file
             return FileChunk(startByte: fileSize, endByte: fileSize, totalFileSize: fileSize, chunkData: Data(capacity: 0))
@@ -100,7 +119,7 @@ class ChunkedFile {
             chunkData: data
         )
         
-        self.filePos = newFilePos
+        state?.filePosition = newFilePos
         
         return chunk
     }

--- a/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
@@ -56,7 +56,7 @@ class ChunkedFile {
     func openFile(fileURL: URL) throws {
         if state == nil {
             do {
-                let fileSize = try (fileManager.attributesOfItem(atPath: fileURL.path) as NSDictionary).fileSize()
+                let fileSize = try fileManager.fileSizeOfItem(atPath: fileURL.path)
                 let fileHandle = try FileHandle(forReadingFrom: fileURL)
                 state = State(
                     fileHandle: fileHandle,
@@ -93,9 +93,9 @@ class ChunkedFile {
         }
         let data = try fileHandle.read(upToCount: chunkSize)
 
-        let fileSize = try (fileManager.attributesOfItem(
+        let fileSize = try fileManager.fileSizeOfItem(
             atPath: fileURL.path
-        ) as NSDictionary).fileSize()
+        )
 
         guard let data = data else {
             // Called while already at the end of the file. We read zero bytes, "ending" at the end of the file

--- a/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/ChunkedFile.swift
@@ -56,9 +56,7 @@ class ChunkedFile {
     func openFile(fileURL: URL) throws {
         if state == nil {
             do {
-                guard let fileSize = try fileManager.attributesOfItem(atPath: fileURL.path)[FileAttributeKey.size] as? UInt64 else {
-                    throw ChunkedFileError.invalidState("Cannot retrieve file size")
-                }
+                let fileSize = try (fileManager.attributesOfItem(atPath: fileURL.path) as NSDictionary).fileSize()
                 let fileHandle = try FileHandle(forReadingFrom: fileURL)
                 state = State(
                     fileHandle: fileHandle,
@@ -95,14 +93,9 @@ class ChunkedFile {
         }
         let data = try fileHandle.read(upToCount: chunkSize)
 
-        let fileAttributes = try fileManager.attributesOfItem(
+        let fileSize = try (fileManager.attributesOfItem(
             atPath: fileURL.path
-        )
-        guard let fileSize = fileAttributes[
-            FileAttributeKey.size
-        ] as? UInt64 else {
-            throw ChunkedFileError.invalidState("Cannot retrieve file size")
-        }
+        ) as NSDictionary).fileSize()
 
         guard let data = data else {
             // Called while already at the end of the file. We read zero bytes, "ending" at the end of the file

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -88,10 +88,7 @@ class ChunkedFileUploader {
         let task = Task.detached { [self] in
             do {
                 // It's fine if it's already open, that's handled by ignoring the call
-                let fileSize = (try? FileManager.default.attributesOfItem(
-                    atPath: uploadInfo.videoFile.path
-                )[FileAttributeKey.size] as? UInt64) ?? 0
-
+                let fileSize = (try FileManager.default.attributesOfItem(atPath: uploadInfo.videoFile.path) as NSDictionary).fileSize()
                 let result = try await makeWorker().performUpload()
                 file.close()
 
@@ -243,16 +240,9 @@ fileprivate actor Worker {
         try chunkedFile.seekTo(byte: startingReadCount)
         
         let startTime = Date().timeIntervalSince1970
-
-        let fileAttributes = try FileManager.default.attributesOfItem(
+        let fileSize = (try FileManager.default.attributesOfItem(
             atPath: uploadInfo.videoFile.path
-        )
-        guard let fileSize = fileAttributes[
-            FileAttributeKey.size
-        ] as? UInt64 else {
-            // TODO: Does the worker need its own error defintion?
-            throw ChunkedFileError.invalidState("Cannot retrieve file size")
-        }
+        ) as NSDictionary).fileSize()
 
         let wideFileSize: Int64
 

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -88,7 +88,9 @@ class ChunkedFileUploader {
         let task = Task.detached { [self] in
             do {
                 // It's fine if it's already open, that's handled by ignoring the call
-                let fileSize = (try FileManager.default.attributesOfItem(atPath: uploadInfo.videoFile.path) as NSDictionary).fileSize()
+                let fileSize = try FileManager.default.fileSizeOfItem(
+                    atPath: uploadInfo.videoFile.path
+                )
                 let result = try await makeWorker().performUpload()
                 file.close()
 
@@ -240,9 +242,9 @@ fileprivate actor Worker {
         try chunkedFile.seekTo(byte: startingReadCount)
         
         let startTime = Date().timeIntervalSince1970
-        let fileSize = (try FileManager.default.attributesOfItem(
+        let fileSize = try FileManager.default.fileSizeOfItem(
             atPath: uploadInfo.videoFile.path
-        ) as NSDictionary).fileSize()
+        )
 
         let wideFileSize: Int64
 

--- a/Tests/MuxUploadSDKTests/Internal Utilities Tests/ChunkedFileTests.swift
+++ b/Tests/MuxUploadSDKTests/Internal Utilities Tests/ChunkedFileTests.swift
@@ -77,14 +77,7 @@ final class ChunkedFileTests: XCTestCase {
     
     func testMisuseBeforeOpen() throws {
         let file = ChunkedFile(chunkSize: 10 * 1000 * 1000)
-        
-        let fileSizeBeforeOpen = file.fileSize
-        XCTAssertEqual(
-            fileSizeBeforeOpen,
-            ChunkedFile.SIZE_UNKNOWN,
-            "File size should not be known before open"
-        )
-        
+
         let readResult = file.readNextChunk()
         switch readResult {
         case .success(_): return XCTFail("readNextChunk should fail before open")
@@ -103,13 +96,6 @@ final class ChunkedFileTests: XCTestCase {
         
         try file.openFile(fileURL: testFileURL)
         file.close()
-        
-        let fileSizeAfterClose = file.fileSize
-        XCTAssertEqual(
-            fileSizeAfterClose,
-            ChunkedFile.SIZE_UNKNOWN,
-            "File size should not be known after close"
-        )
         
         let chunkResult = file.readNextChunk()
         switch chunkResult {


### PR DESCRIPTION
Currently the file size is stored in ChunkedFile, this happens as a side effect of opening the file. This PR removes the stored property and retrieves the file size from `FileManager` directly whenever it is needed. The intention of this change is to reduced duplicate state between the SDK and `FileManager` as well as reduce the number of possible state permutations the SDK can take on.