### PR TITLE
build: add escape from failed guard condition

### DIFF
--- a/Mux-Upload-SDK.podspec
+++ b/Mux-Upload-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Mux-Upload-SDK'
   s.module_name      = 'MuxUploadSDK'
-  s.version          = '1.0.0'
+  s.version          = '1.0.1'
   s.summary          = 'Upload video to Mux.'
   s.description      = 'A library for uploading video to Mux. Similar to UpChunk, but for iOS.'
 

--- a/Sources/MuxUploadSDK/PublicAPI/AVFoundation+DirectUpload/DirectUpload+AVFoundation.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/AVFoundation+DirectUpload/DirectUpload+AVFoundation.swift
@@ -23,8 +23,7 @@ extension DirectUpload {
         options: DirectUploadOptions
     ) {
         guard let urlAsset = inputAsset as? AVURLAsset else {
-            precondition(
-                false,
+            fatalError(
                 "Only assets with URLs can be uploaded"
             )
         }

--- a/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
@@ -14,7 +14,7 @@ public struct SemanticVersion {
     /// Minor version component.
     public static let minor = 0
     /// Patch version component.
-    public static let patch = 0
+    public static let patch = 1
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
precondition gets elided by optimizer under certain optimization modes and results in a build error. Replace with fatalError always remains

## Improvements

* build: add escape from failed guard condition



Co-authored-by: AJ Lauer Barinov <abarinov@mux.com>