### PR TITLE
NAT-481: Add HEVC/4K public API and lock compatibility behavior

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
@@ -45,6 +45,12 @@ struct UploadInputFormatInspectionResult {
                 } else {
                     return false
                 }
+            case .preset2560x1440:
+                if max(recordedResolution.width, recordedResolution.height) > 2560 {
+                    return true
+                } else {
+                    return false
+                }
             case .preset3840x2160:
                 if max(recordedResolution.width, recordedResolution.height) > 3840 {
                     return true

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -19,11 +19,19 @@ enum StandardizationStrategy {
     case exportSession
 }
 
-struct StandardizationError: Error {
+struct StandardizationError: LocalizedError {
     var localizedDescription: String
+
+    var errorDescription: String? {
+        localizedDescription
+    }
 
     static var missingExportPreset = StandardizationError(
         localizedDescription: "Missing export session preset"
+    )
+
+    static var unsupportedResolutionTier = StandardizationError(
+        localizedDescription: "Resolution tier is not supported by the export-session standardizer"
     )
 
     static var exportSessionInitializationFailure = StandardizationError(
@@ -59,6 +67,11 @@ class UploadInputStandardizationWorker {
             exportPreset = AVAssetExportPreset1280x720
         case .preset1920x1080:
             exportPreset = AVAssetExportPreset1920x1080
+        case .preset2560x1440:
+            // AVAssetExportSession has no 1440p preset. The
+            // reader/writer standardizer will implement this tier.
+            completion(sourceAsset, nil, StandardizationError.unsupportedResolutionTier)
+            return
         case .preset3840x2160:
             exportPreset = AVAssetExportPreset3840x2160
         }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -5,7 +5,19 @@
 import AVFoundation
 import Foundation
 
-class UploadInputStandardizer {
+protocol UploadInputStandardizing {
+    func standardize(
+        id: String,
+        sourceAsset: AVURLAsset,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL,
+        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
+    )
+
+    func acknowledgeCompletion(id: String)
+}
+
+class UploadInputStandardizer: UploadInputStandardizing {
     var workers: [String: UploadInputStandardizationWorker] = [:]
 
     func standardize(
@@ -16,6 +28,7 @@ class UploadInputStandardizer {
         completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
     ) {
         let worker = UploadInputStandardizationWorker()
+        workers[id] = worker
 
         worker.standardize(
             sourceAsset: sourceAsset,
@@ -23,7 +36,6 @@ class UploadInputStandardizer {
             outputURL: outputURL,
             completion: completion
         )
-        workers[id] = worker
     }
 
     // Storing the worker might not be necessary if an

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -170,13 +170,15 @@ public final class DirectUpload {
     /// the upload changes
     public var inputStatusHandler: InputStatusHandler?
 
-    /// Confirms if upload should proceed when input
+    /// Determines whether to cancel the upload when input
     /// standardization does not succeed
     public typealias NonStandardInputHandler = () -> Bool
 
     /// Sets a handler that will be executed by the SDK
     /// when input standardization doesn't succeed. Return
-    /// <doc:true> to continue the upload
+    /// `true` to cancel the upload, or `false` to
+    /// upload the original input. Intentionally preserving
+    /// eligible HLG or PQ input does not invoke this handler.
     public var nonStandardInputHandler: NonStandardInputHandler?
 
     private let manageBySDK: Bool
@@ -185,7 +187,7 @@ public final class DirectUpload {
     }
     private let uploadManager: DirectUploadManager
     private let inputInspector: UploadInputInspector
-    private let inputStandardizer: UploadInputStandardizer = UploadInputStandardizer()
+    private let inputStandardizer: UploadInputStandardizing
     
     internal var fileWorker: ChunkedFileUploader?
 
@@ -240,26 +242,28 @@ public final class DirectUpload {
         input: UploadInput,
         manage: Bool = true,
         uploadManager: DirectUploadManager,
-        inputInspector: AVFoundationUploadInputInspector = .shared
+        inputInspector: AVFoundationUploadInputInspector = .shared,
+        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer()
     ) {
         self.input = input
         self.manageBySDK = manage
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
-        // TODO: Same for UploadInputStandardizer when it gets wired in
+        self.inputStandardizer = inputStandardizer
     }
 
     init(
         input: UploadInput,
         manage: Bool = true,
         uploadManager: DirectUploadManager,
-        inputInspector: UploadInputInspector
+        inputInspector: UploadInputInspector,
+        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer()
     ) {
         self.input = input
         self.manageBySDK = manage
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
-        // TODO: Same for UploadInputStandardizer when it gets wired in
+        self.inputStandardizer = inputStandardizer
     }
 
     internal convenience init(

--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -94,13 +94,17 @@ public struct DirectUploadOptions {
         /// If requested the SDK will attempt to detect
         /// non-standard input formats and if so detected
         /// will attempt to standardize to a standard input
-        /// format. ``true`` by default
+        /// format. `true` by default
         public var isRequested: Bool = true
 
         /// Preset to control the maximum resolution of a
         /// standardized input. Inputs with smaller dimensions
         /// won't be scaled up.
         ///
+        /// Selecting a 1440p or 2160p tier controls only the
+        /// on-device output. Configure the matching
+        /// `new_asset_settings.max_resolution_tier` separately
+        /// when creating the Mux Direct Upload.
         public enum MaximumResolution {
             /// By default the standardized input will be
             /// scaled down to 1920x1080 (1080p) from a larger
@@ -116,10 +120,26 @@ public struct DirectUploadOptions {
             /// with smaller dimensions won't be scaled up.
             case preset1920x1080 // 1080p
             /// The standardized input will be scaled down
+            /// to 2560x1440 (1440p) from a larger size. Inputs
+            /// with smaller dimensions won't be scaled up.
+            case preset2560x1440 // 1440p
+            /// The standardized input will be scaled down
             /// to 3840x2160 (2160p/4K) from a larger size.
             /// Inputs with smaller dimensions won't be scaled
             /// up.
             case preset3840x2160 // 2160p
+        }
+
+        /// Controls how the SDK handles HDR input during
+        /// input standardization.
+        public enum HDRHandling: Codable, Equatable {
+            /// Preserve eligible HDR input for server-side
+            /// processing. This is the default behavior and
+            /// does not guarantee end-to-end HDR playback.
+            case preserve
+            /// Convert supported HDR input to BT.709 SDR on
+            /// the device.
+            case toneMapToSDR
         }
 
         /// The maximum resolution of the standardized direct
@@ -130,7 +150,7 @@ public struct DirectUploadOptions {
         /// Example 1: a direct upload input with 1440 x 1080
         /// resolution encoded using Apple ProRes and with
         /// no other non-standard input parameters with
-        /// ``MaximumResolution.default`` selected.
+        /// ``MaximumResolution/default`` selected.
         ///
         /// If input standardization is requested, the SDK
         /// will attempt standardize the input into an H.264
@@ -140,7 +160,7 @@ public struct DirectUploadOptions {
         /// Example 2: a direct upload input with 1440 x 1080
         /// resolution encoded using H.264 and with no other
         /// non-standard input format parameters with
-        /// ``MaximumResolution.preset1280x720`` selected.
+        /// ``MaximumResolution/preset1280x720`` selected.
         ///
         /// If input standardization is requested, the SDK
         /// will attempt standardize the input into an H.264
@@ -148,11 +168,16 @@ public struct DirectUploadOptions {
         ///
         public var maximumResolution: MaximumResolution = .default
 
+        /// The requested behavior for HDR input.
+        public var hdrHandling: HDRHandling = .preserve
+
         /// Default options where input standardization is
-        /// requested and the maximum resolution is set to 1080p.
+        /// requested, the maximum resolution is set to 1080p,
+        /// and eligible HDR input is preserved.
         public static let `default`: InputStandardization = InputStandardization(
             isRequested: true,
-            maximumResolution: .default
+            maximumResolution: .default,
+            hdrHandling: .preserve
         )
 
         /// Skip all local input standardization by the SDK.
@@ -165,29 +190,37 @@ public struct DirectUploadOptions {
         /// on the server when it is ingested.
         public static let skipped: InputStandardization = InputStandardization(
             isRequested: false,
-            maximumResolution: .default
+            maximumResolution: .default,
+            hdrHandling: .preserve
         )
 
         // Kept private to avoid an invalid combination of
         // parameters being used for initialization
         private init(
             isRequested: Bool,
-            maximumResolution: MaximumResolution
+            maximumResolution: MaximumResolution,
+            hdrHandling: HDRHandling
         ) {
             self.isRequested = isRequested
             self.maximumResolution = maximumResolution
+            self.hdrHandling = hdrHandling
         }
 
         /// Initializes options that request input
         /// standardization with a custom maximum resolution
+        /// and HDR behavior.
         /// - Parameters:
         ///     - maximumResolution: the maximum resolution
         ///     of the standardized input
+        ///     - hdrHandling: how eligible HDR input is handled.
+        ///     Defaults to ``HDRHandling/preserve``.
         public init(
-            maximumResolution: MaximumResolution
+            maximumResolution: MaximumResolution,
+            hdrHandling: HDRHandling = .preserve
         ) {
             self.isRequested = true
             self.maximumResolution = maximumResolution
+            self.hdrHandling = hdrHandling
         }
     }
 
@@ -334,6 +367,8 @@ extension DirectUploadOptions.InputStandardization.MaximumResolution: CustomStri
             return "preset1280x720"
         case .preset1920x1080:
             return "preset1920x1080"
+        case .preset2560x1440:
+            return "preset2560x1440"
         case .preset3840x2160:
             return "preset3840x2160"
         case .default:
@@ -346,7 +381,36 @@ extension DirectUploadOptions: Codable { }
 
 extension DirectUploadOptions.EventTracking: Codable { }
 
-extension DirectUploadOptions.InputStandardization: Codable { }
+extension DirectUploadOptions.InputStandardization: Codable {
+    enum CodingKeys: String, CodingKey {
+        case isRequested
+        case maximumResolution
+        case hdrHandling
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.isRequested = try container.decode(
+            Bool.self,
+            forKey: .isRequested
+        )
+        self.maximumResolution = try container.decode(
+            MaximumResolution.self,
+            forKey: .maximumResolution
+        )
+        self.hdrHandling = try container.decodeIfPresent(
+            HDRHandling.self,
+            forKey: .hdrHandling
+        ) ?? .preserve
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(isRequested, forKey: .isRequested)
+        try container.encode(maximumResolution, forKey: .maximumResolution)
+        try container.encode(hdrHandling, forKey: .hdrHandling)
+    }
+}
 
 extension DirectUploadOptions.InputStandardization.MaximumResolution: Codable { }
 

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -1,0 +1,34 @@
+//
+//  MockUploadInputStandardizer.swift
+//
+
+import AVFoundation
+import Foundation
+
+@testable import MuxUploadSDK
+
+final class MockUploadInputStandardizer: UploadInputStandardizing {
+    private(set) var standardizeCallCount = 0
+    private(set) var acknowledgeCompletionCallCount = 0
+
+    let error: Error
+
+    init(error: Error = StandardizationError.standardizedAssetExportFailure) {
+        self.error = error
+    }
+
+    func standardize(
+        id: String,
+        sourceAsset: AVURLAsset,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL,
+        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
+    ) {
+        standardizeCallCount += 1
+        completion(sourceAsset, nil, error)
+    }
+
+    func acknowledgeCompletion(id: String) {
+        acknowledgeCompletionCallCount += 1
+    }
+}

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -1,0 +1,43 @@
+//
+//  UploadInputStandardizerTests.swift
+//
+
+import AVFoundation
+import XCTest
+
+@testable import MuxUploadSDK
+
+final class UploadInputStandardizerTests: XCTestCase {
+
+    func testSynchronousFailureAcknowledgementDoesNotRetainWorker() {
+        let standardizer = UploadInputStandardizer()
+        let id = UUID().uuidString
+        let sourceAsset = AVURLAsset(
+            url: URL(fileURLWithPath: "/tmp/input.mp4")
+        )
+        let completionExpectation = expectation(
+            description: "Expected unsupported tier to fail synchronously"
+        )
+
+        standardizer.standardize(
+            id: id,
+            sourceAsset: sourceAsset,
+            rescalingDetails: .init(
+                maximumDesiredResolutionPreset: .preset2560x1440,
+                recordedResolution: .init(width: 3840, height: 2160)
+            ),
+            outputURL: URL(fileURLWithPath: "/tmp/output.mp4")
+        ) { _, standardizedAsset, error in
+            XCTAssertNil(standardizedAsset)
+            XCTAssertEqual(
+                error?.localizedDescription,
+                StandardizationError.unsupportedResolutionTier.localizedDescription
+            )
+            standardizer.acknowledgeCompletion(id: id)
+            completionExpectation.fulfill()
+        }
+
+        wait(for: [completionExpectation], timeout: 1.0)
+        XCTAssertNil(standardizer.workers[id])
+    }
+}

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadOptionsTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadOptionsTests.swift
@@ -1,0 +1,114 @@
+//
+//  DirectUploadOptionsTests.swift
+//
+
+import XCTest
+@testable import MuxUploadSDK
+
+final class DirectUploadOptionsTests: XCTestCase {
+
+    func testInputStandardizationDefaultsRemain1080pAndPreserveHDR() {
+        XCTAssertEqual(
+            DirectUploadOptions.InputStandardization.default.maximumResolution,
+            .default
+        )
+        XCTAssertEqual(
+            DirectUploadOptions.InputStandardization.default.hdrHandling,
+            .preserve
+        )
+    }
+
+    func testExistingMaximumResolutionInitializerDefaultsToPreserveHDR() {
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .preset3840x2160
+        )
+
+        XCTAssertEqual(options.maximumResolution, .preset3840x2160)
+        XCTAssertEqual(options.hdrHandling, .preserve)
+    }
+
+    func testInputStandardizationSupports1440pAndOptInToneMapping() {
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .preset2560x1440,
+            hdrHandling: .toneMapToSDR
+        )
+
+        XCTAssertEqual(options.maximumResolution, .preset2560x1440)
+        XCTAssertEqual(options.maximumResolution.description, "preset2560x1440")
+        XCTAssertEqual(options.hdrHandling, .toneMapToSDR)
+    }
+
+    func test1440pResolutionThresholdDoesNotUpscale() {
+        var details = UploadInputFormatInspectionResult.RescalingDetails(
+            maximumDesiredResolutionPreset: .preset2560x1440,
+            recordedResolution: .init(width: 2560, height: 1440)
+        )
+
+        XCTAssertFalse(details.needsRescaling)
+
+        details.recordedResolution = .init(width: 2561, height: 1440)
+
+        XCTAssertTrue(details.needsRescaling)
+    }
+
+    func testPersistedOptionsWithoutHDRHandlingDecodeAsPreserve() throws {
+        let persistedOptions = """
+        {
+          "isRequested": true,
+          "maximumResolution": {
+            "preset3840x2160": {}
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(
+            DirectUploadOptions.InputStandardization.self,
+            from: Data(persistedOptions.utf8)
+        )
+
+        XCTAssertEqual(decoded.maximumResolution, .preset3840x2160)
+        XCTAssertEqual(decoded.hdrHandling, .preserve)
+    }
+
+    func testExistingMaximumResolutionSerializedValuesRemainStable() throws {
+        let resolutions: [
+            DirectUploadOptions.InputStandardization.MaximumResolution
+        ] = [
+            .default,
+            .preset1280x720,
+            .preset1920x1080,
+            .preset3840x2160
+        ]
+
+        let encoded = try resolutions.map {
+            try XCTUnwrap(
+                String(data: JSONEncoder().encode($0), encoding: .utf8)
+            )
+        }
+
+        XCTAssertEqual(
+            encoded,
+            [
+                #"{"default":{}}"#,
+                #"{"preset1280x720":{}}"#,
+                #"{"preset1920x1080":{}}"#,
+                #"{"preset3840x2160":{}}"#
+            ]
+        )
+    }
+
+    func testHDRHandlingRoundTripsThroughPersistence() throws {
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .preset2560x1440,
+            hdrHandling: .toneMapToSDR
+        )
+
+        let encoded = try JSONEncoder().encode(options)
+        let decoded = try JSONDecoder().decode(
+            DirectUploadOptions.InputStandardization.self,
+            from: encoded
+        )
+
+        XCTAssertEqual(decoded, options)
+    }
+}

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -116,7 +116,137 @@ class DirectUploadTests: XCTestCase {
             enforceOrder: true
         )
     }
-    
+
+    func testNonStandardInputHandlerReturningTrueCancelsUpload() throws {
+        let input = try UploadInput.mockReadyInput()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector.alwaysFailing
+        )
+        var handlerCallCount = 0
+
+        upload.nonStandardInputHandler = {
+            handlerCallCount += 1
+            return true
+        }
+
+        upload.start()
+
+        XCTAssertEqual(handlerCallCount, 1)
+        guard case .ready = upload.inputStatus else {
+            return XCTFail("Expected true to cancel and reset the upload to ready")
+        }
+    }
+
+    func testNonStandardInputHandlerReturningFalseUploadsOriginal() throws {
+        let input = try UploadInput.mockReadyInput()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector.alwaysFailing
+        )
+        var handlerCallCount = 0
+
+        upload.nonStandardInputHandler = {
+            handlerCallCount += 1
+            return false
+        }
+
+        upload.start()
+
+        XCTAssertEqual(handlerCallCount, 1)
+        guard case .transportInProgress = upload.inputStatus else {
+            return XCTFail("Expected false to upload the original input")
+        }
+        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+        upload.cancel()
+    }
+
+    func testHandlerReturningTrueCancelsAfterRescalingFailure() throws {
+        try assertStandardizationFailureBehavior(
+            inspectionResult: UploadInputFormatInspectionResult(
+                nonStandardInputReasons: [],
+                rescalingDetails: .init(
+                    maximumDesiredResolutionPreset: .default,
+                    recordedResolution: .init(width: 3840, height: 2160)
+                )
+            ),
+            shouldCancel: true
+        )
+    }
+
+    func testHandlerReturningFalseUploadsOriginalAfterRescalingFailure() throws {
+        try assertStandardizationFailureBehavior(
+            inspectionResult: UploadInputFormatInspectionResult(
+                nonStandardInputReasons: [],
+                rescalingDetails: .init(
+                    maximumDesiredResolutionPreset: .default,
+                    recordedResolution: .init(width: 3840, height: 2160)
+                )
+            ),
+            shouldCancel: false
+        )
+    }
+
+    func testHandlerReturningTrueCancelsAfterNonstandardInputFailure() throws {
+        try assertStandardizationFailureBehavior(
+            inspectionResult: UploadInputFormatInspectionResult(
+                nonStandardInputReasons: [.videoCodec],
+                rescalingDetails: .init()
+            ),
+            shouldCancel: true
+        )
+    }
+
+    func testHandlerReturningFalseUploadsOriginalAfterNonstandardInputFailure() throws {
+        try assertStandardizationFailureBehavior(
+            inspectionResult: UploadInputFormatInspectionResult(
+                nonStandardInputReasons: [.videoCodec],
+                rescalingDetails: .init()
+            ),
+            shouldCancel: false
+        )
+    }
+
+    private func assertStandardizationFailureBehavior(
+        inspectionResult: UploadInputFormatInspectionResult,
+        shouldCancel: Bool
+    ) throws {
+        let input = try UploadInput.mockReadyInput()
+        let standardizer = MockUploadInputStandardizer()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: inspectionResult
+            ),
+            inputStandardizer: standardizer
+        )
+        var handlerCallCount = 0
+
+        upload.nonStandardInputHandler = {
+            handlerCallCount += 1
+            return shouldCancel
+        }
+
+        upload.start()
+
+        XCTAssertEqual(handlerCallCount, 1)
+        XCTAssertEqual(standardizer.standardizeCallCount, 1)
+        XCTAssertEqual(standardizer.acknowledgeCompletionCallCount, 1)
+
+        if shouldCancel {
+            guard case .ready = upload.inputStatus else {
+                return XCTFail("Expected true to cancel and reset the upload to ready")
+            }
+        } else {
+            guard case .transportInProgress = upload.inputStatus else {
+                return XCTFail("Expected false to upload the original input")
+            }
+            XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+            upload.cancel()
+        }
+    }
 
 }
-

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -17,6 +17,54 @@ then
     exit 1
 fi
 
+if ! command -v jq &> /dev/null
+then
+    echo -e "\033[1;31m ERROR: jq could not be found and is required to select an iOS simulator... \033[0m"
+    exit 1
+fi
+
+SIMULATOR_DETAILS=$(xcrun simctl list devices available --json | jq -r '
+    [
+        .devices
+        | to_entries[]
+        | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+        | .runtimeVersion = (
+            .key
+            | sub(".*iOS-"; "")
+            | split("-")
+            | map(tonumber)
+        )
+        | .runtimeName = (
+            .key
+            | sub("com.apple.CoreSimulator.SimRuntime.iOS-"; "iOS ")
+            | gsub("-"; ".")
+        )
+        | .eligibleDevices = [
+            .value[]
+            | select(
+                (.isAvailable // false)
+                and (.deviceTypeIdentifier | contains(".iPhone-"))
+            )
+        ]
+        | select(.eligibleDevices | length > 0)
+    ]
+    | sort_by(.runtimeVersion)
+    | last
+    | .eligibleDevices[0] as $device
+    | [$device.udid, $device.name, .runtimeName]
+    | @tsv
+')
+readonly SIMULATOR_DETAILS
+
+if [ -z "${SIMULATOR_DETAILS}" ]
+then
+    echo -e "\033[1;31m ERROR: No available iPhone simulator was found... \033[0m"
+    exit 1
+fi
+
+IFS=$'\t' read -r SIMULATOR_UDID SIMULATOR_NAME SIMULATOR_RUNTIME <<< "${SIMULATOR_DETAILS}"
+readonly SIMULATOR_UDID SIMULATOR_NAME SIMULATOR_RUNTIME
+
 echo "▸ Using Xcode Version: ${XCODE}"
 
 echo "▸ Available Xcode SDKs"
@@ -33,7 +81,9 @@ xcodebuild -list -json
 
 echo "▸ Test ${SCHEME}"
 
+echo "▸ Using ${SIMULATOR_NAME} (${SIMULATOR_RUNTIME}, ${SIMULATOR_UDID})"
+
 xcodebuild clean test \
-	-scheme $SCHEME \
-	-destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -scheme "${SCHEME}" \
+  -destination "platform=iOS Simulator,id=${SIMULATOR_UDID}" \
   | xcbeautify

--- a/scripts/run-unit-tests.sh
+++ b/scripts/run-unit-tests.sh
@@ -49,7 +49,7 @@ SIMULATOR_DETAILS=$(xcrun simctl list devices available --json | jq -r '
         | select(.eligibleDevices | length > 0)
     ]
     | sort_by(.runtimeVersion)
-    | last
+    | last // empty
     | .eligibleDevices[0] as $device
     | [$device.udid, $device.name, .runtimeName]
     | @tsv


### PR DESCRIPTION
## Summary

- expose 1440p and 4K input-standardization resolution tiers
- add HDR handling with eligible HDR preservation as the default and opt-in SDR tone mapping
- lock the existing `nonStandardInputHandler` compatibility contract: `true` cancels and `false` uploads the original input
- preserve decoding compatibility for persisted options that predate `hdrHandling`
- select the newest installed iOS runtime and an available iPhone simulator in the unit-test wrapper

## Developer impact

Existing callers retain the 1080p default and can continue using the maximum-resolution initializer unchanged. New callers can request 1440p or 4K standardization and choose whether supported HDR input is preserved or tone-mapped to SDR.


[NAT-481]: https://mux1.atlassian.net/browse/NAT-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ