### PR TITLE
Avoid duplicate MuxUpload initialization in UploadManager

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -48,7 +48,7 @@ public final class MuxUpload : Hashable, Equatable {
  
     private let uploadInfo: UploadInfo
     private let manageBySDK: Bool
-    private var id: String {
+    var id: String {
         uploadInfo.id
     }
     private let uploadManager: UploadManager
@@ -170,7 +170,7 @@ public final class MuxUpload : Hashable, Equatable {
         // Use an existing globally-managed upload if desired & one exists
         if self.manageBySDK && fileWorker == nil {
             // See if there's anything in progress already
-            fileWorker = uploadManager.findUploaderFor(videoFile: videoFile)
+            fileWorker = uploadManager.findChunkedFileUploader(inputFileURL: videoFile)
         }
         if fileWorker != nil && !forceRestart {
             MuxUploadSDK.logger?.warning("start() called but upload is already in progress")
@@ -193,8 +193,8 @@ public final class MuxUpload : Hashable, Equatable {
             InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
         )
         fileWorker.start()
-        uploadManager.registerUploader(fileWorker, withId: id)
         self.fileWorker = fileWorker
+        uploadManager.registerUpload(self)
     }
     
     /**

--- a/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
@@ -121,6 +121,7 @@ public final class UploadManager {
             // Only started uploads, aka uploads with a file
             // worker can be registered.
             // TODO: Should this throw?
+            MuxUploadSDK.logger?.debug("registerUpload() called for an unstarted upload")
             return
         }
 

--- a/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/UploadManager.swift
@@ -28,7 +28,7 @@ import Foundation
 ///
 public final class UploadManager {
     
-    private var uploadersByID: [String : ChunkedFileUploader] = [:]
+    private var uploadsByID: [String : MuxUpload] = [:]
     private var uploadsUpdateDelegatesByToken: [ObjectIdentifier : any UploadsUpdatedDelegate] = [:]
     private let uploadActor = UploadCacheActor()
     private lazy var uploaderDelegate: FileUploaderDelegate = FileUploaderDelegate(manager: self)
@@ -37,23 +37,21 @@ public final class UploadManager {
     /// to track and control its state
     /// Returns nil if there was no uplod in progress for thr given file
     public func findStartedUpload(ofFile url: URL) -> MuxUpload? {
-        if let uploader = Dictionary<URL, ChunkedFileUploader>(
-            uniqueKeysWithValues: uploadersByID.mapValues { value in
-                (value.uploadInfo.videoFile, value)
+        for upload in uploadsByID.values {
+            if upload.videoFile == url {
+                return upload
             }
-            .values
-        )[url] {
-            return MuxUpload(wrapping: uploader, uploadManager: self)
-        } else {
-            return nil
         }
+
+        return nil
     }
     
     /// Returns all uploads currently-managed uploads.
     /// Uploads are managed while in-progress or compelted.
     ///  Uploads become un-managed when canceled, or if the process dies after they complete
     public func allManagedUploads() -> [MuxUpload] {
-        return uploadersByID.compactMap { (key, value) in MuxUpload(wrapping: value, uploadManager: self) }
+        // Sort upload list for consistent ordering
+        return Array(uploadsByID.values)
     }
     
     /// Attempts to resume an upload that was previously paused or interrupted by process death
@@ -100,27 +98,33 @@ public final class UploadManager {
     }
     
     internal func acknowledgeUpload(id: String) {
-        if let uploader = uploadersByID[id] {
+        if let uploader = uploadsByID[id] {
+            uploadsByID.removeValue(forKey: id)
             uploader.cancel()
         }
-        uploadersByID.removeValue(forKey: id)
         Task.detached {
             await self.uploadActor.remove(uploadID: id)
             self.notifyDelegates()
         }
     }
     
-    internal func findUploaderFor(videoFile url: URL) -> ChunkedFileUploader? {
-        return Dictionary<URL, ChunkedFileUploader>(
-            uniqueKeysWithValues: uploadersByID.mapValues { value in
-                (value.uploadInfo.videoFile, value)
-            }
-            .values
-        )[url]
+    internal func findChunkedFileUploader(
+        inputFileURL: URL
+    ) -> ChunkedFileUploader? {
+        findStartedUpload(
+            ofFile: inputFileURL
+        )?.fileWorker
     }
 
-    internal func registerUploader(_ fileWorker: ChunkedFileUploader, withId id: String) {
-        uploadersByID.updateValue(fileWorker, forKey: fileWorker.uploadInfo.id)
+    internal func registerUpload(_ upload: MuxUpload) {
+        guard let fileWorker = upload.fileWorker else {
+            // Only started uploads, aka uploads with a file
+            // worker can be registered.
+            // TODO: Should this throw?
+            return
+        }
+
+        uploadsByID.updateValue(upload, forKey: upload.id)
         fileWorker.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
         Task.detached {
             await self.uploadActor.updateUpload(

--- a/apps/Test App/Upload Test App.xcodeproj/project.pbxproj
+++ b/apps/Test App/Upload Test App.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Test App/Preview Content\"";
-				DEVELOPMENT_TEAM = CX6AHWLHM6;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app uploads photos from your camera roll";
@@ -498,7 +498,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Test App/Preview Content\"";
-				DEVELOPMENT_TEAM = CX6AHWLHM6;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "This app uploads photos from your camera roll";


### PR DESCRIPTION
This PR contains a fix for `MuxUpload` progress reporting callbacks going silent mid-upload. The actual upload completes and is successfully delivered so the issue is limited to callbacks. To make this fix work `UploadManager` will store `MuxUpload` and not `ChunkedFileUploader`.

`UploadManager` external-facing API is unchanged.

<h3>Root cause analysis</h3>

`UploadManager` exposes a means of subscribing to notifications when a managed `MuxUpload` starts and finishes network transport.

`UploadManager` stores `ChunkedFileUploader` instances by key in a dictionary (hash map). When the dictionary content changes, `UploadManager` emits a delegate callback and provides its delegates with an updated list of entities corresponding to each `ChunkedFileUploader`.

Since `ChunkedFileUploader` is an internal class and the delegates of the `UploadManager` may be internal or external to the package, the delegate callback converts the list of `ChunkedFileUploader` to a list of `MuxUpload` by initializing a new `MuxUpload` for each key-value pair. A new `MuxUpload` gets initialized per delegate method call. Every `MuxUpload` emitted this way is different, when it comes to pointer identity, from the original `MuxUpload` initialized by the SDK client. 

No `MuxUpload` coming from `UploadManager` will have its handler properties set with the SDK clients original closures. This triggers the bug.

If the SDK client does not retain the `MuxUpload` it originally created (and the example code in our case does not retain the original `MuxUpload`, it replaces it with whatever it gets from `UploadManager`) then the original `MuxUpload` is deallocated because the SDK doesn't retain it either.

This wasn't obvious when first introduced because the example code reset the callback handlers during each SwiftUI update cycle, the callbacks usually propagate an update unless a race condition is triggered: where a callback runs before a new handler is set but after the previous `MuxUpload` is deallocated.

