### PR TITLE
Bundle extension

### DIFF
--- a/Sources/MuxUploadSDK/Extensions/Bundle+Reporting.swift
+++ b/Sources/MuxUploadSDK/Extensions/Bundle+Reporting.swift
@@ -1,0 +1,15 @@
+//
+//  Bundle+Reporting.swift
+//  
+
+import Foundation
+
+extension Bundle {
+    var appName: String? {
+        return object(forInfoDictionaryKey: "CFBundleName") as? String
+    }
+
+    var appVersion: String? {
+        return object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    }
+}

--- a/Sources/MuxUploadSDK/InternalUtilities/UploadEvent.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/UploadEvent.swift
@@ -27,13 +27,3 @@ struct UploadEvent: Codable {
 
     var regionCode: String?
 }
-
-extension Bundle {
-    var appName: String? {
-        return object(forInfoDictionaryKey: "CFBundleName") as? String
-    }
-
-    var appVersion: String? {
-        return object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-    }
-}


### PR DESCRIPTION
Now that we have a dedicated directory for first-party API extensions, move the Bundle extension methods to their own file there as well