### PR TITLE
NAT-482: Add Standard Input policy evaluator

### DIFF
--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
@@ -1,0 +1,549 @@
+//
+//  StandardInputPolicy.swift
+//
+
+import Foundation
+
+enum StandardInputFact<Value> {
+    case known(Value)
+    case unknown
+
+    var value: Value? {
+        guard case .known(let value) = self else {
+            return nil
+        }
+
+        return value
+    }
+}
+
+extension StandardInputFact: Equatable where Value: Equatable { }
+
+enum StandardInputVideoCodec: Hashable {
+    case h264
+    case hevc
+    case other
+}
+
+struct StandardInputDisplayDimensions: Equatable {
+    let width: Int
+    let height: Int
+
+    var maximumDimension: Int {
+        max(width, height)
+    }
+
+    var minimumDimension: Int {
+        min(width, height)
+    }
+
+    func fitsWithin(_ other: StandardInputDisplayDimensions) -> Bool {
+        maximumDimension <= other.maximumDimension
+            && minimumDimension <= other.minimumDimension
+    }
+}
+
+struct StandardInputPixelFormat: Hashable {
+    enum ChromaSubsampling: Hashable {
+        case yuv420
+        case other
+    }
+
+    let bitDepth: Int
+    let chromaSubsampling: ChromaSubsampling
+}
+
+enum StandardInputDynamicRange: Hashable {
+    case sdr
+    case hlg
+    case pq
+    case otherHDR
+}
+
+enum StandardInputGOPStructure: Hashable {
+    case closedWithIDR
+    case closedWithoutIDR
+    case open
+}
+
+enum StandardInputAudio: Hashable {
+    enum ChannelLayout: Hashable {
+        case mono
+        case stereo
+        case fivePointOne
+        case other
+    }
+
+    case none
+    case aac(ChannelLayout)
+    case otherCodec
+}
+
+enum StandardInputEditList: Hashable {
+    case none
+    case simple
+    case complex
+}
+
+struct StandardInputMediaFacts: Equatable {
+    var videoCodec: StandardInputFact<StandardInputVideoCodec> = .unknown
+    var displayDimensions: StandardInputFact<StandardInputDisplayDimensions> = .unknown
+    var frameRate: StandardInputFact<Double> = .unknown
+    var averageBitrate: StandardInputFact<Int64> = .unknown
+    var maximumGOPBitrate: StandardInputFact<Int64> = .unknown
+    var maximumGOPByteSize: StandardInputFact<Int64> = .unknown
+    var maximumKeyframeInterval: StandardInputFact<TimeInterval> = .unknown
+    var gopStructure: StandardInputFact<StandardInputGOPStructure> = .unknown
+    var pixelFormat: StandardInputFact<StandardInputPixelFormat> = .unknown
+    var dynamicRange: StandardInputFact<StandardInputDynamicRange> = .unknown
+    var audio: StandardInputFact<StandardInputAudio> = .unknown
+    var editList: StandardInputFact<StandardInputEditList> = .unknown
+}
+
+enum StandardInputAcceptanceTier: Hashable {
+    case upTo1080p
+    case highResolution
+}
+
+struct StandardInputPolicySelection: Equatable {
+    let acceptanceTier: StandardInputAcceptanceTier
+    let generatedOutputDimensions: StandardInputDisplayDimensions
+
+    init(
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution
+    ) {
+        switch maximumResolution {
+        case .preset1280x720:
+            self.acceptanceTier = .upTo1080p
+            self.generatedOutputDimensions = StandardInputDisplayDimensions(
+                width: 1280,
+                height: 720
+            )
+        case .default, .preset1920x1080:
+            self.acceptanceTier = .upTo1080p
+            self.generatedOutputDimensions = StandardInputDisplayDimensions(
+                width: 1920,
+                height: 1080
+            )
+        case .preset2560x1440:
+            self.acceptanceTier = .highResolution
+            self.generatedOutputDimensions = StandardInputDisplayDimensions(
+                width: 2560,
+                height: 1440
+            )
+        case .preset3840x2160:
+            self.acceptanceTier = .highResolution
+            self.generatedOutputDimensions = StandardInputDisplayDimensions(
+                width: 3840,
+                height: 2160
+            )
+        }
+    }
+}
+
+enum StandardInputMediaRole {
+    case sourceInput
+    case generatedOutput
+}
+
+struct StandardInputPolicyProfile {
+    struct TierLimits {
+        let maximumSourceDimension: Int
+        let frameRateRange: ClosedRange<Double>
+        let maximumAverageBitrate: Int64
+        let maximumGOPBitrate: Int64?
+        let maximumKeyframeIntervals: [StandardInputVideoCodec: TimeInterval]
+    }
+
+    let upTo1080pLimits: TierLimits
+    let highResolutionLimits: TierLimits
+    let supportedVideoCodecs: Set<StandardInputVideoCodec>
+    let supportedGOPStructures: Set<StandardInputGOPStructure>
+    let supportedPixelFormats: [
+        StandardInputVideoCodec: Set<StandardInputPixelFormat>
+    ]
+    let supportedDynamicRanges: Set<StandardInputDynamicRange>
+    let supportedHDRVideoCodecs: Set<StandardInputVideoCodec>
+    let supportedHDRPixelFormats: Set<StandardInputPixelFormat>
+    let supportedAudio: Set<StandardInputAudio>
+    let supportedEditLists: Set<StandardInputEditList>
+
+    func limits(for tier: StandardInputAcceptanceTier) -> TierLimits {
+        switch tier {
+        case .upTo1080p:
+            return upTo1080pLimits
+        case .highResolution:
+            return highResolutionLimits
+        }
+    }
+}
+
+extension StandardInputPolicyProfile {
+    static let publishedMux = StandardInputPolicyProfile(
+        upTo1080pLimits: TierLimits(
+            maximumSourceDimension: 2048,
+            frameRateRange: 5.0...120.0,
+            maximumAverageBitrate: 8_000_000,
+            maximumGOPBitrate: 16_000_000,
+            maximumKeyframeIntervals: [
+                .h264: 20.0,
+                .hevc: 10.0
+            ]
+        ),
+        highResolutionLimits: TierLimits(
+            maximumSourceDimension: 4096,
+            frameRateRange: 5.0...60.0,
+            maximumAverageBitrate: 20_000_000,
+            maximumGOPBitrate: nil,
+            maximumKeyframeIntervals: [
+                .h264: 10.0,
+                .hevc: 6.0
+            ]
+        ),
+        supportedVideoCodecs: [.h264, .hevc],
+        supportedGOPStructures: [.closedWithIDR],
+        supportedPixelFormats: [
+            .h264: [
+                StandardInputPixelFormat(
+                    bitDepth: 8,
+                    chromaSubsampling: .yuv420
+                )
+            ],
+            .hevc: [
+                StandardInputPixelFormat(
+                    bitDepth: 8,
+                    chromaSubsampling: .yuv420
+                ),
+                StandardInputPixelFormat(
+                    bitDepth: 10,
+                    chromaSubsampling: .yuv420
+                )
+            ]
+        ],
+        supportedDynamicRanges: [.sdr, .hlg, .pq],
+        supportedHDRVideoCodecs: [.hevc],
+        supportedHDRPixelFormats: [
+            StandardInputPixelFormat(
+                bitDepth: 10,
+                chromaSubsampling: .yuv420
+            )
+        ],
+        supportedAudio: [
+            .none,
+            .aac(.mono),
+            .aac(.stereo),
+            .aac(.fivePointOne)
+        ],
+        supportedEditLists: [.none, .simple]
+    )
+}
+
+struct StandardInputPolicyEvaluation: Equatable {
+    enum Requirement: CaseIterable, Equatable {
+        case videoCodec
+        case videoResolution
+        case frameRate
+        case averageBitrate
+        case maximumGOPBitrate
+        case keyframeInterval
+        case gopStructure
+        case pixelFormat
+        case dynamicRange
+        case audio
+        case editList
+    }
+
+    enum Status: Equatable {
+        case compliant
+        case nonCompliant
+        case unknown
+    }
+
+    enum Outcome: Equatable {
+        case compliant
+        case nonCompliant
+        case unknown
+    }
+
+    struct Check: Equatable {
+        let requirement: Requirement
+        let status: Status
+    }
+
+    let checks: [Check]
+
+    var outcome: Outcome {
+        if checks.contains(where: { $0.status == .nonCompliant }) {
+            return .nonCompliant
+        }
+
+        if checks.contains(where: { $0.status == .unknown }) {
+            return .unknown
+        }
+
+        return .compliant
+    }
+
+    var nonCompliantRequirements: [Requirement] {
+        checks.compactMap { check in
+            check.status == .nonCompliant ? check.requirement : nil
+        }
+    }
+
+    var unknownRequirements: [Requirement] {
+        checks.compactMap { check in
+            check.status == .unknown ? check.requirement : nil
+        }
+    }
+
+    func status(for requirement: Requirement) -> Status? {
+        checks.first(where: { $0.requirement == requirement })?.status
+    }
+}
+
+struct StandardInputPolicyEvaluator {
+    let profile: StandardInputPolicyProfile
+
+    init(profile: StandardInputPolicyProfile = .publishedMux) {
+        self.profile = profile
+    }
+
+    func evaluate(
+        _ facts: StandardInputMediaFacts,
+        selection: StandardInputPolicySelection,
+        role: StandardInputMediaRole = .sourceInput
+    ) -> StandardInputPolicyEvaluation {
+        let acceptanceTier = effectiveAcceptanceTier(
+            dimensions: facts.displayDimensions,
+            maximumTier: selection.acceptanceTier
+        )
+        let limits = profile.limits(for: acceptanceTier)
+
+        return StandardInputPolicyEvaluation(
+            checks: [
+                .init(
+                    requirement: .videoCodec,
+                    status: evaluate(facts.videoCodec) {
+                        profile.supportedVideoCodecs.contains($0)
+                    }
+                ),
+                .init(
+                    requirement: .videoResolution,
+                    status: evaluateDimensions(
+                        facts.displayDimensions,
+                        role: role,
+                        limits: limits,
+                        generatedOutputDimensions: selection.generatedOutputDimensions
+                    )
+                ),
+                .init(
+                    requirement: .frameRate,
+                    status: evaluatePositiveFinite(facts.frameRate) {
+                        limits.frameRateRange.contains($0)
+                    }
+                ),
+                .init(
+                    requirement: .averageBitrate,
+                    status: evaluatePositive(facts.averageBitrate) {
+                        $0 <= limits.maximumAverageBitrate
+                    }
+                ),
+                .init(
+                    requirement: .maximumGOPBitrate,
+                    status: evaluateMaximumGOPBitrate(
+                        facts.maximumGOPBitrate,
+                        maximum: limits.maximumGOPBitrate
+                    )
+                ),
+                .init(
+                    requirement: .keyframeInterval,
+                    status: evaluateKeyframeInterval(
+                        facts.maximumKeyframeInterval,
+                        codec: facts.videoCodec,
+                        limits: limits
+                    )
+                ),
+                .init(
+                    requirement: .gopStructure,
+                    status: evaluate(facts.gopStructure) {
+                        profile.supportedGOPStructures.contains($0)
+                    }
+                ),
+                .init(
+                    requirement: .pixelFormat,
+                    status: evaluatePixelFormat(
+                        facts.pixelFormat,
+                        codec: facts.videoCodec
+                    )
+                ),
+                .init(
+                    requirement: .dynamicRange,
+                    status: evaluateDynamicRange(
+                        facts.dynamicRange,
+                        codec: facts.videoCodec,
+                        pixelFormat: facts.pixelFormat
+                    )
+                ),
+                .init(
+                    requirement: .audio,
+                    status: evaluateAudio(facts.audio)
+                ),
+                .init(
+                    requirement: .editList,
+                    status: evaluate(facts.editList) {
+                        profile.supportedEditLists.contains($0)
+                    }
+                )
+            ]
+        )
+    }
+
+    private func effectiveAcceptanceTier(
+        dimensions: StandardInputFact<StandardInputDisplayDimensions>,
+        maximumTier: StandardInputAcceptanceTier
+    ) -> StandardInputAcceptanceTier {
+        guard maximumTier == .highResolution,
+              let dimensions = dimensions.value,
+              dimensions.width > 0,
+              dimensions.height > 0 else {
+            return maximumTier
+        }
+
+        let upTo1080pLimits = profile.limits(for: .upTo1080p)
+        return dimensions.maximumDimension <= upTo1080pLimits.maximumSourceDimension
+            ? .upTo1080p
+            : .highResolution
+    }
+
+    private func evaluate<Value>(
+        _ fact: StandardInputFact<Value>,
+        predicate: (Value) -> Bool
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let value = fact.value else {
+            return .unknown
+        }
+
+        return predicate(value) ? .compliant : .nonCompliant
+    }
+
+    private func evaluatePositive(
+        _ fact: StandardInputFact<Int64>,
+        predicate: (Int64) -> Bool
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let value = fact.value, value > 0 else {
+            return .unknown
+        }
+
+        return predicate(value) ? .compliant : .nonCompliant
+    }
+
+    private func evaluatePositiveFinite(
+        _ fact: StandardInputFact<Double>,
+        predicate: (Double) -> Bool
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let value = fact.value, value.isFinite, value > 0 else {
+            return .unknown
+        }
+
+        return predicate(value) ? .compliant : .nonCompliant
+    }
+
+    private func evaluateDimensions(
+        _ dimensions: StandardInputFact<StandardInputDisplayDimensions>,
+        role: StandardInputMediaRole,
+        limits: StandardInputPolicyProfile.TierLimits,
+        generatedOutputDimensions: StandardInputDisplayDimensions
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let dimensions = dimensions.value,
+              dimensions.width > 0,
+              dimensions.height > 0 else {
+            return .unknown
+        }
+
+        let isCompliant: Bool
+        switch role {
+        case .sourceInput:
+            isCompliant = dimensions.maximumDimension <= limits.maximumSourceDimension
+        case .generatedOutput:
+            isCompliant = dimensions.fitsWithin(generatedOutputDimensions)
+        }
+
+        return isCompliant ? .compliant : .nonCompliant
+    }
+
+    private func evaluateMaximumGOPBitrate(
+        _ bitrate: StandardInputFact<Int64>,
+        maximum: Int64?
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let maximum else {
+            return .compliant
+        }
+
+        return evaluatePositive(bitrate) { $0 <= maximum }
+    }
+
+    private func evaluateKeyframeInterval(
+        _ interval: StandardInputFact<TimeInterval>,
+        codec: StandardInputFact<StandardInputVideoCodec>,
+        limits: StandardInputPolicyProfile.TierLimits
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let codec = codec.value,
+              let maximumInterval = limits.maximumKeyframeIntervals[codec] else {
+            return .unknown
+        }
+
+        return evaluatePositiveFinite(interval) {
+            $0 <= maximumInterval
+        }
+    }
+
+    private func evaluatePixelFormat(
+        _ pixelFormat: StandardInputFact<StandardInputPixelFormat>,
+        codec: StandardInputFact<StandardInputVideoCodec>
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let pixelFormat = pixelFormat.value,
+              let codec = codec.value else {
+            return .unknown
+        }
+
+        return profile.supportedPixelFormats[codec]?.contains(pixelFormat) == true
+            ? .compliant
+            : .nonCompliant
+    }
+
+    private func evaluateDynamicRange(
+        _ dynamicRange: StandardInputFact<StandardInputDynamicRange>,
+        codec: StandardInputFact<StandardInputVideoCodec>,
+        pixelFormat: StandardInputFact<StandardInputPixelFormat>
+    ) -> StandardInputPolicyEvaluation.Status {
+        guard let dynamicRange = dynamicRange.value else {
+            return .unknown
+        }
+
+        guard profile.supportedDynamicRanges.contains(dynamicRange) else {
+            return .nonCompliant
+        }
+
+        guard dynamicRange != .sdr else {
+            return .compliant
+        }
+
+        guard let codec = codec.value,
+              let pixelFormat = pixelFormat.value else {
+            return .unknown
+        }
+
+        return profile.supportedHDRVideoCodecs.contains(codec)
+            && profile.supportedHDRPixelFormats.contains(pixelFormat)
+            ? .compliant
+            : .nonCompliant
+    }
+
+    private func evaluateAudio(
+        _ audio: StandardInputFact<StandardInputAudio>
+    ) -> StandardInputPolicyEvaluation.Status {
+        evaluate(audio) {
+            profile.supportedAudio.contains($0)
+        }
+    }
+}

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPolicyTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPolicyTests.swift
@@ -1,0 +1,428 @@
+//
+//  StandardInputPolicyTests.swift
+//
+
+import XCTest
+@testable import MuxUploadSDK
+
+final class StandardInputPolicyTests: XCTestCase {
+
+    private let evaluator = StandardInputPolicyEvaluator()
+
+    func testSDKMaximumResolutionSelectsAcceptanceTierAndOutputTarget() {
+        let p720 = selection(.preset1280x720)
+        let defaultResolution = selection(.default)
+        let p1440 = selection(.preset2560x1440)
+        let p2160 = selection(.preset3840x2160)
+
+        XCTAssertEqual(p720.acceptanceTier, .upTo1080p)
+        XCTAssertEqual(
+            p720.generatedOutputDimensions,
+            .init(width: 1280, height: 720)
+        )
+        XCTAssertEqual(defaultResolution.acceptanceTier, .upTo1080p)
+        XCTAssertEqual(
+            defaultResolution.generatedOutputDimensions,
+            .init(width: 1920, height: 1080)
+        )
+        XCTAssertEqual(defaultResolution, selection(.preset1920x1080))
+        XCTAssertEqual(p1440.acceptanceTier, .highResolution)
+        XCTAssertEqual(
+            p1440.generatedOutputDimensions,
+            .init(width: 2560, height: 1440)
+        )
+        XCTAssertEqual(p2160.acceptanceTier, .highResolution)
+        XCTAssertEqual(
+            p2160.generatedOutputDimensions,
+            .init(width: 3840, height: 2160)
+        )
+    }
+
+    func testPublished1080pBoundaryValuesAreCompliant() {
+        let evaluation = evaluator.evaluate(
+            compliantFacts(
+                dimensions: .init(width: 1920, height: 1080),
+                frameRate: 120.0,
+                averageBitrate: 8_000_000,
+                maximumGOPBitrate: 16_000_000,
+                maximumKeyframeInterval: 20.0
+            ),
+            selection: selection()
+        )
+
+        XCTAssertEqual(evaluation.outcome, .compliant)
+        XCTAssertTrue(evaluation.nonCompliantRequirements.isEmpty)
+        XCTAssertTrue(evaluation.unknownRequirements.isEmpty)
+    }
+
+    func testHEVCUsesPublishedKeyframeIntervalForEachTier() {
+        var facts = compliantFacts(
+            codec: .hevc,
+            dimensions: .init(width: 1920, height: 1080),
+            maximumKeyframeInterval: 10.0
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .keyframeInterval),
+            .compliant
+        )
+
+        facts.maximumKeyframeInterval = .known(10.001)
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .keyframeInterval),
+            .nonCompliant
+        )
+
+        facts.displayDimensions = .known(.init(width: 3840, height: 2160))
+        facts.frameRate = .known(60.0)
+        facts.averageBitrate = .known(20_000_000)
+        facts.maximumKeyframeInterval = .known(6.0)
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(.preset3840x2160)
+            ).status(for: .keyframeInterval),
+            .compliant
+        )
+    }
+
+    func testMissingPerGOPBitrateIsUnknownAt1080p() {
+        var facts = compliantFacts()
+        facts.maximumGOPBitrate = .unknown
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.outcome, .unknown)
+        XCTAssertEqual(evaluation.nonCompliantRequirements, [])
+        XCTAssertEqual(evaluation.unknownRequirements, [.maximumGOPBitrate])
+    }
+
+    func testKnownViolationWinsOverUnknownFact() {
+        var facts = compliantFacts()
+        facts.averageBitrate = .known(8_000_001)
+        facts.maximumGOPBitrate = .unknown
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.outcome, .nonCompliant)
+        XCTAssertEqual(evaluation.nonCompliantRequirements, [.averageBitrate])
+        XCTAssertEqual(evaluation.unknownRequirements, [.maximumGOPBitrate])
+    }
+
+    func testHighResolutionPolicyHasNoPerGOPBitrateCeiling() {
+        var facts = compliantFacts(
+            dimensions: .init(width: 2560, height: 1440),
+            frameRate: 60.0,
+            averageBitrate: 20_000_000,
+            maximumGOPBitrate: nil,
+            maximumKeyframeInterval: 10.0
+        )
+
+        var evaluation = evaluator.evaluate(
+            facts,
+            selection: selection(.preset2560x1440)
+        )
+
+        XCTAssertEqual(evaluation.status(for: .maximumGOPBitrate), .compliant)
+        XCTAssertEqual(evaluation.outcome, .compliant)
+
+        facts.averageBitrate = .known(20_000_001)
+        evaluation = evaluator.evaluate(
+            facts,
+            selection: selection(.preset2560x1440)
+        )
+
+        XCTAssertEqual(evaluation.status(for: .averageBitrate), .nonCompliant)
+        XCTAssertEqual(evaluation.outcome, .nonCompliant)
+    }
+
+    func testHighResolutionSelectionUsesSourceResolutionToChooseEffectiveTier() {
+        let facts = compliantFacts(
+            dimensions: .init(width: 1920, height: 1080),
+            frameRate: 120.0,
+            averageBitrate: 15_000_000,
+            maximumGOPBitrate: 16_000_000,
+            maximumKeyframeInterval: 15.0
+        )
+
+        let evaluation = evaluator.evaluate(
+            facts,
+            selection: selection(.preset3840x2160)
+        )
+
+        XCTAssertEqual(evaluation.status(for: .frameRate), .compliant)
+        XCTAssertEqual(evaluation.status(for: .averageBitrate), .nonCompliant)
+        XCTAssertEqual(evaluation.status(for: .maximumGOPBitrate), .compliant)
+        XCTAssertEqual(evaluation.status(for: .keyframeInterval), .compliant)
+        XCTAssertEqual(evaluation.outcome, .nonCompliant)
+    }
+
+    func testMaximumGOPByteSizeIsNotComparedWithBitrateLimits() {
+        var facts = compliantFacts()
+        facts.maximumGOPByteSize = .known(Int64.max)
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.outcome, .compliant)
+        XCTAssertEqual(
+            evaluation.status(for: .maximumGOPBitrate),
+            .compliant
+        )
+    }
+
+    func testPublishedFrameRateRangesAreInclusive() {
+        var facts = compliantFacts(frameRate: 5.0)
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .frameRate),
+            .compliant
+        )
+
+        facts.frameRate = .known(120.001)
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .frameRate),
+            .nonCompliant
+        )
+
+        facts = compliantFacts(
+            dimensions: .init(width: 2560, height: 1440),
+            frameRate: 60.001,
+            averageBitrate: 20_000_000,
+            maximumGOPBitrate: nil,
+            maximumKeyframeInterval: 10.0
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(.preset2560x1440)
+            ).status(for: .frameRate),
+            .nonCompliant
+        )
+    }
+
+    func testPublishedSourceResolutionIsOrientationNeutral() {
+        var facts = compliantFacts(
+            dimensions: .init(width: 1152, height: 2048)
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .videoResolution),
+            .compliant
+        )
+
+        facts.displayDimensions = .known(.init(width: 1152, height: 2049))
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection()
+            ).status(for: .videoResolution),
+            .nonCompliant
+        )
+    }
+
+    func testPublishedSourceLimitIsSeparateFromGeneratedOutputTarget() {
+        let facts = compliantFacts(
+            dimensions: .init(width: 2048, height: 1152)
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(),
+                role: .sourceInput
+            ).status(for: .videoResolution),
+            .compliant
+        )
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(),
+                role: .generatedOutput
+            ).status(for: .videoResolution),
+            .nonCompliant
+        )
+    }
+
+    func test2160pSourceAndGeneratedOutputUsePublishedDimensionRules() {
+        var facts = compliantFacts(
+            dimensions: .init(width: 2160, height: 4096),
+            frameRate: 60.0,
+            averageBitrate: 20_000_000,
+            maximumGOPBitrate: nil,
+            maximumKeyframeInterval: 10.0
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(.preset3840x2160),
+                role: .sourceInput
+            ).status(for: .videoResolution),
+            .compliant
+        )
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(.preset3840x2160),
+                role: .generatedOutput
+            ).status(for: .videoResolution),
+            .nonCompliant
+        )
+
+        facts.displayDimensions = .known(.init(width: 2160, height: 3840))
+
+        XCTAssertEqual(
+            evaluator.evaluate(
+                facts,
+                selection: selection(.preset3840x2160),
+                role: .generatedOutput
+            ).status(for: .videoResolution),
+            .compliant
+        )
+    }
+
+    func testPixelFormatAndHDRRulesAreCodecAware() {
+        var facts = compliantFacts(
+            codec: .hevc,
+            maximumKeyframeInterval: 10.0,
+            pixelFormat: .init(bitDepth: 10, chromaSubsampling: .yuv420),
+            dynamicRange: .hlg
+        )
+
+        var evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.status(for: .pixelFormat), .compliant)
+        XCTAssertEqual(evaluation.status(for: .dynamicRange), .compliant)
+
+        facts.videoCodec = .known(.h264)
+        facts.maximumKeyframeInterval = .known(20.0)
+        evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.status(for: .pixelFormat), .nonCompliant)
+        XCTAssertEqual(evaluation.status(for: .dynamicRange), .nonCompliant)
+    }
+
+    func testUnsupportedCodecAndGOPStructureAreNonCompliant() {
+        var facts = compliantFacts()
+        facts.videoCodec = .known(.other)
+        facts.gopStructure = .known(.open)
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.status(for: .videoCodec), .nonCompliant)
+        XCTAssertEqual(evaluation.status(for: .gopStructure), .nonCompliant)
+        XCTAssertEqual(evaluation.outcome, .nonCompliant)
+    }
+
+    func testAudioAndEditListRulesRejectUnsupportedValues() {
+        var facts = compliantFacts()
+        facts.audio = .known(.aac(.other))
+        facts.editList = .known(.complex)
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.status(for: .audio), .nonCompliant)
+        XCTAssertEqual(evaluation.status(for: .editList), .nonCompliant)
+        XCTAssertEqual(
+            evaluation.nonCompliantRequirements,
+            [.audio, .editList]
+        )
+    }
+
+    func testUnavailableFactsRemainUnknown() {
+        let evaluation = evaluator.evaluate(
+            StandardInputMediaFacts(),
+            selection: selection()
+        )
+
+        XCTAssertEqual(evaluation.outcome, .unknown)
+        XCTAssertEqual(
+            evaluation.unknownRequirements,
+            StandardInputPolicyEvaluation.Requirement.allCases
+        )
+    }
+
+    func testInvalidMeasurementSentinelsRemainUnknown() {
+        var facts = compliantFacts()
+        facts.displayDimensions = .known(.init(width: 0, height: 1080))
+        facts.frameRate = .known(0)
+        facts.averageBitrate = .known(0)
+        facts.maximumGOPBitrate = .known(0)
+        facts.maximumKeyframeInterval = .known(0)
+
+        let evaluation = evaluator.evaluate(facts, selection: selection())
+
+        XCTAssertEqual(evaluation.outcome, .unknown)
+        XCTAssertEqual(
+            evaluation.unknownRequirements,
+            [
+                .videoResolution,
+                .frameRate,
+                .averageBitrate,
+                .maximumGOPBitrate,
+                .keyframeInterval
+            ]
+        )
+        XCTAssertTrue(evaluation.nonCompliantRequirements.isEmpty)
+    }
+
+    private func selection(
+        _ maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution = .default
+    ) -> StandardInputPolicySelection {
+        StandardInputPolicySelection(maximumResolution: maximumResolution)
+    }
+
+    private func compliantFacts(
+        codec: StandardInputVideoCodec = .h264,
+        dimensions: StandardInputDisplayDimensions = .init(
+            width: 1920,
+            height: 1080
+        ),
+        frameRate: Double = 120.0,
+        averageBitrate: Int64 = 8_000_000,
+        maximumGOPBitrate: Int64? = 16_000_000,
+        maximumKeyframeInterval: TimeInterval = 20.0,
+        pixelFormat: StandardInputPixelFormat = .init(
+            bitDepth: 8,
+            chromaSubsampling: .yuv420
+        ),
+        dynamicRange: StandardInputDynamicRange = .sdr
+    ) -> StandardInputMediaFacts {
+        StandardInputMediaFacts(
+            videoCodec: .known(codec),
+            displayDimensions: .known(dimensions),
+            frameRate: .known(frameRate),
+            averageBitrate: .known(averageBitrate),
+            maximumGOPBitrate: maximumGOPBitrate.map(StandardInputFact.known)
+                ?? .unknown,
+            maximumGOPByteSize: .unknown,
+            maximumKeyframeInterval: .known(maximumKeyframeInterval),
+            gopStructure: .known(.closedWithIDR),
+            pixelFormat: .known(pixelFormat),
+            dynamicRange: .known(dynamicRange),
+            audio: .known(.aac(.fivePointOne)),
+            editList: .known(.simple)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a centralized, profile-shaped representation of the published Mux Standard Input policy
- model inspection facts explicitly as known or unknown and evaluate each requirement independently
- separate the two published acceptance tiers from the SDK's four local output targets
- derive the effective acceptance tier from both the source dimensions and the selected maximum tier
- cover codec, resolution, frame rate, average and per-GOP bitrate, keyframe interval, GOP structure, pixel format, HDR, audio, and edit-list behavior

This change adds only policy data, typed facts, pure evaluation, and focused tests. It does not change inspection, planning, conversion, or upload behavior, and it introduces no public API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New internal-only types and tests; no changes to inspection, upload behavior, or public API surface.
> 
> **Overview**
> Introduces **internal** policy modeling and pure evaluation for Mux Standard Input, without wiring it into inspection, conversion, or upload yet.
> 
> Adds `StandardInputPolicy.swift` with typed media facts (`known` / `unknown`), a `publishedMux` profile (1080p vs high-res tiers), mapping from `DirectUploadOptions.InputStandardization.MaximumResolution` to acceptance tier and output dimensions, and `StandardInputPolicyEvaluator` that returns per-requirement **compliant**, **nonCompliant**, or **unknown** checks (codec, resolution by source vs generated role, frame rate, bitrates, keyframes, GOP, pixel format, HDR, audio, edit lists). Overall outcome treats any violation as non-compliant and otherwise surfaces unknowns when facts are missing.
> 
> Adds `StandardInputPolicyTests.swift` to lock in tier selection, effective tier from source size, boundary values, and unknown-vs-violation precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c6fc098fbccf1a8b392d370ec70cede5951b131. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->