### PR TITLE
NAT-419: Fix interrupted upload resume

### DIFF
--- a/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Model/UploadCreationModel.swift
+++ b/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Model/UploadCreationModel.swift
@@ -83,7 +83,36 @@ final class UploadCreationModel: ObservableObject {
         startUpload(preparedMedia: preparedMedia)
     }
 
-    // TODO: Add pause/resume/restore controls when building the interrupted-upload test harness.
+    func resumeManagedUpload(for preparedMedia: PreparedUpload) {
+        workflowState = .restoring(preparedMedia)
+
+        Task { [weak self] in
+            guard let self else {
+                return
+            }
+
+            // This is the SDK's managed-upload restore path. If it returns nil, the SDK
+            // could not find persisted state for the selected local file.
+            guard let upload = await DirectUploadManager.shared.resumeDirectUpload(
+                ofFile: preparedMedia.localVideoFile
+            ) else {
+                self.workflowState = .restoreFailed(
+                    "No persisted upload was found for this local video file.",
+                    preparedMedia: preparedMedia
+                )
+                return
+            }
+
+            self.attachHandlers(to: upload, preparedMedia: preparedMedia)
+            self.workflowState = .uploading(
+                upload,
+                progress: upload.uploadStatus,
+                preparedMedia: preparedMedia
+            )
+            upload.start(forceRestart: false)
+        }
+    }
+
     private func startUpload(preparedMedia: PreparedUpload) {
         // DirectUpload is the SDK entry point: pass the Mux direct upload URL and the local media asset.
         let upload = DirectUpload(
@@ -311,6 +340,8 @@ enum WorkflowState {
     case preparationFailed(UploadCreationModel.PickerError)
     case ready(PreparedUpload)
     case uploading(DirectUpload, progress: DirectUpload.TransportStatus?, preparedMedia: PreparedUpload)
+    case restoring(PreparedUpload)
+    case restoreFailed(String, preparedMedia: PreparedUpload)
     case completed(DirectUploadResult, preparedMedia: PreparedUpload)
 }
 

--- a/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Model/UploadCreationModel.swift
+++ b/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Model/UploadCreationModel.swift
@@ -44,6 +44,7 @@ final class UploadCreationModel: ObservableObject {
 
     private var assetRequestId: PHImageRequestID? = nil
     private var prepareTask: Task<Void, Never>? = nil
+    private var resumeTask: Task<Void, Never>? = nil
     private var thumbnailGenerator: AVAssetImageGenerator? = nil
 
     private let logger = SwiftUploadSDKExample.logger
@@ -68,6 +69,7 @@ final class UploadCreationModel: ObservableObject {
 
     func resetSelection() {
         prepareTask?.cancel()
+        resumeTask?.cancel()
         cancelPhotoKitRequests()
         cancelActiveUpload()
         pickedItem = []
@@ -84,9 +86,10 @@ final class UploadCreationModel: ObservableObject {
     }
 
     func resumeManagedUpload(for preparedMedia: PreparedUpload) {
+        resumeTask?.cancel()
         workflowState = .restoring(preparedMedia)
 
-        Task { [weak self] in
+        resumeTask = Task { [weak self] in
             guard let self else {
                 return
             }
@@ -96,10 +99,16 @@ final class UploadCreationModel: ObservableObject {
             guard let upload = await DirectUploadManager.shared.resumeDirectUpload(
                 ofFile: preparedMedia.localVideoFile
             ) else {
+                guard !Task.isCancelled else {
+                    return
+                }
                 self.workflowState = .restoreFailed(
                     "No persisted upload was found for this local video file.",
                     preparedMedia: preparedMedia
                 )
+                return
+            }
+            guard !Task.isCancelled else {
                 return
             }
 
@@ -150,6 +159,7 @@ final class UploadCreationModel: ObservableObject {
     /// Prepares the selected video as a local file before handing it to the upload SDK.
     func tryToPrepare(from pickerItem: PhotosPickerItem) {
         prepareTask?.cancel()
+        resumeTask?.cancel()
         cancelPhotoKitRequests()
         cancelActiveUpload()
         workflowState = .preparing

--- a/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Views/UploadWorkspaceView.swift
+++ b/Example/SwiftUploadSDKExample/SwiftUploadSDKExample/Views/UploadWorkspaceView.swift
@@ -25,6 +25,8 @@ struct UploadWorkspaceView: View {
         switch uploadCreationModel.workflowState {
         case .ready(let preparedUpload),
              .uploading(_, _, let preparedUpload),
+             .restoring(let preparedUpload),
+             .restoreFailed(_, let preparedUpload),
              .completed(_, let preparedUpload):
             UploadPreview(thumbnail: preparedUpload.thumbnail)
         case .preparing:
@@ -83,7 +85,7 @@ struct UploadWorkspaceView: View {
                 Text(progressText)
                     .uploadProgressTextStyle()
             }
-        case .idle, .preparing, .preparationFailed, .ready, .completed:
+        case .idle, .preparing, .preparationFailed, .ready, .restoring, .restoreFailed, .completed:
             EmptyView()
         }
     }
@@ -99,12 +101,29 @@ struct UploadWorkspaceView: View {
                     Text("Cancel")
                         .controlButtonStyle()
                 }
+            case .completed(.failure(_), let preparedUpload),
+                 .restoreFailed(_, let preparedUpload):
+                Button {
+                    uploadCreationModel.resumeManagedUpload(for: preparedUpload)
+                } label: {
+                    Text("Resume upload")
+                        .primaryControlButtonStyle()
+                }
+                videoPicker {
+                    Text("Upload another video")
+                        .controlButtonStyle()
+                }
+            case .completed(.success, _):
+                videoPicker {
+                    Text("Upload another video")
+                        .primaryControlButtonStyle()
+                }
             case .preparing, .ready, .preparationFailed:
                 videoPicker {
                     Text("Change video")
                         .controlButtonStyle()
                 }
-            case .idle, .completed:
+            case .idle, .restoring, .completed:
                 EmptyView()
             }
 
@@ -133,6 +152,10 @@ struct UploadWorkspaceView: View {
             return "Preparing upload"
         case .uploading:
             return "Uploading"
+        case .restoring:
+            return "Looking for resumable upload"
+        case .restoreFailed:
+            return "Resume unavailable"
         case .completed(let result, _):
             switch result {
             case .success:
@@ -157,6 +180,10 @@ struct UploadWorkspaceView: View {
             return "Inspecting the selected video and starting network upload."
         case .uploading:
             return "Uploading selected video."
+        case .restoring:
+            return "Checking the SDK-managed upload cache for this local video file."
+        case .restoreFailed(let message, _):
+            return message
         case .completed(let result, _):
             switch result {
             case .success:
@@ -171,13 +198,17 @@ struct UploadWorkspaceView: View {
         switch uploadCreationModel.workflowState {
         case .uploading:
             return true
-        case .idle, .preparing, .preparationFailed, .ready, .completed:
+        case .idle, .preparing, .preparationFailed, .ready, .restoring, .restoreFailed, .completed:
             return false
         }
     }
 
     private var progressText: String {
-        guard case .uploading(_, let status, _) = uploadCreationModel.workflowState else {
+        let status: DirectUpload.TransportStatus?
+        switch uploadCreationModel.workflowState {
+        case .uploading(_, let uploadStatus, _):
+            status = uploadStatus
+        case .idle, .preparing, .preparationFailed, .ready, .restoring, .restoreFailed, .completed:
             return ""
         }
 

--- a/Sources/MuxUploadSDK/InternalUtilities/Error+InternalErrors.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/Error+InternalErrors.swift
@@ -28,4 +28,14 @@ extension Error {
     func asCancellationError() -> CancellationError? {
         return self as? CancellationError
     }
+
+    var isCancellation: Bool {
+        if self is CancellationError {
+            return true
+        }
+        if let urlError = self as? URLError {
+            return urlError.code == .cancelled
+        }
+        return false
+    }
 }

--- a/Sources/MuxUploadSDK/InternalUtilities/UploadInput.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/UploadInput.swift
@@ -154,6 +154,8 @@ extension UploadInput {
         asset: AVURLAsset,
         info: UploadInfo
     ) {
-        self.status = .ready(asset, info)
+        var uploadInfo = info
+        uploadInfo.sourceFileURL = asset.url
+        self.status = .ready(asset, uploadInfo)
     }
 }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -269,7 +269,7 @@ public final class DirectUpload {
         self.init(
             input: UploadInput(
                 status: .uploadInProgress(
-                    AVURLAsset(url: uploader.inputFileURL),
+                    AVURLAsset(url: uploader.uploadInfo.sourceFileURL ?? uploader.inputFileURL),
                     uploader.uploadInfo,
                     TransportStatus(
                         progress: uploader.currentState.progress ?? Progress(),
@@ -279,7 +279,7 @@ public final class DirectUpload {
                     )
                 )
             ),
-            uploadManager: .shared,
+            uploadManager: uploadManager,
             inputInspector: .shared
         )
         self.fileWorker = uploader
@@ -364,7 +364,7 @@ public final class DirectUpload {
     /// restarted. If false the upload will resume from where
     /// it left off if paused, otherwise the upload will change.
     public func start(forceRestart: Bool = false) {
-        if self.manageBySDK {
+        if self.manageBySDK && fileWorker == nil {
             // See if there's anything in progress already
             fileWorker = uploadManager.findChunkedFileUploader(
                 inputFileURL: input.sourceAsset.url

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -7,23 +7,23 @@
 
 import Foundation
 
-/// Manages uploads in-progress by the Mux Upload SDK. Uploads are managed globally by default and can be started, paused,
-/// or cancelled from anywhere in your app.
+/// Manages uploads in progress by the Mux Upload SDK. Uploads are managed globally by default and can be started, paused,
+/// or canceled from anywhere in your app.
 ///
-/// This class is used to find and resume uploads previously-created via ``DirectUpload``. Upload tasks created by ``DirectUpload``
-/// are, by defauly globally managed. If your ``DirectUpload`` is managed, you can get a new handle to it anywhere by  using
-/// ``startedDirectUpload(ofFile:)`` or ``allManagedDirectUploads()``
+/// This class is used to find and resume uploads previously created via ``DirectUpload``. Upload tasks created by ``DirectUpload``
+/// are globally managed by default. If your ``DirectUpload`` is managed, you can get a new handle to it anywhere by using
+/// ``startedDirectUpload(ofFile:)`` or ``allManagedDirectUploads()``.
 ///
 /// ## Handling failure, backgrounding, and process death
 /// Managed uploads can be resumed where they left off after process death, and can be accessed anywhere in your
 /// app without needing to manually track the tasks or their state. Managed uploads only survive process death if they
-/// were paused, in progress, or have failed. Success must be handled by you, even if it occurs, eg, during a `BGTask`
+/// were paused, in progress, or failed. Success must be handled by you, even if it occurs, for example, during a `BGTask`.
 ///
 /// ```swift
 /// // Call during app init
 /// DirectUploadManager.shared.resumeAllDirectUploads()
 /// let restartedUploads = DirectUploadManager.shared.allManagedDirectUploads()
-/// // ... do something with the restrted uploads, like subscribing to progress updates for instance
+/// // Do something with the restarted uploads, like subscribing to progress updates.
 /// ```
 ///
 public final class DirectUploadManager {
@@ -46,12 +46,16 @@ public final class DirectUploadManager {
     
     private var uploadsByID: [String : UploadStorage] = [:]
     private var uploadsUpdateDelegatesByToken: [ObjectIdentifier : any DirectUploadManagerDelegate] = [:]
-    private let uploadActor = UploadCacheActor()
+    private let uploadActor: UploadCacheActor
     private lazy var uploaderDelegate: FileUploaderDelegate = FileUploaderDelegate(manager: self)
+
+    init(uploadActor: UploadCacheActor = UploadCacheActor()) {
+        self.uploadActor = uploadActor
+    }
     
-    /// Finds an upload already in-progress and returns a new ``DirectUpload`` that can be observed
-    /// to track and control its state
-    /// Returns nil if there was no uplod in progress for thr given file
+    /// Finds an upload already in progress and returns a new ``DirectUpload`` that can be observed
+    /// to track and control its state.
+    /// Returns nil if there was no upload in progress for the given file.
     public func startedDirectUpload(ofFile url: URL) -> DirectUpload? {
         for upload in uploadsByID.values.map(\.upload) {
             if upload.videoFile == url {
@@ -65,26 +69,29 @@ public final class DirectUploadManager {
     /// Returns all currently-managed uploads that are
     /// in-progress or completed. Uploads that are canceled
     /// or uploads that completed before the most recent
-    /// application termination are omitted
+    /// application termination are omitted.
     public func allManagedDirectUploads() -> [DirectUpload] {
         // Sort upload list for consistent ordering
         return Array(uploadsByID.values.map(\.upload))
     }
-    
-    /// Attempts to resume an upload that was previously paused or interrupted by process death
-    ///  If no upload was found in the cache, this method returns null without taking any action
+
+    /// Attempts to resume an upload that was previously paused or interrupted by process death.
+    /// If no upload was found in the cache, this method returns nil without taking any action.
     public func resumeDirectUpload(ofFile url: URL) async -> DirectUpload? {
         let fileUploader = await uploadActor.getUpload(ofFileAt: url)
         if let nonNilUploader = fileUploader {
             nonNilUploader.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
-            return DirectUpload(wrapping: nonNilUploader, uploadManager: self)
+            let upload = DirectUpload(wrapping: nonNilUploader, uploadManager: self)
+            uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
+            notifyDelegates()
+            return upload
         } else {
             return nil
         }
     }
     
-    /// Attempts to resume an upload that was previously paused or interrupted by process death
-    ///  If no upload was found in the cache, this method returns null without taking any action
+    /// Attempts to resume an upload that was previously paused or interrupted by process death.
+    /// If no upload was found in the cache, this method returns nil without taking any action.
     public func resumeDirectUpload(ofFile url: URL, completion: @escaping (DirectUpload) -> Void) {
         Task.detached {
             let upload = await self.resumeDirectUpload(ofFile: url)
@@ -94,8 +101,8 @@ public final class DirectUploadManager {
         }
     }
     
-    /// Resumes all upload that were paused or interrupted
-    /// It can be useful to call this during app initialization to resume uploads that have been killed by the process dying
+    /// Resumes all uploads that were paused or interrupted.
+    /// It can be useful to call this during app initialization to resume uploads that were interrupted by process death.
     public func resumeAllDirectUploads() {
         Task.detached { [self] in
             for upload in await uploadActor.getAllUploads() {
@@ -104,7 +111,7 @@ public final class DirectUploadManager {
         }
     }
     
-    /// Adds an ``DirectUploadManagerDelegate`` You can add as many of these as you like
+    /// Adds a ``DirectUploadManagerDelegate``. You can add as many of these as you like.
     public func addDelegate<Delegate: DirectUploadManagerDelegate>(_ delegate: Delegate) {
         uploadsUpdateDelegatesByToken[ObjectIdentifier(delegate)] = delegate
     }
@@ -168,7 +175,7 @@ public final class DirectUploadManager {
         }
     }
     
-    /// The shared instance of this object that should be used
+    /// The shared instance of this object that should be used.
     public static let shared = DirectUploadManager()
     
     private struct FileUploaderDelegate : ChunkedFileUploaderDelegate {
@@ -182,7 +189,7 @@ public final class DirectUploadManager {
                 await manager.uploadActor.updateUpload(
                     uploader.uploadInfo,
                     fileInputURL: uploader.inputFileURL,
-                    withUpdate: state
+                    withUpdate: uploader.persistenceState(for: state)
                 )
                 manager.notifyDelegates()
             }
@@ -198,9 +205,9 @@ public final class DirectUploadManager {
     }
 }
 
-/// A delegate that handles changes to the list of active uploads
+/// A delegate that handles changes to the list of active uploads.
 public protocol DirectUploadManagerDelegate: AnyObject {
-    /// Called when the global list of uploads changes. This happens whenever a new upload is started, or an existing one completes or fails
+    /// Called when the global list of uploads changes. This happens whenever a new upload starts, or an existing one completes or fails.
     func didUpdate(managedDirectUploads: [DirectUpload])
 }
 
@@ -214,13 +221,11 @@ internal actor UploadCacheActor {
         fileInputURL: URL,
         withUpdate update: ChunkedFileUploader.InternalUploadState
     ) async {
-        Task {
-            persistence.update(
-                uploadState: update,
-                for: uploadInfo,
-                fileInputURL: fileInputURL
-            )
-        }
+        persistence.update(
+            uploadState: update,
+            for: uploadInfo,
+            fileInputURL: fileInputURL
+        )
     }
     
     func getUpload(uploadID: String) async -> ChunkedFileUploader? {
@@ -239,7 +244,7 @@ internal actor UploadCacheActor {
     func getUpload(ofFileAt: URL) async -> ChunkedFileUploader? {
         return await Task<ChunkedFileUploader?, Never> {
             guard let matchingEntry = try? persistence.readAll().first(
-                where: { $0.uploadInfo.uploadURL == ofFileAt }
+                where: { $0.inputFileURL == ofFileAt || $0.uploadInfo.sourceFileURL == ofFileAt }
             ) else {
                 return nil
             }
@@ -259,15 +264,13 @@ internal actor UploadCacheActor {
             }
         }.value ?? []
     }
-    
+
     func remove(uploadID: String) async {
-        await Task<(), Never> {
-            try? persistence.remove(entryAtID: uploadID)
-        }.value
+        try? persistence.remove(entryAtID: uploadID)
     }
     
-    init() {
+    init(persistence: UploadPersistence = try! UploadPersistence()) {
         // This try-assert is safe if the process home dir is writeable (which it is generally)
-        self.persistence = try! UploadPersistence()
+        self.persistence = persistence
     }
 }

--- a/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkWorker.swift
@@ -61,6 +61,8 @@ class ChunkWorker {
         let repsonseValidator = ChunkResponseValidator()
         
         repeat {
+            try Task.checkCancellation()
+
             do {
                 let chunkActor = ChunkActor(
                     uploadURL: uploadURL,
@@ -95,6 +97,10 @@ class ChunkWorker {
                 }
                 } // switch responseValidator.validate()
             } catch {
+                if Task.isCancelled || error.isCancellation {
+                    throw CancellationError()
+                }
+
                 SDKLogger.logger?.error("Failed to upload a chunk with error: \(error.localizedDescription)")
                 retries += 1
                 requestError = error

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -308,7 +308,7 @@ class ChunkedFileUploader {
             if Thread.isMainThread {
                 notify()
             } else {
-                DispatchQueue.main.async(execute: notify)
+                DispatchQueue.main.sync(execute: notify)
             }
         }
     }

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -158,7 +158,7 @@ class ChunkedFileUploader {
         if error is CancellationError {
             SDKLogger.logger?.debug("Task finished due to cancellation in state \(String(describing: self.currentState))")
             if case let .uploading(update) = self.currentState {
-                self.currentState = .paused(update)
+                self.currentState = .paused(update.withCompletedUnitCount(lastSuccessfulByte))
             }
         } else {
             SDKLogger.logger?.debug("Task finished due to error in state \(String(describing: self.currentState))")
@@ -235,7 +235,7 @@ class ChunkedFileUploader {
                 if error is CancellationError {
                     SDKLogger.logger?.debug("Task finished due to cancellation in state \(String(describing: self.currentState))")
                     if case let .uploading(update) = self.currentState {
-                        self.currentState = .paused(update)
+                        self.currentState = .paused(update.withCompletedUnitCount(lastSuccessfulByte))
                     }
                 } else {
                     SDKLogger.logger?.debug("Task finished due to error in state \(String(describing: self.currentState))")

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -289,7 +289,7 @@ class ChunkedFileUploader {
             inputFileURL: inputFileURL,
             chunkedFile: file,
             progress: overallProgress,
-            startByte: lastReadCount
+            startByte: lastSuccessfulByte
         ) { [self] progress, startTime, eventTime, completedChunkByte in
             let update = Update(
                 progress: progress,
@@ -297,10 +297,11 @@ class ChunkedFileUploader {
                 updateTime: eventTime
             )
 
+            if let completedChunkByte {
+                self.recordSuccessfulChunk(endByte: completedChunkByte)
+            }
+
             let notify = {
-                if let completedChunkByte {
-                    self.recordSuccessfulChunk(endByte: completedChunkByte)
-                }
                 self.notifyStateFromMain(.uploading(update))
             }
 

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -22,6 +22,7 @@ class ChunkedFileUploader {
     private var currentWorkTask: Task<(), Never>? = nil
     private var overallProgress: Progress = Progress()
     private var lastReadCount: UInt64 = 0
+    private var lastSuccessfulByte: UInt64 = 0
     private let reporter: Reporter
     
     func addDelegate(withToken token: String, _ delegate: ChunkedFileUploaderDelegate) {
@@ -51,7 +52,8 @@ class ChunkedFileUploader {
         case .uploading(let update): do {
             currentWorkTask?.cancel()
             currentWorkTask = nil
-            notifyStateFromMain(.paused(update))
+            recordSuccessfulChunk(endByte: lastSuccessfulByte)
+            notifyStateFromMain(.paused(update.withCompletedUnitCount(lastSuccessfulByte)))
         }
         default: do {}
         }
@@ -160,7 +162,7 @@ class ChunkedFileUploader {
             }
         } else {
             SDKLogger.logger?.debug("Task finished due to error in state \(String(describing: self.currentState))")
-            let uploadError = InternalUploaderError(reason: error, lastByte: lastReadCount)
+            let uploadError = InternalUploaderError(reason: error, lastByte: lastSuccessfulByte)
 
             let lastUpdate: Update?
             if case InternalUploadState.uploading(let update) = currentState {
@@ -237,7 +239,7 @@ class ChunkedFileUploader {
                     }
                 } else {
                     SDKLogger.logger?.debug("Task finished due to error in state \(String(describing: self.currentState))")
-                    let uploadError = InternalUploaderError(reason: error, lastByte: lastReadCount)
+                    let uploadError = InternalUploaderError(reason: error, lastByte: lastSuccessfulByte)
 
                     let lastUpdate: Update?
                     if case InternalUploadState.uploading(let update) = currentState {
@@ -288,14 +290,25 @@ class ChunkedFileUploader {
             chunkedFile: file,
             progress: overallProgress,
             startByte: lastReadCount
-        ) { progress, startTime, eventTime in
+        ) { [self] progress, startTime, eventTime, completedChunkByte in
             let update = Update(
                 progress: progress,
                 startTime: startTime,
                 updateTime: eventTime
             )
-            // ChunkWorker delivers callbacks on the main dispatch queue, making this safe
-            self.notifyStateFromMain(.uploading(update))
+
+            let notify = {
+                if let completedChunkByte {
+                    self.recordSuccessfulChunk(endByte: completedChunkByte)
+                }
+                self.notifyStateFromMain(.uploading(update))
+            }
+
+            if Thread.isMainThread {
+                notify()
+            } else {
+                DispatchQueue.main.async(execute: notify)
+            }
         }
     }
     
@@ -316,9 +329,25 @@ class ChunkedFileUploader {
             let count = update.progress.completedUnitCount
             lastReadCount = UInt64(count)
         }
-        
+
         for delegate in delegates.values {
             delegate.chunkedFileUploader(self, stateUpdated: state)
+        }
+    }
+
+    private func recordSuccessfulChunk(endByte: UInt64) {
+        lastReadCount = endByte
+        lastSuccessfulByte = endByte
+    }
+
+    func persistenceState(for state: InternalUploadState) -> InternalUploadState {
+        switch state {
+        case .uploading(let update):
+            return .uploading(update.withCompletedUnitCount(lastSuccessfulByte))
+        case .paused(let update):
+            return .paused(update.withCompletedUnitCount(lastSuccessfulByte))
+        case .ready, .starting, .canceled, .success, .failure:
+            return state
         }
     }
     
@@ -349,6 +378,7 @@ class ChunkedFileUploader {
         self.uploadInfo = uploadInfo
         self.file = file
         self.lastReadCount = startingByte
+        self.lastSuccessfulByte = startingByte
         self.inputFileURL = inputFileURL
         self.reporter = Reporter.shared
     }
@@ -382,6 +412,19 @@ class ChunkedFileUploader {
         let progress: Progress
         let startTime: TimeInterval
         let updateTime: TimeInterval
+
+        func withCompletedUnitCount(_ completedUnitCount: UInt64) -> Update {
+            let safeProgress = Progress(totalUnitCount: progress.totalUnitCount)
+            safeProgress.completedUnitCount = min(
+                Int64(completedUnitCount),
+                progress.totalUnitCount
+            )
+            return Update(
+                progress: safeProgress,
+                startTime: startTime,
+                updateTime: updateTime
+            )
+        }
     }
 }
 
@@ -457,16 +500,31 @@ fileprivate actor Worker {
             )
             chunkWorker.addDelegate {[self] update in
                 // Called on the main thread
-                overallProgress.completedUnitCount += update.bytesSinceLastUpdate
+                let chunkStartByte = Int64(chunk.startByte)
+                let absoluteCompletedByte = chunkStartByte + update.progress.completedUnitCount
+                overallProgress.completedUnitCount = min(
+                    absoluteCompletedByte,
+                    Int64(chunk.totalFileSize)
+                )
                 progressHandler(
                     self.overallProgress,
                     startTime,
-                    update.eventTime
+                    update.eventTime,
+                    nil
                 )
             }
             
             // Do not use task in a loop it will create an memory consumption issue.
-            let chunkResult = try await chunkWorker.directUpload(chunk: chunk)
+            guard let chunkResult = try await chunkWorker.directUpload(chunk: chunk) as? ChunkWorker.Success else {
+                throw ChunkedFileUploaderError.unexpectedChunkResult
+            }
+            overallProgress.completedUnitCount = Int64(chunk.endByte)
+            progressHandler(
+                self.overallProgress,
+                startTime,
+                chunkResult.finalState.eventTime,
+                chunk.endByte
+            )
             SDKLogger.logger?.info("Completed Chunk:\n \(String(describing: chunkResult))")
         } while (readBytes == uploadInfo.options.transport.chunkSizeInBytes)
 
@@ -480,7 +538,7 @@ fileprivate actor Worker {
         return finalState
     }
     
-    typealias ProgressHandler = (Progress, TimeInterval, TimeInterval) ->  Void
+    typealias ProgressHandler = (Progress, TimeInterval, TimeInterval, UInt64?) ->  Void
     
     init(
         uploadInfo: UploadInfo,
@@ -497,4 +555,8 @@ fileprivate actor Worker {
         self.overallProgress = progress
         self.startingReadCount = startByte
     }
+}
+
+enum ChunkedFileUploaderError: Error {
+    case unexpectedChunkResult
 }

--- a/Sources/MuxUploadSDK/Upload/UploadInfo.swift
+++ b/Sources/MuxUploadSDK/Upload/UploadInfo.swift
@@ -23,6 +23,13 @@ struct UploadInfo : Codable {
     var uploadURL: URL
 
     /**
+     Original local file selected by the caller. The SDK may upload a
+     standardized temporary file instead, but public resume APIs receive the
+     caller's original file URL.
+     */
+    var sourceFileURL: URL?
+
+    /**
      Options selected for the upload
      */
     var options: DirectUploadOptions

--- a/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
+++ b/Sources/MuxUploadSDK/Upload/UploadPersistence.swift
@@ -113,8 +113,12 @@ class UploadPersistence {
     
     /// Configures and initlaizes an ``UploadPersistence`` for normal production use
     init() throws {
-        let dirpath = FileManager.default.currentDirectoryPath + "/mux"
-        self.fileURL = URL(string: "file:/\(dirpath)/uploads.json")!
+        let baseDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.temporaryDirectory
+        let directoryURL = baseDirectory.appendingPathComponent("mux", isDirectory: true)
+        self.fileURL = directoryURL.appendingPathComponent("uploads.json")
         self.uploadsFile = try UploadsFileImpl(fromFile: fileURL)
     }
     
@@ -161,7 +165,18 @@ struct PersistenceEntry : Codable {
     ) -> PersistenceEntry? {
         switch state {
             // Cases that aren't stored also aren't parsed
-        case .success(_), .canceled, .failure(_): return nil
+        case .success(_), .canceled: return nil
+        case .failure(let error):
+            guard let uploadError = error as? InternalUploaderError else {
+                return nil
+            }
+            return PersistenceEntry(
+                savedAt: Date().timeIntervalSince1970,
+                stateCode: .wasInProgress,
+                lastSuccessfulByte: uploadError.lastByte,
+                uploadInfo: upload,
+                inputFileURL: inputFileURL
+            )
             // Can start again but from the beginning
         case .starting, .ready: return PersistenceEntry(
             savedAt: Date().timeIntervalSince1970,
@@ -184,12 +199,6 @@ struct PersistenceEntry : Codable {
             uploadInfo: upload,
             inputFileURL: inputFileURL
         )
-//        case .failure(let error): return PersistenceEntry(
-//            savedAt: Date().timeIntervalSince1970,
-//            stateCode: .was_in_progress,
-//            lastSuccessfulByte: (error as? InternalUploaderError)?.lastByte ?? 0,
-//            uploadInfo: upload
-//        )
         }
     }
 }
@@ -233,10 +242,8 @@ fileprivate struct UploadsFileImpl : UploadsFile {
     }
     
     func writeContents(of jsonData: UploadsFileContents) throws {
-        let fileHandle = try FileHandle(forWritingTo: fileURL)
         let data = try JSONEncoder().encode(jsonData)
-        try fileHandle.write(contentsOf: data)
-        try fileHandle.close()
+        try data.write(to: fileURL, options: .atomic)
     }
     
     func readContents() throws -> UploadsFileContents {

--- a/Tests/MuxUploadSDKTests/Upload Tests/ChunkedFileUploaderTests.swift
+++ b/Tests/MuxUploadSDKTests/Upload Tests/ChunkedFileUploaderTests.swift
@@ -6,8 +6,37 @@
 //
 
 import XCTest
+@testable import MuxUploadSDK
 
 final class ChunkedFileUploaderTests: XCTestCase {
 
+    func testPersistenceStateUsesLastSuccessfulByteForUploadingProgress() throws {
+        let uploadInfo = UploadInfo(
+            uploadURL: try XCTUnwrap(URL(string: "https://www.example.com/upload")),
+            options: .default
+        )
+        let inputFileURL = try XCTUnwrap(URL(string: "file://path/to/dummy/file/resume"))
+        let uploader = ChunkedFileUploader(
+            uploadInfo: uploadInfo,
+            inputFileURL: inputFileURL,
+            file: ChunkedFile(chunkSize: 1000),
+            startingByte: 1000
+        )
+        let streamingProgress = Progress(totalUnitCount: 10_000)
+        streamingProgress.completedUnitCount = 1_500
+        let streamingUpdate = ChunkedFileUploader.Update(
+            progress: streamingProgress,
+            startTime: 0,
+            updateTime: 0
+        )
+
+        let state = uploader.persistenceState(for: .uploading(streamingUpdate))
+
+        guard case .uploading(let persistedUpdate) = state else {
+            XCTFail("Expected uploading state")
+            return
+        }
+        XCTAssertEqual(persistedUpdate.progress.completedUnitCount, 1000)
+    }
 
 }

--- a/Tests/MuxUploadSDKTests/Upload Tests/UploadPersistenceTests.swift
+++ b/Tests/MuxUploadSDKTests/Upload Tests/UploadPersistenceTests.swift
@@ -169,6 +169,75 @@ final class UploadPersistenceTests: XCTestCase {
             "The newer entry should be saved but not the older"
         )
     }
+
+    func testFailureWithLastBytePreservesEntryForResume() throws {
+        let persistence = UploadPersistence(innerFile: makeSimulatedUploadsFile(), atURL: makeDummyFileURL(basename: "fake-cache-file"))
+        let uploadInfo = renameDummyUploadInfo(basename: "failed-upload")
+        let inputFileURL = makeDummyFileURL(basename: "failed-upload")
+
+        persistence.update(
+            uploadState: .failure(InternalUploaderError(reason: DummyError(), lastByte: 1234)),
+            for: uploadInfo,
+            fileInputURL: inputFileURL
+        )
+
+        let entry = try XCTUnwrap(persistence.readEntry(uploadID: uploadInfo.id))
+        XCTAssertEqual(entry.inputFileURL, inputFileURL)
+        XCTAssertEqual(entry.lastSuccessfulByte, 1234)
+        XCTAssertEqual(entry.stateCode, .wasInProgress)
+    }
+
+    func testPausedStatePersistsSafeCheckpoint() throws {
+        let safeProgress = Progress(totalUnitCount: 10_000)
+        safeProgress.completedUnitCount = 1_000
+        let update = ChunkedFileUploader.Update(
+            progress: safeProgress,
+            startTime: 0,
+            updateTime: 0
+        )
+        let persistence = UploadPersistence(innerFile: makeSimulatedUploadsFile(), atURL: makeDummyFileURL(basename: "fake-cache-file"))
+        let uploadInfo = renameDummyUploadInfo(basename: "paused-upload")
+        let inputFileURL = makeDummyFileURL(basename: "paused-upload")
+
+        persistence.update(
+            uploadState: .paused(update),
+            for: uploadInfo,
+            fileInputURL: inputFileURL
+        )
+
+        let entry = try XCTUnwrap(persistence.readEntry(uploadID: uploadInfo.id))
+        XCTAssertEqual(entry.lastSuccessfulByte, 1_000)
+        XCTAssertEqual(entry.stateCode, .wasPaused)
+    }
+
+    func testDefaultPersistenceCreatesBackingFileOnFirstWrite() throws {
+        let applicationSupportDirectory = try XCTUnwrap(
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        )
+        let uploadCacheDirectory = applicationSupportDirectory.appendingPathComponent("mux", isDirectory: true)
+        let uploadCacheFile = uploadCacheDirectory.appendingPathComponent("uploads.json")
+        defer {
+            try? FileManager.default.removeItem(at: uploadCacheFile)
+        }
+
+        try? FileManager.default.removeItem(at: uploadCacheFile)
+
+        let uploadInfo = renameDummyUploadInfo(basename: "default-persistence")
+        let inputFileURL = makeDummyFileURL(basename: "default-persistence")
+        let persistence = try UploadPersistence()
+
+        XCTAssertNoThrow(
+            persistence.update(
+                uploadState: .failure(InternalUploaderError(reason: DummyError(), lastByte: 1234)),
+                for: uploadInfo,
+                fileInputURL: inputFileURL
+            )
+        )
+
+        let entry = try XCTUnwrap(persistence.readEntry(uploadID: uploadInfo.id))
+        XCTAssertEqual(entry.lastSuccessfulByte, 1234)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: uploadCacheFile.path))
+    }
     
     private func makeSimulatedUploadsFile() -> UploadsFile {
         return FakeUploadsFile.simiulatedStorage()

--- a/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerTests.swift
+++ b/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerTests.swift
@@ -65,4 +65,85 @@ class UploadManagerTests: XCTestCase {
 
     }
 
+    func testResumeDirectUploadFindsPersistedUploadByInputFileURL() async throws {
+        let inputFileURL = try XCTUnwrap(
+            URL(string: "file://path/to/dummy/file/resume")
+        )
+        let uploadURL = try XCTUnwrap(
+            URL(string: "https://www.example.com/upload/resume")
+        )
+        let uploadInfo = UploadInfo(
+            id: UUID().uuidString,
+            uploadURL: uploadURL,
+            options: .inputStandardizationSkipped
+        )
+        let persistence = UploadPersistence(
+            innerFile: FakeUploadsFile.simiulatedStorage(),
+            atURL: inputFileURL
+        )
+        try persistence.write(
+            entry: PersistenceEntry(
+                savedAt: Date().timeIntervalSince1970,
+                stateCode: .wasInProgress,
+                lastSuccessfulByte: 1234,
+                uploadInfo: uploadInfo,
+                inputFileURL: inputFileURL
+            ),
+            for: uploadInfo.id
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(persistence: persistence)
+        )
+
+        let restoredUpload = await uploadManager.resumeDirectUpload(ofFile: inputFileURL)
+
+        XCTAssertNotNil(restoredUpload)
+        XCTAssertEqual(restoredUpload?.videoFile, inputFileURL)
+        XCTAssertEqual(restoredUpload?.uploadURL, uploadURL)
+        XCTAssertEqual(uploadManager.allManagedDirectUploads().count, 1)
+    }
+
+    func testResumeDirectUploadFindsPersistedUploadByOriginalSourceFileURL() async throws {
+        let sourceFileURL = try XCTUnwrap(
+            URL(string: "file://path/to/dummy/file/source")
+        )
+        let transportFileURL = try XCTUnwrap(
+            URL(string: "file://path/to/dummy/file/standardized")
+        )
+        let uploadURL = try XCTUnwrap(
+            URL(string: "https://www.example.com/upload/resume")
+        )
+        let uploadInfo = UploadInfo(
+            id: UUID().uuidString,
+            uploadURL: uploadURL,
+            sourceFileURL: sourceFileURL,
+            options: .inputStandardizationSkipped
+        )
+        let persistence = UploadPersistence(
+            innerFile: FakeUploadsFile.simiulatedStorage(),
+            atURL: transportFileURL
+        )
+        try persistence.write(
+            entry: PersistenceEntry(
+                savedAt: Date().timeIntervalSince1970,
+                stateCode: .wasInProgress,
+                lastSuccessfulByte: 1234,
+                uploadInfo: uploadInfo,
+                inputFileURL: transportFileURL
+            ),
+            for: uploadInfo.id
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(persistence: persistence)
+        )
+
+        let restoredUpload = await uploadManager.resumeDirectUpload(ofFile: sourceFileURL)
+
+        XCTAssertNotNil(restoredUpload)
+        XCTAssertEqual(restoredUpload?.videoFile, transportFileURL)
+        let inputAsset = try XCTUnwrap(restoredUpload?.inputAsset as? AVURLAsset)
+        XCTAssertEqual(inputAsset.url, sourceFileURL)
+        XCTAssertEqual(restoredUpload?.uploadURL, uploadURL)
+    }
+
 }


### PR DESCRIPTION
[NAT-419]

## Summary
- Preserve resumable upload state after interrupted network failures instead of deleting persistence entries on failure.
- Restore managed uploads by matching either the SDK transport file URL or the caller source file URL, including standardized-upload flows.
- Resume from last successfully completed chunk boundaries and fix progress accounting so retries cannot push progress past total file size.
- Move upload persistence to Application Support and make first-write creation atomic.
- Add sample-app recovery controls for failed and completed uploads: Resume upload and Upload another video.

## Details
The interrupted-upload path had a few compounding issues: failure persistence was removed, file-based resume lookup compared against the wrong URL for standardized uploads, restored uploads could be replaced before starting, and retry progress counted attempted bytes rather than server-safe completed chunk boundaries.

This change keeps failed uploads resumable, restores the correct worker, and persists safe checkpoints for failure, pause, and in-progress states.

## Validation
Manual device testing: airplane-mode interruption resumes and completes; repeated interruption/resume does not exceed total file size; temporary pause/resume smoke test completed during investigation before removing the sample-app pause UI.

## Screenshots
<img src="https://github.com/user-attachments/assets/a548a0e8-d2dd-4a04-ac92-9a801be3ef41" alt="Upload failed video" width="220"> <img src="https://github.com/user-attachments/assets/6c2179d5-b7be-401a-89b7-1c131af5acfd" alt="Upload complete" width="220">



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core upload transport, persistence, and resume APIs used after failures; behavior is well covered by new tests but incorrect checkpoint logic could affect production uploads.
> 
> **Overview**
> Fixes **interrupted and failed upload resume** so managed uploads can continue after network loss or app restart instead of losing persisted state.
> 
> The SDK now **keeps failure checkpoints** (`InternalUploaderError.lastByte`), persists **safe byte boundaries** only after chunks complete (not in-flight progress), and **looks up cache entries** by transport file URL or the caller’s original `sourceFileURL` (for standardized uploads). **Persistence** moves to Application Support with **atomic** writes; `resumeDirectUpload` registers restored uploads with the correct manager instance. **Cancellation** is detected during chunk retries; `DirectUpload.start` only re-attaches an existing worker when one is already present.
> 
> The Swift example app adds **Resume upload** / restore UI states wired to `DirectUploadManager.shared.resumeDirectUpload(ofFile:)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbd87832cd023fc8c8dc5765ced16f77cf27025e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[NAT-419]: https://mux1.atlassian.net/browse/NAT-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ