### PR TITLE
Fix success reporting

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -749,7 +749,14 @@ public final class MuxUpload : Hashable, Equatable {
                 startTime: update.startTime,
                 isPaused: false
             )
-            input.status = .uploadInProgress(input.uploadInfo, status)
+            if update.progress.totalUnitCount == update.progress.completedUnitCount {
+                input.processUploadSuccess(transportStatus: status)
+            } else {
+                input.status = .uploadInProgress(
+                    input.uploadInfo,
+                    status
+                )
+            }
             progressHandler?(status)
         }
         default: do {}


### PR DESCRIPTION
When the SDK upload succeeds, it is possible to hit a race that results in conflicting state values when using both `MuxUpload` and `UploadManager` APIs. This is a quick, internal-to-the-SDK workaround for this issue.

Have a deeper fix for what I think is the underlying root cause for this coming next week but this removes the immediate issue.