### PR TITLE
Chunked file uploader set starting and switch cleanup

### DIFF
--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -79,6 +79,7 @@ class ChunkedFileUploader {
         case .starting, .uploading:
             notifyStateFromMain(.canceled)
         case .ready, .canceled, .success, .failure, .paused:
+            // Should paused be handled differently?
             break
         }
     }

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -78,7 +78,7 @@ class ChunkedFileUploader {
         switch _currentState {
         case .starting, .uploading:
             notifyStateFromMain(.canceled)
-        default:
+        case .ready, .canceled, .success, .failure, .paused:
             break
         }
     }

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -62,6 +62,7 @@ class ChunkedFileUploader {
     func start() {
         switch _currentState {
         case .ready, .paused:
+            _currentState = .starting
             beginUpload()
         case .starting, .uploading, .canceled, .success, .failure:
             MuxUploadSDK.logger?.info("start() ignored in state \(String(describing: self._currentState))")
@@ -75,11 +76,10 @@ class ChunkedFileUploader {
         cleanupResources()
         
         switch _currentState {
-        case .starting: fallthrough
-        case .uploading(_): do {
+        case .starting, .uploading:
             notifyStateFromMain(.canceled)
-        }
-        default: do {}
+        default:
+            break
         }
     }
     

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -61,10 +61,9 @@ class ChunkedFileUploader {
     /// Starts the upload if it wasn't already starting
     func start() {
         switch _currentState {
-        case .ready: fallthrough
-        case .paused(_):
+        case .ready, .paused:
             beginUpload()
-        default:
+        case .starting, .uploading, .canceled, .success, .failure:
             MuxUploadSDK.logger?.info("start() ignored in state \(String(describing: self._currentState))")
         }
     }

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -54,7 +54,8 @@ class ChunkedFileUploader {
             currentWorkTask = nil
             notifyStateFromMain(.paused(update))
         }
-        default: do {}
+        case .ready, .paused, .canceled, .success, .failure:
+            break
         }
     }
     

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -62,8 +62,10 @@ class ChunkedFileUploader {
     /// Starts the upload if it wasn't already starting
     func start() {
         switch _currentState {
-        case .ready, .paused:
+        case .ready:
             _currentState = .starting
+            beginUpload()
+        case .paused:
             beginUpload()
         case .starting, .uploading, .canceled, .success, .failure:
             MuxUploadSDK.logger?.info("start() ignored in state \(String(describing: self._currentState))")


### PR DESCRIPTION
Set the `ChunkedFileUploader` state to starting when start method is called. `currentUploadState` is currently never set to `.starting` anywhere. Assuming the intent was: `.ready` -> `.starting` -> `.uploading`. AIUI (please correct me if this is wrong) `.starting` is the brief interval period between when `start` is first called and when `Task` created in `beginUpload` begins to be executed by the cooperative thread pool, the latter is an async operation.

Several switch statements were modified: in `start` the state is converted from `ready` to `starting`. Like before, the SDK avoids setting the `internalUploadState` to `.starting` when resuming a paused upload. Otherwise these changes keep existing upload behavior and make the meaning of the code more explicit. Summary of the changes below.

- Remove `fallthrough` 
    - Instead combine enum cases into a single statement, this is recommended Swift practice. [See TSPL discussion on `fallthrough`.](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/controlflow#Fallthrough)
    - Note: In Swift, as in C, `fallthrough` moves execution to the next case statement of the switch. The default statement, if it is present, is only executed if it directly follows the case statement with the `fallthrough`. (Adding this note here because I got bitten by this in C too many times to count.)
- Remove default in favor of explicitly listing enum cases
    - Benefit is each time states are added or removed from this enum, the compiler will help catch any unintended implicit behavior

(Separately from this PR: need to store the start time of the first upload chunk request inside this state in order for it to be available when reporting, which was the impetus for this change. However this PR does not contain reporting-related changes.)