### PR TITLE
Releases/v1.0.2

### DIFF
--- a/Mux-Upload-SDK.podspec
+++ b/Mux-Upload-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Mux-Upload-SDK'
   s.module_name      = 'MuxUploadSDK'
-  s.version          = '1.0.1'
+  s.version          = '1.0.2'
   s.summary          = 'Upload video to Mux.'
   s.description      = 'A library for uploading video to Mux. Similar to UpChunk, but for iOS.'
 

--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -17,7 +17,10 @@ public struct DirectUploadOptions {
     public struct Transport {
 
         /// The size of each file chunk in bytes sent by the
-        /// SDK during an upload. At least 8MB is recommended.
+        /// SDK during an upload. At least 8MiB is recommended.
+        /// Chunk size should be a multiple of 256 KiB (256 x 1024 bytes)
+        /// unless it's the final chunk or is greater than the size of 
+        /// the video file.
         public var chunkSizeInBytes: Int
 
         /// Number of retry attempts per chunk if its upload
@@ -25,7 +28,7 @@ public struct DirectUploadOptions {
         public var retryLimitPerChunk: Int
 
         /// Default options for ``DirectUpload`` chunk transport
-        /// over the network. The chunk size is 8MB and the
+        /// over the network. The chunk size is 8MiB and the
         /// per-chunk retry limit is 3.
         public static var `default`: Transport {
             Transport(
@@ -39,7 +42,10 @@ public struct DirectUploadOptions {
         /// - Parameters:
         ///     - chunkSize: the size of each file chunk sent
         ///     by the SDK during an upload.
-        ///     Defaults to 8MB.
+        ///     Defaults to 8MiB. Chunk size should be a 
+        ///     multiple of 256 KiB (256 x 1024 bytes)
+        ///     unless it's the final chunk or is greater than the 
+        ///     size of the video file.
         ///     - retryLimitPerChunk: number of times a failed
         ///     chunk request is retried. Default limit is
         ///     3 retries.
@@ -59,7 +65,10 @@ public struct DirectUploadOptions {
         /// - Parameters:
         ///     - chunkSizeInBytes: the size of each file
         ///     chunk in bytes the SDK uploads in a single
-        ///     request. Default chunk size is 8MB.
+        ///     request. Defaults to 8MiB. Chunk size should be a 
+        ///     multiple of 256 KiB (256 x 1024 bytes)
+        ///     unless it's the final chunk or is greater than the 
+        ///     size of the video file.
         ///     - retryLimitPerChunk: number of times a failed
         ///     chunk request is retried. Default limit is
         ///     3 retries.
@@ -252,7 +261,10 @@ public struct DirectUploadOptions {
     ///     To skip input standardization pass in
     ///     ``DirectUploadOptions.InputStandardization.skipped``.
     ///     - chunkSize: The size of each file chunk sent by
-    ///     the SDK during an upload. Defaults to 8MB.
+    ///     the SDK during an upload. Defaults to 8MiB. 
+    ///     Chunk size should be a multiple of 256 KiB (256 x 1024 bytes)
+    ///     unless it's the final chunk or is greater than the size of 
+    ///     the video file.
     ///     - retryLimitPerChunk: number of retry attempts
     ///     if the chunk request fails. Defaults to 3.
     public init(
@@ -281,7 +293,10 @@ public struct DirectUploadOptions {
     ///     ``DirectUploadOptions.InputStandardization.skipped``.
     ///     - chunkSizeInBytes: The size of each file chunk
     ///     in bytes sent by the SDK during an upload.
-    ///     Defaults to 8MB.
+    ///     Defaults to 8MiB. Chunk size should be a 
+    ///     multiple of 256 KiB (256 x 1024 bytes)
+    ///     unless it's the final chunk or is greater than the 
+    ///     size of the video file.
     ///     - retryLimitPerChunk: number of retry attempts
     ///     if the chunk request fails. Defaults to 3.
     public init(
@@ -307,7 +322,7 @@ extension Measurement where UnitType == UnitInformationStorage {
     public static var defaultDirectUploadChunkSize: Self {
         Measurement(
             value: 8,
-            unit: .megabytes
+            unit: .mebibytes
         )
     }
 }

--- a/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
@@ -14,7 +14,7 @@ public struct SemanticVersion {
     /// Minor version component.
     public static let minor = 0
     /// Patch version component.
-    public static let patch = 1
+    public static let patch = 2
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
## Fixes:
* use mebibytes as chunk size default unit (#118)