### PR TITLE
Report cancellation before clearing completion handler

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -727,7 +727,7 @@ public final class DirectUpload {
     }
     
     private func cancel(notifyCaller: Bool) {
-        if notifyCaller && !isUploadComplete() {
+        if notifyCaller && !isUploadComplete() && isUploadStarted() {
             resultHandler?(.failure(
                 DirectUploadError(
                     lastStatus: uploadStatus,
@@ -744,6 +744,13 @@ public final class DirectUpload {
         
         progressHandler = nil
         resultHandler = nil
+    }
+    
+    private func isUploadStarted() -> Bool {
+        switch internalStatus {
+        case .ready(_, _): return false
+        default: return true
+        }
     }
     
     private func isUploadComplete() -> Bool {

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -727,11 +727,7 @@ public final class DirectUpload {
     }
     
     private func cancel(notifyCaller: Bool) {
-        fileWorker?.cancel()
-        uploadManager.acknowledgeUpload(id: id)
-        input.processUploadCancellation()
-        
-        if notifyCaller {
+        if notifyCaller && !isUploadComplete() {
             resultHandler?(.failure(
                 DirectUploadError(
                     lastStatus: uploadStatus,
@@ -742,8 +738,20 @@ public final class DirectUpload {
             ))
         }
         
+        fileWorker?.cancel()
+        uploadManager.acknowledgeUpload(id: id)
+        input.processUploadCancellation()
+        
         progressHandler = nil
         resultHandler = nil
+    }
+    
+    private func isUploadComplete() -> Bool {
+        switch internalStatus {
+        case .uploadSucceeded: return true
+        case .uploadFailed: return true
+        default: return false
+        }
     }
     
     private func handleStateUpdate(_ state: ChunkedFileUploader.InternalUploadState) {

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -247,6 +247,8 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         // TODO: Same for UploadInputStandardizer when it gets wired in
+        
+        SDKLogger.enableDefaultLogging()
     }
 
     init(
@@ -260,6 +262,8 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         // TODO: Same for UploadInputStandardizer when it gets wired in
+        
+        SDKLogger.enableDefaultLogging()
     }
 
     internal convenience init(
@@ -388,7 +392,7 @@ public final class DirectUpload {
             input.status = .started(input.sourceAsset, uploadInfo)
             startInspection(sourceAsset: input.sourceAsset)
         } else if forceRestart {
-            cancel()
+            cancel(notifyCaller: false)
         }
     }
 
@@ -638,8 +642,11 @@ public final class DirectUpload {
         videoFile: URL
     ) {
         guard readyForTransport() else {
+            SDKLogger.logger?.info("Tried to start network transport before being ready")
             return
         }
+        
+        SDKLogger.logger?.info("Starting network transport")
 
         let completedUnitCount = UInt64(uploadStatus?.progress?.completedUnitCount ?? 0)
 
@@ -718,11 +725,27 @@ public final class DirectUpload {
     
     /// Cancels an upload that has already been started.
     /// Any delegates or handlers set prior to this will
-    /// receive no further updates.
+    /// receive no further updates after the resultHandler is called
     public func cancel() {
+        self.cancel(notifyCaller: true)
+    }
+    
+    private func cancel(notifyCaller: Bool) {
         fileWorker?.cancel()
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()
+        
+        if notifyCaller {
+            resultHandler?(.failure(
+                DirectUploadError(
+                    lastStatus: uploadStatus,
+                    kind: .cancelled,
+                    message: "Upload was cancelled by caller",
+                    reason: nil
+                )
+            ))
+        }
+        
         progressHandler = nil
         resultHandler = nil
     }
@@ -764,6 +787,12 @@ public final class DirectUpload {
                     isPaused: true
                 )
                 progressHandler?(canceledStatus)
+                resultHandler?(DirectUploadResult.failure(DirectUploadError(
+                    lastStatus: canceledStatus,
+                    kind: .cancelled,
+                    message: "user cancelled",
+                    reason: nil
+                )))
             } else {
                 resultHandler?(Result.failure(parsedError))
             }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -247,8 +247,6 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         // TODO: Same for UploadInputStandardizer when it gets wired in
-        
-        SDKLogger.enableDefaultLogging()
     }
 
     init(
@@ -262,8 +260,6 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         // TODO: Same for UploadInputStandardizer when it gets wired in
-        
-        SDKLogger.enableDefaultLogging()
     }
 
     internal convenience init(

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -33,8 +33,6 @@ xcodebuild -list -json
 
 echo "▸ Test ${SCHEME}"
 
-# 'iOS Simulator' 'iPhone 16 Pro'
-
 xcodebuild clean test \
 	-scheme $SCHEME \
 	-destination 'platform=iOS Simulator,name=iPhone 16 Pro' \

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -33,8 +33,9 @@ xcodebuild -list -json
 
 echo "▸ Test ${SCHEME}"
 
+# 'iOS Simulator' 'iPhone 16 Pro'
+
 xcodebuild clean test \
 	-scheme $SCHEME \
-	-destination 'platform=iOS Simulator,OS=17.5,name=iPhone 15' \
-	-sdk iphonesimulator18.0 \
+	-destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
   | xcbeautify


### PR DESCRIPTION
Resolves [NAT-374]

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes observable completion-callback behavior for cancellations/restarts, which could impact client code relying on previous handler timing or callback patterns.
> 
> **Overview**
> Improves `DirectUpload` cancellation semantics so callers reliably receive a `.cancelled` failure via `resultHandler` before the SDK clears `progressHandler`/`resultHandler`, including a new internal `cancel(notifyCaller:)` used to avoid emitting cancellation when `start(forceRestart:)` restarts an upload.
> 
> Adds a couple of `SDKLogger` info logs around `startNetworkTransport`, and updates `scripts/run-unit-tests.sh` to run tests on an `iPhone 16 Pro` simulator destination.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9923e16f9aee246dac52f619b0ca27def20acc00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[NAT-374]: https://mux1.atlassian.net/browse/NAT-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ