### PR TITLE
NAT-497: Build the sample app in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,10 @@ agents:
 steps:
   - command: "./scripts/run-unit-tests.sh MuxUploadSDK"
     label: ":xcode_simulator: Unit Tests"
+  # Compiles the sample app against the working tree. Independent of the unit
+  # tests, so it runs alongside them rather than after.
+  - command: "./scripts/build-example-app.sh SwiftUploadSDKExample"
+    label: ":iphone: Sample App Build"
   - wait
   - command: "./scripts/version-check.sh"
     label: ":clipboard: Version Check"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,6 @@ agents:
 steps:
   - command: "./scripts/run-unit-tests.sh MuxUploadSDK"
     label: ":xcode_simulator: Unit Tests"
-  # Compiles the sample app against the working tree. Independent of the unit
-  # tests, so it runs alongside them rather than after.
   - command: "./scripts/build-example-app.sh SwiftUploadSDKExample"
     label: ":iphone: Sample App Build"
   - wait

--- a/scripts/build-example-app.sh
+++ b/scripts/build-example-app.sh
@@ -19,7 +19,6 @@ fi
 
 echo "▸ Using Xcode Version: ${XCODE}"
 
-# MuxUploadSDK is consumed as a local package, so this builds against the working tree.
 cd Example/SwiftUploadSDKExample
 
 echo "▸ Resolve Package Dependencies"

--- a/scripts/build-example-app.sh
+++ b/scripts/build-example-app.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+readonly XCODE=$(xcodebuild -version | grep Xcode | cut -d " " -f2)
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "▸ Usage: $0 SCHEME"
+    exit 1
+fi
+
+readonly SCHEME="$1"
+
+if ! command -v xcbeautify &> /dev/null
+then
+    echo -e "\033[1;31m ERROR: xcbeautify could not be found please install it... \033[0m"
+    exit 1
+fi
+
+echo "▸ Using Xcode Version: ${XCODE}"
+
+# The example app consumes MuxUploadSDK as a local package rooted at the
+# repository, so this compiles the sample app against the working tree and
+# catches public API changes that break SDK consumers.
+cd Example/SwiftUploadSDKExample
+
+echo "▸ Resolve Package Dependencies"
+
+xcodebuild -resolvePackageDependencies
+
+echo "▸ Available Schemes"
+
+xcodebuild -list -json
+
+echo "▸ Build ${SCHEME}"
+
+# A generic destination keeps this off any particular simulator runtime, so the
+# step survives Xcode upgrades on the agent and does not boot a device.
+xcodebuild clean build \
+	-scheme $SCHEME \
+	-destination 'generic/platform=iOS Simulator' \
+	CODE_SIGNING_ALLOWED=NO \
+  | xcbeautify

--- a/scripts/build-example-app.sh
+++ b/scripts/build-example-app.sh
@@ -19,9 +19,7 @@ fi
 
 echo "▸ Using Xcode Version: ${XCODE}"
 
-# The example app consumes MuxUploadSDK as a local package rooted at the
-# repository, so this compiles the sample app against the working tree and
-# catches public API changes that break SDK consumers.
+# MuxUploadSDK is consumed as a local package, so this builds against the working tree.
 cd Example/SwiftUploadSDKExample
 
 echo "▸ Resolve Package Dependencies"
@@ -34,8 +32,6 @@ xcodebuild -list -json
 
 echo "▸ Build ${SCHEME}"
 
-# A generic destination keeps this off any particular simulator runtime, so the
-# step survives Xcode upgrades on the agent and does not boot a device.
 xcodebuild clean build \
 	-scheme $SCHEME \
 	-destination 'generic/platform=iOS Simulator' \


### PR DESCRIPTION
Jira: [NAT-497](https://mux1.atlassian.net/browse/NAT-497)

Adds a Buildkite step that compiles the sample app in `Example/SwiftUploadSDKExample`. It consumes `MuxUploadSDK` as a local package rooted at the repository, so this catches public API changes that break SDK consumers. Nothing in the pipeline built it before.

- `scripts/build-example-app.sh`, following the existing `run-unit-tests.sh`
- a `:iphone: Sample App Build` step, running alongside the unit tests since the two are independent

Build-only, so it uses a generic simulator destination and skips code signing.

Verified both directions: the build succeeds on this branch in ~49s, and renaming a public initializer label fails it with the error located in the sample app.

[NAT-497]: https://mux1.atlassian.net/browse/NAT-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ