### PR TITLE
NAT-484: Inspect standard input metadata

### DIFF
--- a/Mux-Upload-SDK.podspec
+++ b/Mux-Upload-SDK.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.0'
 
-  s.ios.deployment_target = '14.0'
+  s.ios.deployment_target = '15.0'
   s.macos.deployment_target = '13.0'
 
   s.source_files = 'Sources/MuxUploadSDK/**/*'

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "MuxUploadSDK",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v14),
+        .iOS(.v15),
         .macOS(.v13)
     ],
     

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This SDK is currently in public beta. If you encounter any issues please let us 
 ## Usage
 To use this SDK, you'll need to add it as a dependency using either Swift Package Manager or Cocoapods.
 
-The Upload SDK is supported on iOS 14 and iPadOS 14, or higher. macOS is not supported at this time.
+The Upload SDK is supported on iOS 15 and iPadOS 15, or higher. macOS is not supported at this time.
 
 ## Documentation
 A getting started guide can be found [here](https://docs.mux.com/guides/video/upload-video-directly-from-ios-or-ipados).

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
@@ -22,6 +22,10 @@ struct UploadInputFormatInspectionResult {
 
     var nonStandardInputReasons: [NonstandardInputReason] = []
 
+    var mediaFacts: StandardInputMediaFacts = StandardInputMediaFacts()
+
+    var metadata: UploadInputMetadataInspection = UploadInputMetadataInspection()
+
     var isStandardInput: Bool {
         nonStandardInputReasons.isEmpty
     }

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -93,16 +93,10 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     completionHandler: completionHandler
                 )
             default:
-                let audioResult = AVFoundationUploadInputMetadataReader.inspect(
-                    videoTracks: [],
-                    audioTracks: audioMetadata
-                )
-                var metadata = audioResult.metadata
-                metadata.videoTrackCount = videoTracks.count
                 completionHandler(
-                    UploadInputFormatInspectionResult(
-                        mediaFacts: audioResult.mediaFacts,
-                        metadata: metadata
+                    self.makeVideoInspectionFailureResult(
+                        videoTrackCount: videoTracks.count,
+                        audioMetadata: audioMetadata
                     ),
                     CMTime.zero,
                     UploadInputInspectionError.inspectionFailure
@@ -132,13 +126,9 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     as? [CMFormatDescription],
                       let formatDescription = formatDescriptions.first else {
                     completionHandler(
-                        UploadInputFormatInspectionResult(
-                            metadata: UploadInputMetadataInspection(
-                                videoTrackCount: 1,
-                                audioTrackCount: audioMetadata.map {
-                                    .known($0.count)
-                                } ?? .unknown
-                            )
+                        self.makeVideoInspectionFailureResult(
+                            videoTrackCount: 1,
+                            audioMetadata: audioMetadata
                         ),
                         sourceInputDuration,
                         UploadInputInspectionError.inspectionFailure
@@ -182,6 +172,22 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                 )
             }
         }
+    }
+
+    func makeVideoInspectionFailureResult(
+        videoTrackCount: Int,
+        audioMetadata: [AVFoundationAudioTrackMetadata]?
+    ) -> UploadInputFormatInspectionResult {
+        let audioResult = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [],
+            audioTracks: audioMetadata
+        )
+        var metadata = audioResult.metadata
+        metadata.videoTrackCount = videoTrackCount
+        return UploadInputFormatInspectionResult(
+            mediaFacts: audioResult.mediaFacts,
+            metadata: metadata
+        )
     }
 
     private func loadAudioMetadata(

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -36,43 +36,25 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         completionHandler: @escaping UploadInputInspectionCompletionHandler
     ) {
-        // TODO: Eventually load audio tracks too
-        if #available(iOS 15, *) {
-            sourceInput.loadTracks(
-                withMediaType: .video
-            ) { tracks, error in
-                if error != nil {
-                    completionHandler(
-                        nil, 
-                        CMTime.zero,
-                        UploadInputInspectionError.inspectionFailure
-                    )
-                    return
-                }
-
-                if let tracks {
-                    self.inspect(
-                        sourceInput: sourceInput,
-                        tracks: tracks,
-                        maximumResolution: maximumResolution,
-                        completionHandler: completionHandler
-                    )
-                }
-            }
-        } else {
-            sourceInput.loadValuesAsynchronously(
-                forKeys: [
-                    "tracks"
-                ]
-            ) {
-                // Non-blocking if "tracks" is already loaded
-                let tracks = sourceInput.tracks(
-                    withMediaType: .video
+        sourceInput.loadTracks(
+            withMediaType: .video
+        ) { videoTracks, videoError in
+            guard videoError == nil, let videoTracks else {
+                completionHandler(
+                    nil,
+                    CMTime.zero,
+                    UploadInputInspectionError.inspectionFailure
                 )
+                return
+            }
 
+            sourceInput.loadTracks(
+                withMediaType: .audio
+            ) { audioTracks, audioError in
                 self.inspect(
                     sourceInput: sourceInput,
-                    tracks: tracks,
+                    videoTracks: videoTracks,
+                    audioTracks: audioError == nil ? audioTracks : nil,
                     maximumResolution: maximumResolution,
                     completionHandler: completionHandler
                 )
@@ -82,117 +64,182 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
 
     func inspect(
         sourceInput: AVAsset,
-        tracks: [AVAssetTrack],
+        videoTracks: [AVAssetTrack],
+        audioTracks: [AVAssetTrack]?,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         completionHandler: @escaping UploadInputInspectionCompletionHandler
     ) {
-        switch tracks.count {
-        case 0:
-            // Nothing to inspect, therefore nothing to standardize
-            // declare as already standard
-            completionHandler(
-                UploadInputFormatInspectionResult(),
-                CMTime.zero,
-                nil
-            )
-        case 1:
+        loadAudioMetadata(audioTracks) { audioMetadata in
+            switch videoTracks.count {
+            case 0:
+                let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
+                    videoTracks: [],
+                    audioTracks: audioMetadata
+                )
+                completionHandler(
+                    UploadInputFormatInspectionResult(
+                        mediaFacts: metadataResult.mediaFacts,
+                        metadata: metadataResult.metadata
+                    ),
+                    CMTime.zero,
+                    nil
+                )
+            case 1:
+                self.inspectSingleVideoTrack(
+                    sourceInput: sourceInput,
+                    videoTrack: videoTracks[0],
+                    audioMetadata: audioMetadata,
+                    maximumResolution: maximumResolution,
+                    completionHandler: completionHandler
+                )
+            default:
+                let audioResult = AVFoundationUploadInputMetadataReader.inspect(
+                    videoTracks: [],
+                    audioTracks: audioMetadata
+                )
+                var metadata = audioResult.metadata
+                metadata.videoTrackCount = videoTracks.count
+                completionHandler(
+                    UploadInputFormatInspectionResult(
+                        mediaFacts: audioResult.mediaFacts,
+                        metadata: metadata
+                    ),
+                    CMTime.zero,
+                    UploadInputInspectionError.inspectionFailure
+                )
+            }
+        }
+    }
 
-            sourceInput.loadValuesAsynchronously(
+    private func inspectSingleVideoTrack(
+        sourceInput: AVAsset,
+        videoTrack: AVAssetTrack,
+        audioMetadata: [AVFoundationAudioTrackMetadata]?,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
+        completionHandler: @escaping UploadInputInspectionCompletionHandler
+    ) {
+        sourceInput.loadValuesAsynchronously(forKeys: ["duration"]) {
+            let sourceInputDuration = sourceInput.duration
+            videoTrack.loadValuesAsynchronously(
                 forKeys: [
-                    "duration"
+                    "formatDescriptions",
+                    "preferredTransform",
+                    "nominalFrameRate",
+                    "estimatedDataRate"
                 ]
             ) {
-                let sourceInputDuration = sourceInput.duration
-                if let track = tracks.first {
-                    track.loadValuesAsynchronously(
-                        forKeys: [
-                            "formatDescriptions",
-                            "nominalFrameRate",
-                            "estimatedDataRate"
-                        ]
-                    ) {
-                        var nonStandardReasons: [UploadInputFormatInspectionResult.NonstandardInputReason] = []
-
-                        guard let formatDescriptions = track.formatDescriptions as? [CMFormatDescription] else {
-                            completionHandler(
-                                nil,
-                                sourceInputDuration,
-                                UploadInputInspectionError.inspectionFailure
+                guard let formatDescriptions = videoTrack.formatDescriptions
+                    as? [CMFormatDescription],
+                      let formatDescription = formatDescriptions.first else {
+                    completionHandler(
+                        UploadInputFormatInspectionResult(
+                            metadata: UploadInputMetadataInspection(
+                                videoTrackCount: 1,
+                                audioTrackCount: audioMetadata.map {
+                                    .known($0.count)
+                                } ?? .unknown
                             )
-                            return
-                        }
-
-                        guard let formatDescription = formatDescriptions.first else {
-                            completionHandler(
-                                nil,
-                                sourceInputDuration,
-                                UploadInputInspectionError.inspectionFailure
-                            )
-                            return
-                        }
-
-                        let videoDimensions = CMVideoFormatDescriptionGetDimensions(
-                            formatDescription
-                        )
-
-                        if max(videoDimensions.width, videoDimensions.height) > 3840 {
-                            nonStandardReasons.append(.videoResolution)
-                        }
-
-                        let rawVideoCodecType = formatDescription.mediaSubType.rawValue
-
-                        let rawStandardCodecType = CMFormatDescription.MediaSubType.h264.rawValue
-
-                        if rawVideoCodecType != rawStandardCodecType {
-                            nonStandardReasons.append(.videoCodec)
-                        }
-
-                        let frameRate = track.nominalFrameRate
-
-                        if max(videoDimensions.width, videoDimensions.height) > 1920 {
-                            if frameRate > 60.0 {
-                                nonStandardReasons.append(.videoFrameRate)
-                            }
-                        } else {
-                            if frameRate > 120.0 {
-                                nonStandardReasons.append(.videoFrameRate)
-                            }
-                        }
-
-                        let estimatedBitrate = track.estimatedDataRate
-
-                        if max(videoDimensions.width, videoDimensions.height) > 1920 {
-                            if estimatedBitrate > 40_000_000 {
-                                nonStandardReasons.append(.videoBitrate)
-                            }
-                        } else {
-                            if estimatedBitrate > 16_000_000 {
-                                nonStandardReasons.append(.videoBitrate)
-                            }
-                        }
-
-                        completionHandler(
-                            UploadInputFormatInspectionResult(
-                                nonStandardInputReasons: nonStandardReasons,
-                                rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails(
-                                    maximumDesiredResolutionPreset: maximumResolution,
-                                    recordedResolution: videoDimensions
-                                )
-                            ),
-                            sourceInputDuration,
-                            nil
-                        )
-                    }
+                        ),
+                        sourceInputDuration,
+                        UploadInputInspectionError.inspectionFailure
+                    )
+                    return
                 }
+
+                let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
+                    videoTracks: [
+                        AVFoundationVideoTrackMetadata(
+                            formatDescriptions: formatDescriptions,
+                            preferredTransform: videoTrack.preferredTransform,
+                            nominalFrameRate: videoTrack.nominalFrameRate,
+                            estimatedDataRate: videoTrack.estimatedDataRate
+                        )
+                    ],
+                    audioTracks: audioMetadata
+                )
+                let videoDimensions = CMVideoFormatDescriptionGetDimensions(
+                    formatDescription
+                )
+                let nonStandardReasons = self.legacyNonStandardReasons(
+                    formatDescription: formatDescription,
+                    videoDimensions: videoDimensions,
+                    frameRate: videoTrack.nominalFrameRate,
+                    estimatedBitrate: videoTrack.estimatedDataRate
+                )
+
+                completionHandler(
+                    UploadInputFormatInspectionResult(
+                        nonStandardInputReasons: nonStandardReasons,
+                        mediaFacts: metadataResult.mediaFacts,
+                        metadata: metadataResult.metadata,
+                        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails(
+                            maximumDesiredResolutionPreset: maximumResolution,
+                            recordedResolution: videoDimensions
+                        )
+                    ),
+                    sourceInputDuration,
+                    nil
+                )
             }
-        default:
-            // Inspection fails for multi-video track inputs
-            // for the time being
-            completionHandler(
-                nil,
-                CMTime.zero,
-                UploadInputInspectionError.inspectionFailure
+        }
+    }
+
+    private func loadAudioMetadata(
+        _ tracks: [AVAssetTrack]?,
+        index: Int = 0,
+        accumulated: [AVFoundationAudioTrackMetadata] = [],
+        completionHandler: @escaping ([AVFoundationAudioTrackMetadata]?) -> Void
+    ) {
+        guard let tracks else {
+            completionHandler(nil)
+            return
+        }
+
+        guard index < tracks.count else {
+            completionHandler(accumulated)
+            return
+        }
+
+        let track = tracks[index]
+        track.loadValuesAsynchronously(forKeys: ["formatDescriptions"]) {
+            let formatDescriptions = track.formatDescriptions as? [CMFormatDescription]
+                ?? []
+            self.loadAudioMetadata(
+                tracks,
+                index: index + 1,
+                accumulated: accumulated + [
+                    AVFoundationAudioTrackMetadata(
+                        formatDescriptions: formatDescriptions
+                    )
+                ],
+                completionHandler: completionHandler
             )
         }
+    }
+
+    private func legacyNonStandardReasons(
+        formatDescription: CMFormatDescription,
+        videoDimensions: CMVideoDimensions,
+        frameRate: Float,
+        estimatedBitrate: Float
+    ) -> [UploadInputFormatInspectionResult.NonstandardInputReason] {
+        var reasons: [UploadInputFormatInspectionResult.NonstandardInputReason] = []
+        let maximumDimension = max(videoDimensions.width, videoDimensions.height)
+
+        if maximumDimension > 3840 {
+            reasons.append(.videoResolution)
+        }
+        if formatDescription.mediaSubType.rawValue
+            != CMFormatDescription.MediaSubType.h264.rawValue {
+            reasons.append(.videoCodec)
+        }
+        if frameRate > (maximumDimension > 1920 ? 60.0 : 120.0) {
+            reasons.append(.videoFrameRate)
+        }
+        if estimatedBitrate > (maximumDimension > 1920 ? 40_000_000 : 16_000_000) {
+            reasons.append(.videoBitrate)
+        }
+
+        return reasons
     }
 }

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
@@ -1,0 +1,480 @@
+//
+//  UploadInputMetadataInspection.swift
+//
+
+import AudioToolbox
+import CoreGraphics
+import CoreMedia
+import Foundation
+
+struct UploadInputMetadataInspection: Equatable {
+    struct VideoTransform: Equatable {
+        /// The source metadata orientation normalized to the range 0...270.
+        /// For example, a signed -90-degree rotation is represented as 270 degrees.
+        enum Rotation: Int, Equatable {
+            case degrees0 = 0
+            case degrees90 = 90
+            case degrees180 = 180
+            case degrees270 = 270
+        }
+
+        let rotation: Rotation
+        let isMirrored: Bool
+    }
+
+    struct ColorProperties: Equatable {
+        var primaries: StandardInputFact<String> = .unknown
+        var transferFunction: StandardInputFact<String> = .unknown
+        var yCbCrMatrix: StandardInputFact<String> = .unknown
+        var isFullRangeVideo: StandardInputFact<Bool> = .unknown
+    }
+
+    var videoTrackCount: Int = 0
+    var audioTrackCount: StandardInputFact<Int> = .unknown
+    var encodedDimensions: StandardInputFact<StandardInputDisplayDimensions> = .unknown
+    var videoTransform: StandardInputFact<VideoTransform> = .unknown
+    var colorProperties: ColorProperties = ColorProperties()
+}
+
+struct AVFoundationVideoTrackMetadata {
+    let formatDescriptions: [CMFormatDescription]
+    let preferredTransform: CGAffineTransform
+    let nominalFrameRate: Float
+    let estimatedDataRate: Float
+}
+
+struct AVFoundationAudioTrackMetadata {
+    let formatDescriptions: [CMFormatDescription]
+}
+
+enum AVFoundationUploadInputMetadataReader {
+    struct Result {
+        let mediaFacts: StandardInputMediaFacts
+        let metadata: UploadInputMetadataInspection
+    }
+
+    static func inspect(
+        videoTracks: [AVFoundationVideoTrackMetadata],
+        audioTracks: [AVFoundationAudioTrackMetadata]?
+    ) -> Result {
+        var facts = StandardInputMediaFacts()
+        var metadata = UploadInputMetadataInspection(
+            videoTrackCount: videoTracks.count,
+            audioTrackCount: audioTracks.map { .known($0.count) } ?? .unknown
+        )
+
+        facts.audio = audioTracks.map(inspectAudio) ?? .unknown
+
+        guard videoTracks.count == 1,
+              let videoTrack = videoTracks.first,
+              let formatDescription = videoTrack.formatDescriptions.first else {
+            return Result(mediaFacts: facts, metadata: metadata)
+        }
+
+        facts.videoCodec = inspectVideoCodec(formatDescription.mediaSubType)
+
+        let encodedDimensions = CMVideoFormatDescriptionGetDimensions(formatDescription)
+        if encodedDimensions.width > 0, encodedDimensions.height > 0 {
+            metadata.encodedDimensions = .known(
+                StandardInputDisplayDimensions(
+                    width: Int(encodedDimensions.width),
+                    height: Int(encodedDimensions.height)
+                )
+            )
+        }
+
+        facts.displayDimensions = inspectDisplayDimensions(
+            formatDescription: formatDescription,
+            preferredTransform: videoTrack.preferredTransform
+        )
+        metadata.videoTransform = inspectVideoTransform(videoTrack.preferredTransform)
+        facts.frameRate = positiveFinite(Double(videoTrack.nominalFrameRate))
+        facts.averageBitrate = positiveFiniteInteger(Double(videoTrack.estimatedDataRate))
+
+        let extensions = (CMFormatDescriptionGetExtensions(formatDescription)
+            as NSDictionary?) ?? NSDictionary()
+        metadata.colorProperties = inspectColorProperties(extensions)
+        facts.dynamicRange = inspectDynamicRange(
+            transferFunction: metadata.colorProperties.transferFunction,
+            extensions: extensions
+        )
+        facts.pixelFormat = inspectPixelFormat(
+            codec: facts.videoCodec,
+            extensions: extensions
+        )
+
+        return Result(mediaFacts: facts, metadata: metadata)
+    }
+
+    private static func inspectVideoCodec(
+        _ mediaSubType: CMFormatDescription.MediaSubType
+    ) -> StandardInputFact<StandardInputVideoCodec> {
+        switch fourCharacterCodeString(mediaSubType.rawValue) {
+        case "avc1", "avc3":
+            return .known(.h264)
+        case "hvc1", "hev1":
+            return .known(.hevc)
+        default:
+            return .known(.other)
+        }
+    }
+
+    private static func inspectDisplayDimensions(
+        formatDescription: CMFormatDescription,
+        preferredTransform: CGAffineTransform
+    ) -> StandardInputFact<StandardInputDisplayDimensions> {
+        let presentationDimensions = CMVideoFormatDescriptionGetPresentationDimensions(
+            formatDescription,
+            usePixelAspectRatio: true,
+            useCleanAperture: true
+        )
+
+        guard presentationDimensions.width.isFinite,
+              presentationDimensions.height.isFinite,
+              presentationDimensions.width > 0,
+              presentationDimensions.height > 0,
+              inspectVideoTransform(preferredTransform).value != nil else {
+            return .unknown
+        }
+
+        let transformedBounds = CGRect(
+            origin: .zero,
+            size: presentationDimensions
+        ).applying(preferredTransform)
+        let width = Int(abs(transformedBounds.width).rounded())
+        let height = Int(abs(transformedBounds.height).rounded())
+
+        guard width > 0, height > 0 else {
+            return .unknown
+        }
+
+        return .known(StandardInputDisplayDimensions(width: width, height: height))
+    }
+
+    private static func inspectVideoTransform(
+        _ transform: CGAffineTransform
+    ) -> StandardInputFact<UploadInputMetadataInspection.VideoTransform> {
+        let values = [transform.a, transform.b, transform.c, transform.d]
+        guard values.allSatisfy(\.isFinite) else {
+            return .unknown
+        }
+
+        let firstAxisLength = hypot(transform.a, transform.b)
+        let secondAxisLength = hypot(transform.c, transform.d)
+        guard firstAxisLength > 0,
+              secondAxisLength > 0,
+              abs((transform.a * transform.c + transform.b * transform.d)
+                  / (firstAxisLength * secondAxisLength)) < 0.001 else {
+            return .unknown
+        }
+
+        let angle = atan2(transform.b / firstAxisLength, transform.a / firstAxisLength)
+        let counterclockwiseQuarterTurns = Int((angle / (.pi / 2)).rounded())
+        let clockwiseQuarterTurns = -counterclockwiseQuarterTurns
+        let normalizedQuarterTurns = (clockwiseQuarterTurns % 4 + 4) % 4
+        let expectedAngle = Double(counterclockwiseQuarterTurns) * (.pi / 2)
+        guard abs(angle - expectedAngle) < 0.001 else {
+            return .unknown
+        }
+
+        let rotation: UploadInputMetadataInspection.VideoTransform.Rotation
+        switch normalizedQuarterTurns {
+        case 0:
+            rotation = .degrees0
+        case 1:
+            rotation = .degrees90
+        case 2:
+            rotation = .degrees180
+        default:
+            rotation = .degrees270
+        }
+
+        return .known(
+            UploadInputMetadataInspection.VideoTransform(
+                rotation: rotation,
+                isMirrored: transform.a * transform.d - transform.b * transform.c < 0
+            )
+        )
+    }
+
+    private static func inspectColorProperties(
+        _ extensions: NSDictionary
+    ) -> UploadInputMetadataInspection.ColorProperties {
+        UploadInputMetadataInspection.ColorProperties(
+            primaries: stringFact(
+                extensions[kCMFormatDescriptionExtension_ColorPrimaries]
+            ),
+            transferFunction: stringFact(
+                extensions[kCMFormatDescriptionExtension_TransferFunction]
+            ),
+            yCbCrMatrix: stringFact(
+                extensions[kCMFormatDescriptionExtension_YCbCrMatrix]
+            ),
+            isFullRangeVideo: boolFact(
+                extensions[kCMFormatDescriptionExtension_FullRangeVideo]
+            )
+        )
+    }
+
+    private static func inspectDynamicRange(
+        transferFunction: StandardInputFact<String>,
+        extensions: NSDictionary
+    ) -> StandardInputFact<StandardInputDynamicRange> {
+        guard let transferFunction = transferFunction.value else {
+            return hasHDRMetadata(extensions) ? .known(.otherHDR) : .unknown
+        }
+
+        if transferFunction == swiftString(
+            kCMFormatDescriptionTransferFunction_ITU_R_2100_HLG
+        ) {
+            return .known(.hlg)
+        }
+        if transferFunction == swiftString(
+            kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ
+        ) {
+            return .known(.pq)
+        }
+
+        let sdrTransferFunctions = [
+            kCMFormatDescriptionTransferFunction_ITU_R_709_2,
+            kCMFormatDescriptionTransferFunction_SMPTE_240M_1995,
+            kCMFormatDescriptionTransferFunction_sRGB,
+            kCMFormatDescriptionTransferFunction_UseGamma
+        ].map(swiftString)
+        if sdrTransferFunctions.contains(transferFunction) {
+            return .known(.sdr)
+        }
+
+        if hasHDRMetadata(extensions) {
+            return .known(.otherHDR)
+        }
+        return .unknown
+    }
+
+    private static func inspectPixelFormat(
+        codec: StandardInputFact<StandardInputVideoCodec>,
+        extensions: NSDictionary
+    ) -> StandardInputFact<StandardInputPixelFormat> {
+        guard let codec = codec.value,
+              codec == .h264 || codec == .hevc else {
+            return .unknown
+        }
+
+        if let codecConfiguration = codecConfiguration(
+            codec: codec,
+            extensions: extensions
+        ) {
+            return .known(codecConfiguration)
+        }
+
+        return .unknown
+    }
+
+    private static func codecConfiguration(
+        codec: StandardInputVideoCodec,
+        extensions: NSDictionary
+    ) -> StandardInputPixelFormat? {
+        guard let atoms = extensions[
+            kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+        ] as? NSDictionary else {
+            return nil
+        }
+
+        switch codec {
+        case .h264:
+            guard let data = atoms["avcC"] as? Data else {
+                return nil
+            }
+            return inspectAVCConfiguration(data)
+        case .hevc:
+            guard let data = atoms["hvcC"] as? Data else {
+                return nil
+            }
+            return inspectHEVCConfiguration(data)
+        case .other:
+            return nil
+        }
+    }
+
+    private static func inspectHEVCConfiguration(
+        _ data: Data
+    ) -> StandardInputPixelFormat? {
+        guard data.count > 18, byte(in: data, at: 0) == 1 else {
+            return nil
+        }
+
+        let chromaFormat = byte(in: data, at: 16) & 0x03
+        let lumaBitDepth = Int(byte(in: data, at: 17) & 0x07) + 8
+        let chromaBitDepth = Int(byte(in: data, at: 18) & 0x07) + 8
+
+        return StandardInputPixelFormat(
+            bitDepth: max(lumaBitDepth, chromaBitDepth),
+            chromaSubsampling: chromaFormat == 1 ? .yuv420 : .other
+        )
+    }
+
+    private static func inspectAVCConfiguration(
+        _ data: Data
+    ) -> StandardInputPixelFormat? {
+        guard data.count > 6, byte(in: data, at: 0) == 1 else {
+            return nil
+        }
+
+        let profile = byte(in: data, at: 1)
+        let eightBit420Profiles: Set<UInt8> = [66, 77, 88]
+        if eightBit420Profiles.contains(profile) {
+            return StandardInputPixelFormat(
+                bitDepth: 8,
+                chromaSubsampling: .yuv420
+            )
+        }
+
+        let profilesWithExtendedConfiguration: Set<UInt8> = [
+            100, 110, 122, 144
+        ]
+        guard profilesWithExtendedConfiguration.contains(profile) else {
+            return nil
+        }
+
+        var offset = 6
+        let sequenceParameterSetCount = Int(byte(in: data, at: 5) & 0x1f)
+        guard skipLengthPrefixedEntries(
+            count: sequenceParameterSetCount,
+            data: data,
+            offset: &offset
+        ), offset < data.count else {
+            return nil
+        }
+
+        let pictureParameterSetCount = Int(byte(in: data, at: offset))
+        offset += 1
+        guard skipLengthPrefixedEntries(
+            count: pictureParameterSetCount,
+            data: data,
+            offset: &offset
+        ), offset + 2 < data.count else {
+            return nil
+        }
+
+        let chromaFormat = byte(in: data, at: offset) & 0x03
+        let lumaBitDepth = Int(byte(in: data, at: offset + 1) & 0x07) + 8
+        let chromaBitDepth = Int(byte(in: data, at: offset + 2) & 0x07) + 8
+
+        return StandardInputPixelFormat(
+            bitDepth: max(lumaBitDepth, chromaBitDepth),
+            chromaSubsampling: chromaFormat == 1 ? .yuv420 : .other
+        )
+    }
+
+    private static func skipLengthPrefixedEntries(
+        count: Int,
+        data: Data,
+        offset: inout Int
+    ) -> Bool {
+        for _ in 0..<count {
+            guard offset + 1 < data.count else {
+                return false
+            }
+            let length = Int(byte(in: data, at: offset)) << 8
+                | Int(byte(in: data, at: offset + 1))
+            offset += 2
+            guard offset + length <= data.count else {
+                return false
+            }
+            offset += length
+        }
+        return true
+    }
+
+    private static func byte(in data: Data, at offset: Int) -> UInt8 {
+        data[data.index(data.startIndex, offsetBy: offset)]
+    }
+
+    private static func inspectAudio(
+        _ tracks: [AVFoundationAudioTrackMetadata]
+    ) -> StandardInputFact<StandardInputAudio> {
+        guard !tracks.isEmpty else {
+            return .known(.none)
+        }
+        guard tracks.count == 1,
+              let formatDescription = tracks[0].formatDescriptions.first else {
+            return .unknown
+        }
+
+        let mediaSubType = formatDescription.mediaSubType.rawValue
+        guard mediaSubType == kAudioFormatMPEG4AAC else {
+            return .known(.otherCodec)
+        }
+
+        guard let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(
+            formatDescription
+        ) else {
+            return .unknown
+        }
+
+        let channelLayout: StandardInputAudio.ChannelLayout
+        switch streamDescription.pointee.mChannelsPerFrame {
+        case 1:
+            channelLayout = .mono
+        case 2:
+            channelLayout = .stereo
+        case 6:
+            channelLayout = .fivePointOne
+        default:
+            channelLayout = .other
+        }
+
+        return .known(.aac(channelLayout))
+    }
+
+    private static func positiveFinite(_ value: Double) -> StandardInputFact<Double> {
+        guard value.isFinite, value > 0 else {
+            return .unknown
+        }
+        return .known(value)
+    }
+
+    private static func positiveFiniteInteger(
+        _ value: Double
+    ) -> StandardInputFact<Int64> {
+        guard value.isFinite,
+              value > 0,
+              value <= Double(Int64.max) else {
+            return .unknown
+        }
+        return .known(Int64(value.rounded()))
+    }
+
+    private static func stringFact(_ value: Any?) -> StandardInputFact<String> {
+        guard let value = value as? String, !value.isEmpty else {
+            return .unknown
+        }
+        return .known(value)
+    }
+
+    private static func swiftString(_ value: CFString) -> String {
+        value as String
+    }
+
+    private static func boolFact(_ value: Any?) -> StandardInputFact<Bool> {
+        guard let value = value as? NSNumber else {
+            return .unknown
+        }
+        return .known(value.boolValue)
+    }
+
+    private static func hasHDRMetadata(_ extensions: NSDictionary) -> Bool {
+        extensions[kCMFormatDescriptionExtension_MasteringDisplayColorVolume] != nil
+            || extensions[kCMFormatDescriptionExtension_ContentLightLevelInfo] != nil
+    }
+
+    private static func fourCharacterCodeString(_ value: FourCharCode) -> String {
+        let bytes: [UInt8] = [
+            UInt8((value >> 24) & 0xff),
+            UInt8((value >> 16) & 0xff),
+            UInt8((value >> 8) & 0xff),
+            UInt8(value & 0xff)
+        ]
+        return String(bytes: bytes, encoding: .ascii) ?? ""
+    }
+}

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -103,12 +103,7 @@ class ChunkedFileUploader {
             var duration: CMTime
 
             do {
-                if #available(iOS 15, *) {
-                    duration = try await asset.load(.duration)
-                } else {
-                    await asset.loadValues(forKeys: ["duration"])
-                    duration = asset.duration
-                }
+                duration = try await asset.load(.duration)
             } catch {
                 // Cannot get duration, assume it is zero
                 duration = CMTime.zero

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
@@ -1,0 +1,531 @@
+//
+//  UploadInputMetadataInspectionTests.swift
+//
+
+import AudioToolbox
+import AVFoundation
+import CoreMedia
+import XCTest
+@testable import MuxUploadSDK
+
+final class UploadInputMetadataInspectionTests: XCTestCase {
+
+    func testReadsH264SDRMetadataIntoPolicyFacts() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("avc1"),
+            width: 1920,
+            height: 1080,
+            extensions: [
+                swiftString(kCMFormatDescriptionExtension_ColorPrimaries):
+                    kCMFormatDescriptionColorPrimaries_ITU_R_709_2,
+                swiftString(kCMFormatDescriptionExtension_TransferFunction):
+                    kCMFormatDescriptionTransferFunction_ITU_R_709_2,
+                swiftString(kCMFormatDescriptionExtension_YCbCrMatrix):
+                    kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2,
+                swiftString(kCMFormatDescriptionExtension_FullRangeVideo): false,
+                swiftString(
+                    kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+                ): ["avcC": Data([1, 77, 0, 40, 0xff, 0xe0, 0])]
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 7_500_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(result.mediaFacts.videoCodec, .known(.h264))
+        XCTAssertEqual(
+            result.mediaFacts.displayDimensions,
+            .known(.init(width: 1920, height: 1080))
+        )
+        XCTAssertEqual(result.mediaFacts.frameRate, .known(30))
+        XCTAssertEqual(result.mediaFacts.averageBitrate, .known(7_500_000))
+        XCTAssertEqual(
+            result.mediaFacts.pixelFormat,
+            .known(.init(bitDepth: 8, chromaSubsampling: .yuv420))
+        )
+        XCTAssertEqual(result.mediaFacts.dynamicRange, .known(.sdr))
+        XCTAssertEqual(result.mediaFacts.audio, .known(.none))
+        XCTAssertEqual(result.mediaFacts.maximumGOPBitrate, .unknown)
+        XCTAssertEqual(result.mediaFacts.maximumGOPByteSize, .unknown)
+        XCTAssertEqual(result.mediaFacts.maximumKeyframeInterval, .unknown)
+        XCTAssertEqual(result.mediaFacts.gopStructure, .unknown)
+        XCTAssertEqual(
+            result.metadata.encodedDimensions,
+            .known(.init(width: 1920, height: 1080))
+        )
+        XCTAssertEqual(
+            result.metadata.videoTransform,
+            .known(.init(rotation: .degrees0, isMirrored: false))
+        )
+        XCTAssertEqual(result.metadata.videoTrackCount, 1)
+        XCTAssertEqual(result.metadata.audioTrackCount, .known(0))
+        XCTAssertEqual(
+            result.metadata.colorProperties.transferFunction,
+            .known(swiftString(kCMFormatDescriptionTransferFunction_ITU_R_709_2))
+        )
+        XCTAssertEqual(result.metadata.colorProperties.isFullRangeVideo, .known(false))
+
+        let evaluation = StandardInputPolicyEvaluator().evaluate(
+            result.mediaFacts,
+            selection: StandardInputPolicySelection(maximumResolution: .default)
+        )
+        XCTAssertEqual(evaluation.status(for: .videoCodec), .compliant)
+        XCTAssertEqual(evaluation.status(for: .videoResolution), .compliant)
+        XCTAssertEqual(evaluation.status(for: .frameRate), .compliant)
+        XCTAssertEqual(evaluation.status(for: .averageBitrate), .compliant)
+        XCTAssertEqual(evaluation.status(for: .pixelFormat), .compliant)
+        XCTAssertEqual(evaluation.status(for: .dynamicRange), .compliant)
+        XCTAssertEqual(evaluation.status(for: .audio), .compliant)
+        XCTAssertEqual(evaluation.status(for: .gopStructure), .unknown)
+        XCTAssertEqual(evaluation.outcome, .unknown)
+        XCTAssertTrue(evaluation.nonCompliantRequirements.isEmpty)
+    }
+
+    func testReadsPortraitHEVCMain10HLGMetadataWithNormalizedRotation() throws {
+        var hevcConfiguration = Data(repeating: 0, count: 19)
+        hevcConfiguration[0] = 1
+        hevcConfiguration[16] = 1
+        hevcConfiguration[17] = 2
+        hevcConfiguration[18] = 2
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("hvc1"),
+            width: 3840,
+            height: 2160,
+            extensions: [
+                swiftString(kCMFormatDescriptionExtension_ColorPrimaries):
+                    kCMFormatDescriptionColorPrimaries_ITU_R_2020,
+                swiftString(kCMFormatDescriptionExtension_TransferFunction):
+                    kCMFormatDescriptionTransferFunction_ITU_R_2100_HLG,
+                swiftString(kCMFormatDescriptionExtension_YCbCrMatrix):
+                    kCMFormatDescriptionYCbCrMatrix_ITU_R_2020,
+                swiftString(
+                    kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+                ): ["hvcC": hevcConfiguration]
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: CGAffineTransform(
+                        a: 0,
+                        b: 1,
+                        c: -1,
+                        d: 0,
+                        tx: 2160,
+                        ty: 0
+                    ),
+                    nominalFrameRate: 59.94,
+                    estimatedDataRate: 19_500_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(result.mediaFacts.videoCodec, .known(.hevc))
+        XCTAssertEqual(
+            result.mediaFacts.displayDimensions,
+            .known(.init(width: 2160, height: 3840))
+        )
+        XCTAssertEqual(
+            result.mediaFacts.pixelFormat,
+            .known(.init(bitDepth: 10, chromaSubsampling: .yuv420))
+        )
+        XCTAssertEqual(result.mediaFacts.dynamicRange, .known(.hlg))
+        XCTAssertEqual(
+            result.metadata.encodedDimensions,
+            .known(.init(width: 3840, height: 2160))
+        )
+        XCTAssertEqual(
+            result.metadata.videoTransform,
+            .known(.init(rotation: .degrees270, isMirrored: false))
+        )
+    }
+
+    func testReadsPQTransferFunction() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("hev1"),
+            width: 1920,
+            height: 1080,
+            extensions: [
+                swiftString(kCMFormatDescriptionExtension_TransferFunction):
+                    kCMFormatDescriptionTransferFunction_SMPTE_ST_2084_PQ
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 8_000_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(result.mediaFacts.videoCodec, .known(.hevc))
+        XCTAssertEqual(result.mediaFacts.dynamicRange, .known(.pq))
+        XCTAssertEqual(result.mediaFacts.pixelFormat, .unknown)
+    }
+
+    func testUnavailableAndInvalidMetadataRemainUnknown() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("hvc1"),
+            width: 1920,
+            height: 1080
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: CGAffineTransform(
+                        a: 1,
+                        b: 0,
+                        c: 0.5,
+                        d: 1,
+                        tx: 0,
+                        ty: 0
+                    ),
+                    nominalFrameRate: 0,
+                    estimatedDataRate: .nan
+                )
+            ],
+            audioTracks: [
+                AVFoundationAudioTrackMetadata(formatDescriptions: [])
+            ]
+        )
+
+        XCTAssertEqual(result.mediaFacts.displayDimensions, .unknown)
+        XCTAssertEqual(result.mediaFacts.frameRate, .unknown)
+        XCTAssertEqual(result.mediaFacts.averageBitrate, .unknown)
+        XCTAssertEqual(result.mediaFacts.pixelFormat, .unknown)
+        XCTAssertEqual(result.mediaFacts.dynamicRange, .unknown)
+        XCTAssertEqual(result.mediaFacts.audio, .unknown)
+        XCTAssertEqual(result.metadata.videoTransform, .unknown)
+        XCTAssertEqual(result.metadata.colorProperties.primaries, .unknown)
+        XCTAssertEqual(result.metadata.colorProperties.transferFunction, .unknown)
+        XCTAssertEqual(result.metadata.colorProperties.yCbCrMatrix, .unknown)
+        XCTAssertEqual(result.metadata.colorProperties.isFullRangeVideo, .unknown)
+    }
+
+    func testReadsAACChannelLayoutAndTrackCounts() throws {
+        let audioFormatDescription = try makeAudioFormatDescription(
+            formatID: kAudioFormatMPEG4AAC,
+            channelCount: 2
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [],
+            audioTracks: [
+                AVFoundationAudioTrackMetadata(
+                    formatDescriptions: [audioFormatDescription]
+                )
+            ]
+        )
+
+        XCTAssertEqual(result.mediaFacts.audio, .known(.aac(.stereo)))
+        XCTAssertEqual(result.metadata.videoTrackCount, 0)
+        XCTAssertEqual(result.metadata.audioTrackCount, .known(1))
+        XCTAssertEqual(result.mediaFacts.videoCodec, .unknown)
+    }
+
+    func testReadsNonAACAudioCodec() throws {
+        let audioFormatDescription = try makeAudioFormatDescription(
+            formatID: kAudioFormatLinearPCM,
+            channelCount: 2
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [],
+            audioTracks: [
+                AVFoundationAudioTrackMetadata(
+                    formatDescriptions: [audioFormatDescription]
+                )
+            ]
+        )
+
+        XCTAssertEqual(result.mediaFacts.audio, .known(.otherCodec))
+    }
+
+    func testReadsNonLCAACProfilesAsUnsupported() throws {
+        let nonLCProfiles: [AudioFormatID] = [
+            kAudioFormatMPEG4AAC_HE,
+            kAudioFormatMPEG4AAC_HE_V2,
+            kAudioFormatMPEG4AAC_LD,
+            kAudioFormatMPEG4AAC_ELD
+        ]
+
+        for formatID in nonLCProfiles {
+            let formatDescription = try makeAudioFormatDescription(
+                formatID: formatID,
+                channelCount: 2
+            )
+            let result = AVFoundationUploadInputMetadataReader.inspect(
+                videoTracks: [],
+                audioTracks: [
+                    AVFoundationAudioTrackMetadata(
+                        formatDescriptions: [formatDescription]
+                    )
+                ]
+            )
+
+            XCTAssertEqual(
+                result.mediaFacts.audio,
+                .known(.otherCodec),
+                "Expected format ID \(formatID) to remain distinct from AAC-LC"
+            )
+        }
+    }
+
+    func testUnavailableAudioMetadataDoesNotBlockKnownVideoFacts() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("avc1"),
+            width: 1920,
+            height: 1080
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 7_500_000
+                )
+            ],
+            audioTracks: nil
+        )
+
+        XCTAssertEqual(result.mediaFacts.videoCodec, .known(.h264))
+        XCTAssertEqual(
+            result.mediaFacts.displayDimensions,
+            .known(.init(width: 1920, height: 1080))
+        )
+        XCTAssertEqual(result.mediaFacts.audio, .unknown)
+        XCTAssertEqual(result.metadata.audioTrackCount, .unknown)
+    }
+
+    func testMultipleTracksAreCountedAndAmbiguousAudioIsUnknown() {
+        let emptyVideo = AVFoundationVideoTrackMetadata(
+            formatDescriptions: [],
+            preferredTransform: .identity,
+            nominalFrameRate: 0,
+            estimatedDataRate: 0
+        )
+        let emptyAudio = AVFoundationAudioTrackMetadata(formatDescriptions: [])
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [emptyVideo, emptyVideo],
+            audioTracks: [emptyAudio, emptyAudio]
+        )
+
+        XCTAssertEqual(result.metadata.videoTrackCount, 2)
+        XCTAssertEqual(result.metadata.audioTrackCount, .known(2))
+        XCTAssertEqual(result.mediaFacts.videoCodec, .unknown)
+        XCTAssertEqual(result.mediaFacts.audio, .unknown)
+    }
+
+    func testReadsKnownUnsupportedHEVCPixelFormat() throws {
+        var hevcConfiguration = Data(repeating: 0, count: 19)
+        hevcConfiguration[0] = 1
+        hevcConfiguration[16] = 2
+        hevcConfiguration[17] = 4
+        hevcConfiguration[18] = 4
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("hvc1"),
+            width: 1920,
+            height: 1080,
+            extensions: [
+                swiftString(
+                    kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+                ): ["hvcC": hevcConfiguration]
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 8_000_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(
+            result.mediaFacts.pixelFormat,
+            .known(.init(bitDepth: 12, chromaSubsampling: .other))
+        )
+    }
+
+    func testReadsKnownUnsupportedAVCPixelFormat() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("avc1"),
+            width: 1920,
+            height: 1080,
+            extensions: [
+                swiftString(
+                    kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+                ): [
+                    "avcC": Data([
+                        1, 100, 0, 40, 0xff, 0xe0, 0,
+                        0xfe, 0xfa, 0xfa
+                    ])
+                ]
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 8_000_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(
+            result.mediaFacts.pixelFormat,
+            .known(.init(bitDepth: 10, chromaSubsampling: .other))
+        )
+    }
+
+    func testDoesNotReadExtendedAVCFieldsForSVCProfile() throws {
+        let formatDescription = try makeVideoFormatDescription(
+            codecType: fourCharacterCode("avc1"),
+            width: 1920,
+            height: 1080,
+            extensions: [
+                swiftString(
+                    kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+                ): [
+                    "avcC": Data([
+                        1, 83, 0, 40, 0xff, 0xe0, 0,
+                        0xfd, 0xfa, 0xfa
+                    ])
+                ]
+            ]
+        )
+
+        let result = AVFoundationUploadInputMetadataReader.inspect(
+            videoTracks: [
+                AVFoundationVideoTrackMetadata(
+                    formatDescriptions: [formatDescription],
+                    preferredTransform: .identity,
+                    nominalFrameRate: 30,
+                    estimatedDataRate: 8_000_000
+                )
+            ],
+            audioTracks: []
+        )
+
+        XCTAssertEqual(result.mediaFacts.pixelFormat, .unknown)
+    }
+
+    func testInspectorReturnsTrackCountsWithMultiVideoFallback() {
+        let asset = AVMutableComposition()
+        XCTAssertNotNil(
+            asset.addMutableTrack(
+                withMediaType: .video,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            )
+        )
+        XCTAssertNotNil(
+            asset.addMutableTrack(
+                withMediaType: .video,
+                preferredTrackID: kCMPersistentTrackID_Invalid
+            )
+        )
+        let completion = expectation(description: "inspection completes")
+
+        AVFoundationUploadInputInspector().performInspection(
+            sourceInput: asset,
+            maximumResolution: .default
+        ) { result, duration, error in
+            XCTAssertEqual(result?.metadata.videoTrackCount, 2)
+            XCTAssertEqual(result?.metadata.audioTrackCount, .known(0))
+            XCTAssertEqual(duration, .zero)
+            XCTAssertNotNil(error)
+            completion.fulfill()
+        }
+
+        wait(for: [completion], timeout: 2)
+    }
+
+    private func makeVideoFormatDescription(
+        codecType: CMVideoCodecType,
+        width: Int32,
+        height: Int32,
+        extensions: [String: Any] = [:]
+    ) throws -> CMVideoFormatDescription {
+        var formatDescription: CMVideoFormatDescription?
+        let status = CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: codecType,
+            width: width,
+            height: height,
+            extensions: extensions as CFDictionary,
+            formatDescriptionOut: &formatDescription
+        )
+        XCTAssertEqual(status, noErr)
+        return try XCTUnwrap(formatDescription)
+    }
+
+    private func makeAudioFormatDescription(
+        formatID: AudioFormatID,
+        channelCount: UInt32
+    ) throws -> CMAudioFormatDescription {
+        var streamDescription = AudioStreamBasicDescription(
+            mSampleRate: 48_000,
+            mFormatID: formatID,
+            mFormatFlags: 0,
+            mBytesPerPacket: 0,
+            mFramesPerPacket: 1024,
+            mBytesPerFrame: 0,
+            mChannelsPerFrame: channelCount,
+            mBitsPerChannel: 0,
+            mReserved: 0
+        )
+        var formatDescription: CMAudioFormatDescription?
+        let status = CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            asbd: &streamDescription,
+            layoutSize: 0,
+            layout: nil,
+            magicCookieSize: 0,
+            magicCookie: nil,
+            extensions: nil,
+            formatDescriptionOut: &formatDescription
+        )
+        XCTAssertEqual(status, noErr)
+        return try XCTUnwrap(formatDescription)
+    }
+
+    private func swiftString(_ value: CFString) -> String {
+        value as String
+    }
+
+    private func fourCharacterCode(_ value: String) -> FourCharCode {
+        value.utf8.reduce(0) { partialResult, byte in
+            partialResult << 8 | FourCharCode(byte)
+        }
+    }
+}

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
@@ -440,6 +440,28 @@ final class UploadInputMetadataInspectionTests: XCTestCase {
         XCTAssertEqual(result.mediaFacts.pixelFormat, .unknown)
     }
 
+    func testVideoInspectionFailurePreservesKnownAudioFacts() throws {
+        let audioFormatDescription = try makeAudioFormatDescription(
+            formatID: kAudioFormatMPEG4AAC,
+            channelCount: 2
+        )
+
+        let result = AVFoundationUploadInputInspector()
+            .makeVideoInspectionFailureResult(
+                videoTrackCount: 1,
+                audioMetadata: [
+                    AVFoundationAudioTrackMetadata(
+                        formatDescriptions: [audioFormatDescription]
+                    )
+                ]
+            )
+
+        XCTAssertEqual(result.mediaFacts.audio, .known(.aac(.stereo)))
+        XCTAssertEqual(result.metadata.videoTrackCount, 1)
+        XCTAssertEqual(result.metadata.audioTrackCount, .known(1))
+        XCTAssertEqual(result.mediaFacts.videoCodec, .unknown)
+    }
+
     func testInspectorReturnsTrackCountsWithMultiVideoFallback() {
         let asset = AVMutableComposition()
         XCTAssertNotNil(


### PR DESCRIPTION
## Summary

- Add AVFoundation metadata-level inspection that populates the Standard Input fact model.
- Inspect video/audio track counts, codec, orientation-aware display dimensions, frame rate, average bitrate, pixel format, dynamic range, color properties, AAC-LC, and channel layout.
- Preserve the existing legacy `nonStandardInputReasons` classification while exposing the additive typed facts for later planning work.
- Treat unavailable or ambiguous metadata conservatively as `.unknown`, including audio enumeration failures and unsupported `avcC` layouts.
- Raise the package and podspec minimum to iOS/iPadOS 15 and remove the obsolete iOS 14 inspection/duration branches.

## Why the iOS 15 bump is included

This scope rewrites the inspection path around AVFoundation's iOS 15 track-loading API. Setting the new baseline here removes the compatibility fork from the exact code this ticket changes and aligns the next SDK release with the Xcode 26/Buildkite toolchain requirement.

## Scope

This remains metadata-only inspection integrated with the fact model. It does not inspect compressed samples or GOPs and does not add planning, conversion, or DirectUpload orchestration.

GOP bitrate/size, keyframe interval, GOP structure, and edit-list facts intentionally remain `.unknown` for later tickets.

[NAT-484](https://mux1.atlassian.net/browse/NAT-484)

[NAT-484]: https://mux1.atlassian.net/browse/NAT-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the pre-upload inspection pipeline and is a semver-breaking floor for iOS 14 apps; behavior is largely additive but mis-read metadata could affect future standard-input decisions.
> 
> **Overview**
> Adds **AVFoundation metadata inspection** that fills `StandardInputMediaFacts` and `UploadInputMetadataInspection` on `UploadInputFormatInspectionResult`, covering codecs, orientation-aware display size, frame rate, bitrate, pixel format (via `avcC`/`hvcC`), HDR/SDR, color tags, and AAC-LC channel layout. **Legacy `nonStandardInputReasons`** behavior is unchanged and is still computed separately via `legacyNonStandardReasons`.
> 
> **`UploadInputInspector`** now loads **audio** tracks (sequential `formatDescriptions`), routes single-/multi-video cases through `AVFoundationUploadInputMetadataReader`, and on video inspection failure still returns partial results (e.g. known audio facts and track counts) instead of only `nil`.
> 
> **Minimum deployment target** is raised to **iOS/iPadOS 15** in the podspec, SPM, and README; **iOS 14** `loadTracks` / async duration forks are removed (e.g. `ChunkedFileUploader` always uses `asset.load(.duration)`).
> 
> GOP/edit-list facts stay `.unknown`; scope is metadata-only with no upload planning or transcoding changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f7eda3c7dc6346e0616f610abb6e1ffdc94f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->