### PR TITLE
Fix DocC Pages workflow actions

### DIFF
--- a/.github/workflows/docc-static-site-deployment.yml
+++ b/.github/workflows/docc-static-site-deployment.yml
@@ -16,7 +16,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: sersoft-gmbh/swifty-docs-action@v2
         with:
           output: docs
@@ -27,8 +27,8 @@ jobs:
           hosting-base-path: swift-upload-sdk
       - name: Post Process Docc Archive
         run: ./scripts/post-process-docc-archive-for-github-pages.sh swift-upload-sdk muxuploadsdk
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs
-      - uses: actions/deploy-pages@v1.2.3
+      - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Summary
- update the DocC Pages workflow to supported GitHub Actions versions
- move checkout to v4, upload-pages-artifact to v3, and deploy-pages to v4

## Why
The current main-branch docs deployment fails during job setup because the old Pages artifact action stack uses deprecated `actions/upload-artifact: v3`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only version bumps on the docs deployment workflow with no application or runtime code changes.
> 
> **Overview**
> Updates the **DocC static site** GitHub Pages workflow so deployment can run again after upstream deprecations broke the old action stack.
> 
> `actions/checkout` moves to **v4**, `actions/upload-pages-artifact` to **v3**, and `actions/deploy-pages` to **v4**. DocC build steps (`swifty-docs-action`, post-process script, paths, and Xcode settings) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc75be7efc192aa71261e3bfcb31502d558c3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->