### PR TITLE
refactor: Explicit semantic version API

### DIFF
--- a/Sources/MuxUploadSDK/InternalUtilities/Reporting/Reporter.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/Reporting/Reporter.swift
@@ -147,7 +147,7 @@ extension Reporter {
             platformName: platformName,
             platformVersion: platformVersion,
             regionCode: regionCode,
-            sdkVersion: Version.versionString,
+            sdkVersion: SemanticVersion.versionString,
             uploadStartTime: uploadStartTime,
             uploadEndTime: uploadEndTime,
             uploadURL: uploadURL
@@ -188,7 +188,7 @@ extension Reporter {
             platformName: platformName,
             platformVersion: platformVersion,
             regionCode: regionCode,
-            sdkVersion: Version.versionString,
+            sdkVersion: SemanticVersion.versionString,
             uploadStartTime: uploadStartTime,
             uploadEndTime: uploadEndTime,
             uploadURL: url
@@ -229,7 +229,7 @@ extension Reporter {
             platformName: platformName,
             platformVersion: platformVersion,
             regionCode: regionCode,
-            sdkVersion: Version.versionString,
+            sdkVersion: SemanticVersion.versionString,
             standardizationStartTime: standardizationStartTime,
             standardizationEndTime: standardizationEndTime,
             uploadURL: uploadURL
@@ -273,7 +273,7 @@ extension Reporter {
             platformName: platformName,
             platformVersion: platformVersion,
             regionCode: regionCode,
-            sdkVersion: Version.versionString,
+            sdkVersion: SemanticVersion.versionString,
             standardizationStartTime: standardizationStartTime,
             standardizationEndTime: standardizationEndTime,
             uploadCanceled: uploadCanceled,

--- a/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
@@ -1,5 +1,5 @@
 //
-//  Version.swift
+//  SemanticVersion.swift
 //  
 //
 //  Created by Emily Dixon on 2/21/23.
@@ -8,14 +8,14 @@
 import Foundation
 
 /// Version information about the SDK
-public struct Version {
+public struct SemanticVersion {
   /// Major version.
   public static let major = 0
   /// Minor version.
   public static let minor = 6
-  /// Revision number.
-  public static let revision = 0
+  /// Patch version.
+  public static let patch = 0
 
   /// String form of the version number.
-  public static let versionString = "\(major).\(minor).\(revision)"
+  public static let versionString = "\(major).\(minor).\(patch)"
 }

--- a/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
@@ -9,13 +9,15 @@ import Foundation
 
 /// Version information about the SDK
 public struct SemanticVersion {
-  /// Major version.
-  public static let major = 0
-  /// Minor version.
-  public static let minor = 6
-  /// Patch version.
-  public static let patch = 0
+    /// Major version component.
+    public static let major = 0
+    /// Minor version component.
+    public static let minor = 6
+    /// Patch version component.
+    public static let patch = 0
 
-  /// String form of the version number.
-  public static let versionString = "\(major).\(minor).\(patch)"
+    /// String form of the version number in the format X.Y.Z
+    /// where X, Y, and Z are the major, minor, and patch
+    /// version components
+    public static let versionString = "\(major).\(minor).\(patch)"
 }


### PR DESCRIPTION
Rename revision to patch as in SemVer 2.0.0

Rename Version to SemanticVersion for explicitness