### PR TITLE
feat: Expose Foundation Measurement API for chunk size

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -35,7 +35,25 @@ public struct DirectUploadOptions {
 
         /// Initializes options for upload chunk transport
         /// over the network
-        ///
+        /// - Parameters:
+        ///     - chunkSize: the size of each file chunk sent
+        ///     by the SDK during an upload.
+        ///     Defaults to 8MB.
+        ///     - retryLimitPerChunk: number of retry attempts
+        ///     if the chunk request fails, default value is 3
+        public init(
+            chunkSize: Measurement<UnitInformationStorage> = .defaultDirectUploadChunkSize,
+            retryLimitPerChunk: Int = 3
+        ) {
+            self.chunkSizeInBytes = Int(
+                abs(chunkSize.converted(to: .bytes).value)
+                    .rounded(.down)
+            )
+            self.retryLimitPerChunk = retryLimitPerChunk
+        }
+
+        /// Initializes options for upload chunk transport
+        /// over the network
         /// - Parameters:
         ///     - chunkSizeInBytes: the size of each file chunk in
         ///     bytes the SDK sends when uploading, default
@@ -190,6 +208,8 @@ public struct DirectUploadOptions {
 
     // MARK: Direct Upload Options Initializers
 
+    /// Initializes options that dictate how the direct upload
+    /// is carried out by the SDK
     /// - Parameters:
     ///     - inputStandardization: options to enable or
     ///     disable standardizing the format of the direct
@@ -210,13 +230,8 @@ public struct DirectUploadOptions {
         self.eventTracking = eventTracking
     }
 
-    /// - Parameters:
-    ///     - eventTracking: event tracking options for the
-    ///     direct upload
-    ///     - inputStandardization: options to enable or
-    ///     disable standardizing the format of the direct
-    ///     upload inputs, it is requested by default. To
-    ///     prevent the SDK from making any changes to the
+    /// Initializes options that dictate how the direct upload
+    /// is carried out by the SDK
     /// - Parameters:
     ///     - eventTracking: event tracking options for the
     ///     direct upload
@@ -224,12 +239,43 @@ public struct DirectUploadOptions {
     ///     disable standardizing the format of the direct
     ///     upload inputs. True by default.
     ///     To prevent the SDK from making any changes to the
+    ///     upload inputs. True by default.
+    ///     To prevent the SDK from making any changes to the
+    ///     format of the input use ``DirectUploadOptions.InputStandardization.skipped``
+    ///     - chunkSize: The size of each file chunk sent by
+    ///     the SDK during an upload. Defaults to 8MB.
+    ///     - retryLimitPerChunk: number of retry attempts
+    ///     if the chunk request fails. Defaults to 3.
+    public init(
+        eventTracking: EventTracking = .default,
+        inputStandardization: InputStandardization = .default,
+        chunkSize: Measurement<UnitInformationStorage> = .defaultDirectUploadChunkSize,
+        retryLimitPerChunk: Int = 3
+    ) {
+        self.eventTracking = eventTracking
+        self.inputStandardization = inputStandardization
+        self.transport = Transport(
+            chunkSize: chunkSize,
+            retryLimitPerChunk: retryLimitPerChunk
+        )
+    }
+
+    /// Initializes options that dictate how the direct upload
+    /// is carried out by the SDK
+    /// - Parameters:
+    ///     - eventTracking: event tracking options for the
+    ///     direct upload
+    ///     - inputStandardization: options to enable or
+    ///     disable standardizing the format of the direct
+    ///     upload inputs. True by default.
+    ///     To prevent the SDK from making any changes to the
+    ///     upload inputs. True by default.
     ///     format of the input use ``DirectUploadOptions.InputStandardization.skipped``
     ///     - chunkSizeInBytes: The size of each file chunk
     ///     in bytes sent by the SDK during an upload.
     ///     Defaults to 8MB.
     ///     - retryLimitPerChunk: number of retry attempts
-    ///     if the chunk request fails, default value is 3
+    ///     if the chunk request fails. Defaults to 3.
     public init(
         eventTracking: EventTracking = .default,
         inputStandardization: InputStandardization = .default,
@@ -247,6 +293,16 @@ public struct DirectUploadOptions {
 }
 
 // MARK: - Extensions
+
+extension Measurement where UnitType == UnitInformationStorage {
+    /// Default direct upload chunk size
+    public static var defaultDirectUploadChunkSize: Self {
+        Measurement(
+            value: 8,
+            unit: .megabytes
+        )
+    }
+}
 
 extension DirectUploadOptions.InputStandardization.MaximumResolution: CustomStringConvertible {
     public var description: String {

--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -11,8 +11,9 @@ public struct DirectUploadOptions {
 
     // MARK: - Transport Options
 
-    /// Options to adjust ``DirectUpload`` chunk transport
-    /// over the network.
+    /// Options for tuning network transport of direct upload
+    /// chunks to Mux. Using the ``default`` is recommended
+    /// for most applications.
     public struct Transport {
 
         /// The size of each file chunk in bytes sent by the
@@ -33,14 +34,15 @@ public struct DirectUploadOptions {
             )
         }
 
-        /// Initializes options for upload chunk transport
+        /// Initializes options for transport of upload chunks
         /// over the network
         /// - Parameters:
         ///     - chunkSize: the size of each file chunk sent
         ///     by the SDK during an upload.
         ///     Defaults to 8MB.
-        ///     - retryLimitPerChunk: number of retry attempts
-        ///     if the chunk request fails, default value is 3
+        ///     - retryLimitPerChunk: number of times a failed
+        ///     chunk request is retried. Default limit is
+        ///     3 retries.
         public init(
             chunkSize: Measurement<UnitInformationStorage> = .defaultDirectUploadChunkSize,
             retryLimitPerChunk: Int = 3
@@ -52,14 +54,15 @@ public struct DirectUploadOptions {
             self.retryLimitPerChunk = retryLimitPerChunk
         }
 
-        /// Initializes options for upload chunk transport
+        /// Initializes options for transport of upload chunks
         /// over the network
         /// - Parameters:
-        ///     - chunkSizeInBytes: the size of each file chunk in
-        ///     bytes the SDK sends when uploading, default
-        ///     value is 8MB
-        ///     - retryLimitPerChunk: number of retry attempts
-        ///     if the chunk request fails, default value is 3
+        ///     - chunkSizeInBytes: the size of each file
+        ///     chunk in bytes the SDK uploads in a single
+        ///     request. Default chunk size is 8MB.
+        ///     - retryLimitPerChunk: number of times a failed
+        ///     chunk request is retried. Default limit is
+        ///     3 retries.
         public init(
             chunkSizeInBytes: Int = 8 * 1024 * 1024,
             retryLimitPerChunk: Int = 3
@@ -69,7 +72,7 @@ public struct DirectUploadOptions {
         }
     }
 
-    /// Transport options for the direct upload
+    /// Network transport options for direct upload chunks
     public var transport: Transport
 
     // MARK: - Input Standardization Options

--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -211,11 +211,11 @@ public struct DirectUploadOptions {
     /// Initializes options that dictate how the direct upload
     /// is carried out by the SDK
     /// - Parameters:
-    ///     - inputStandardization: options to enable or
-    ///     disable standardizing the format of the direct
-    ///     upload inputs, it is requested by default. To
-    ///     prevent the SDK from making any changes to the
-    ///     format of the input use ``DirectUploadOptions.InputStandardization.skipped``
+    ///     - inputStandardization: options related to input
+    ///     standardization. Input standardization is requested
+    ///     by default.
+    ///     To skip input standardization pass in
+    ///     ``DirectUploadOptions.InputStandardization.skipped``.
     ///     - transport: options for transporting the
     ///     direct upload input to Mux
     ///     - eventTracking: event tracking options for the
@@ -235,13 +235,11 @@ public struct DirectUploadOptions {
     /// - Parameters:
     ///     - eventTracking: event tracking options for the
     ///     direct upload
-    ///     - inputStandardization: options to enable or
-    ///     disable standardizing the format of the direct
-    ///     upload inputs. True by default.
-    ///     To prevent the SDK from making any changes to the
-    ///     upload inputs. True by default.
-    ///     To prevent the SDK from making any changes to the
-    ///     format of the input use ``DirectUploadOptions.InputStandardization.skipped``
+    ///     - inputStandardization: options related to input
+    ///     standardization. Input standardization is requested
+    ///     by default.
+    ///     To skip input standardization pass in
+    ///     ``DirectUploadOptions.InputStandardization.skipped``.
     ///     - chunkSize: The size of each file chunk sent by
     ///     the SDK during an upload. Defaults to 8MB.
     ///     - retryLimitPerChunk: number of retry attempts
@@ -265,12 +263,11 @@ public struct DirectUploadOptions {
     /// - Parameters:
     ///     - eventTracking: event tracking options for the
     ///     direct upload
-    ///     - inputStandardization: options to enable or
-    ///     disable standardizing the format of the direct
-    ///     upload inputs. True by default.
-    ///     To prevent the SDK from making any changes to the
-    ///     upload inputs. True by default.
-    ///     format of the input use ``DirectUploadOptions.InputStandardization.skipped``
+    ///     - inputStandardization: options related to input
+    ///     standardization. Input standardization is requested
+    ///     by default.
+    ///     To skip input standardization pass in
+    ///     ``DirectUploadOptions.InputStandardization.skipped``.
     ///     - chunkSizeInBytes: The size of each file chunk
     ///     in bytes sent by the SDK during an upload.
     ///     Defaults to 8MB.


### PR DESCRIPTION
[Foundation supports](https://developer.apple.com/documentation/foundation/measurement) conversion from [megabytes, `*bytes`, `*bits` to bytes](https://developer.apple.com/documentation/foundation/unitinformationstorage) which feels like a useful convenience to support