### PR TITLE
Remove custom Hashable and Equatable logic from MuxUpload

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/MuxUpload.swift
@@ -48,7 +48,7 @@ public typealias UploadResult = Result<MuxUpload.Success, MuxUpload.UploadError>
 /// Uploads created by this SDK are globally managed by default, and can be resumed after failures or even after process death. For more information on
 /// this topic, see ``UploadManager``
 ///
-public final class MuxUpload : Hashable, Equatable {
+public final class MuxUpload {
 
     var input: UploadInput {
         didSet {
@@ -745,18 +745,6 @@ public final class MuxUpload : Hashable, Equatable {
         default: do {}
         }
     }
-    
-    /// Two`MuxUpload`s with the same ``MuxUpload/videoFile`` and ``MuxUpload/uploadURL`` are considered equivalent
-    public static func == (lhs: MuxUpload, rhs: MuxUpload) -> Bool {
-        lhs.videoFile == rhs.videoFile
-        && lhs.uploadURL == rhs.uploadURL
-    }
-    
-    /// This object's hash is computed based on its ``MuxUpload/videoFile`` and its ``MuxUpload/uploadURL``
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(videoFile)
-        hasher.combine(uploadURL)
-    }   
 }
 
 extension MuxUpload.UploadError {

--- a/apps/Test App/Test App/Model/UploadListModel.swift
+++ b/apps/Test App/Test App/Model/UploadListModel.swift
@@ -15,17 +15,27 @@ class UploadListModel : ObservableObject {
         UploadManager.shared.addUploadsUpdatedDelegate(
             Delegate(
                 handler: { uploads in
-                var uploadSet = Set(self.lastKnownUploads)
-                uploads.forEach {
-                    uploadSet.insert($0)
-                }
-                self.lastKnownUploads = Array(uploadSet)
-                    .sorted(
-                        by: { lhs, rhs in
-                            (lhs.uploadStatus?.startTime ?? 0) >= (rhs.uploadStatus?.startTime ?? 0)
+
+                    var lastKnownUploadsToUpdate = self.lastKnownUploads
+
+                    for updatedUpload in uploads {
+                        if !lastKnownUploadsToUpdate.contains(
+                            where: {
+                                $0.uploadURL == updatedUpload.uploadURL &&
+                                $0.videoFile == updatedUpload.videoFile
+                            }
+                        ) {
+                            lastKnownUploadsToUpdate.append(updatedUpload)
                         }
-                    )
-                }
+                    }
+
+                    self.lastKnownUploads = lastKnownUploadsToUpdate
+                        .sorted(
+                            by: { lhs, rhs in
+                                (lhs.uploadStatus?.startTime ?? 0) >= (rhs.uploadStatus?.startTime ?? 0)
+                            }
+                        )
+                    }
             )
         )
     }

--- a/apps/Test App/Test App/Screens/UploadListView.swift
+++ b/apps/Test App/Test App/Screens/UploadListView.swift
@@ -23,6 +23,12 @@ struct UploadListScreen: View {
     }
 }
 
+extension MuxUpload {
+    var objectIdentifier: ObjectIdentifier {
+        ObjectIdentifier(self)
+    }
+}
+
 fileprivate struct ListContainerView: View {
     
     @EnvironmentObject var viewModel: UploadListModel
@@ -33,7 +39,7 @@ fileprivate struct ListContainerView: View {
         } else {
             ScrollView {
                 LazyVStack {
-                    ForEach(viewModel.lastKnownUploads, id: \.self) { upload in
+                    ForEach(viewModel.lastKnownUploads, id: \.objectIdentifier) { upload in
                         ListItem(upload: upload)
                     }
                 }


### PR DESCRIPTION
Swift restricts the number of times a type can conform to a protocol: it can only happen once across all modules. Because of this restriction, if the SDK exposes or even defines an internal-only `MuxUpload` conformance to `Equatable` and `Hashable` then that removes the flexibility of SDK clients to define these themselves.

There is an occasional crash in the SDK due to a non-unique upload stored in a dictionary. It is hard to reproduce consistently, I suspect that the custom Hashable / Equatable logic plays a part in it. Will introduce additional guardrails for dictionary storage in a separate PR from this one.