### PR TITLE
Cancellation ready state

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -720,6 +720,13 @@ public final class DirectUpload {
     /// Any delegates or handlers set prior to this will
     /// receive no further updates.
     public func cancel() {
+        switch inputStatus {
+        case .ready, .finished:
+            return
+        default:
+            break
+        }
+
         fileWorker?.cancel()
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -116,6 +116,39 @@ class DirectUploadTests: XCTestCase {
             enforceOrder: true
         )
     }
+
+    func testCancelBeforeStartIsNoOp() throws {
+        let upload = DirectUpload(
+            uploadURL: URL(string: "https://www.example.com/upload")!,
+            inputFileURL: URL(string: "file://var/mobile/Containers/Data/Application/Documents/myvideo.mp4")!
+        )
+
+        let unexpectedStatusUpdate = XCTestExpectation(
+            description: "Expected no status update when canceling an unstarted upload"
+        )
+        unexpectedStatusUpdate.isInverted = true
+
+        upload.inputStatusHandler = { _ in
+            unexpectedStatusUpdate.fulfill()
+        }
+        upload.progressHandler = { _ in
+            XCTFail("Did not expect progress update when canceling an unstarted upload")
+        }
+        upload.resultHandler = { _ in
+            XCTFail("Did not expect result update when canceling an unstarted upload")
+        }
+
+        upload.cancel()
+
+        guard case DirectUpload.InputStatus.ready = upload.inputStatus else {
+            XCTFail("Expected status to remain ready after cancel on unstarted upload")
+            return
+        }
+        XCTAssertNotNil(upload.progressHandler)
+        XCTAssertNotNil(upload.resultHandler)
+
+        wait(for: [unexpectedStatusUpdate], timeout: 0.2)
+    }
     
 
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add a guard to `cancel()` to prevent it from running in `.ready` or `.finished` states.

The `cancel()` method was previously running unconditionally, leading to unintended side effects (like clearing handlers) when called before an upload had started, contradicting its documentation.

<div><a href="https://cursor.com/agents/bc-ed3a2a86-6dac-4eea-a8a9-50c78c64c4dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed3a2a86-6dac-4eea-a8a9-50c78c64c4dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->