### PR TITLE
NAT-485: Inspect GOP and keyframe characteristics

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -8,12 +8,99 @@ import Foundation
 
 typealias UploadInputInspectionCompletionHandler = (UploadInputFormatInspectionResult?, CMTime, Error?) -> ()
 
+final class UploadInputInspectionOperation {
+    private enum State {
+        case active
+        case cancelled
+        case completed
+    }
+
+    private let lock = NSLock()
+    private let completionHandler: UploadInputInspectionCompletionHandler
+    private var state: State = .active
+    private var assetReader: AVAssetReader?
+
+    init(completionHandler: @escaping UploadInputInspectionCompletionHandler) {
+        self.completionHandler = completionHandler
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return state == .cancelled
+    }
+
+    func register(assetReader: AVAssetReader) -> Bool {
+        lock.lock()
+        let isActive = state == .active
+        if isActive {
+            self.assetReader = assetReader
+        }
+        lock.unlock()
+
+        if !isActive {
+            assetReader.cancelReading()
+        }
+        return isActive
+    }
+
+    func cancel() {
+        lock.lock()
+        guard state == .active else {
+            lock.unlock()
+            return
+        }
+        state = .cancelled
+        let assetReader = self.assetReader
+        self.assetReader = nil
+        lock.unlock()
+
+        assetReader?.cancelReading()
+    }
+
+    func complete(
+        _ result: UploadInputFormatInspectionResult?,
+        duration: CMTime,
+        error: Error?
+    ) {
+        lock.lock()
+        guard state == .active else {
+            lock.unlock()
+            return
+        }
+        state = .completed
+        assetReader = nil
+        lock.unlock()
+
+        completionHandler(result, duration, error)
+    }
+}
+
 protocol UploadInputInspector {
     func performInspection(
         sourceInput: AVAsset,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        completionHandler: @escaping UploadInputInspectionCompletionHandler
+        operation: UploadInputInspectionOperation
     )
+}
+
+extension UploadInputInspector {
+    @discardableResult
+    func performInspection(
+        sourceInput: AVAsset,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
+        completionHandler: @escaping UploadInputInspectionCompletionHandler
+    ) -> UploadInputInspectionOperation {
+        let operation = UploadInputInspectionOperation(
+            completionHandler: completionHandler
+        )
+        performInspection(
+            sourceInput: sourceInput,
+            maximumResolution: maximumResolution,
+            operation: operation
+        )
+        return operation
+    }
 }
 
 struct UploadInputInspectionError: Error {
@@ -34,16 +121,17 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
     func performInspection(
         sourceInput: AVAsset,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        completionHandler: @escaping UploadInputInspectionCompletionHandler
+        operation: UploadInputInspectionOperation
     ) {
         sourceInput.loadTracks(
             withMediaType: .video
         ) { videoTracks, videoError in
+            guard !operation.isCancelled else { return }
             guard videoError == nil, let videoTracks else {
-                completionHandler(
+                operation.complete(
                     nil,
-                    CMTime.zero,
-                    UploadInputInspectionError.inspectionFailure
+                    duration: CMTime.zero,
+                    error: UploadInputInspectionError.inspectionFailure
                 )
                 return
             }
@@ -51,12 +139,13 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
             sourceInput.loadTracks(
                 withMediaType: .audio
             ) { audioTracks, audioError in
+                guard !operation.isCancelled else { return }
                 self.inspect(
                     sourceInput: sourceInput,
                     videoTracks: videoTracks,
                     audioTracks: audioError == nil ? audioTracks : nil,
                     maximumResolution: maximumResolution,
-                    completionHandler: completionHandler
+                    operation: operation
                 )
             }
         }
@@ -67,22 +156,23 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
         videoTracks: [AVAssetTrack],
         audioTracks: [AVAssetTrack]?,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        completionHandler: @escaping UploadInputInspectionCompletionHandler
+        operation: UploadInputInspectionOperation
     ) {
-        loadAudioMetadata(audioTracks) { audioMetadata in
+        loadAudioMetadata(audioTracks, operation: operation) { audioMetadata in
+            guard !operation.isCancelled else { return }
             switch videoTracks.count {
             case 0:
                 let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
                     videoTracks: [],
                     audioTracks: audioMetadata
                 )
-                completionHandler(
+                operation.complete(
                     UploadInputFormatInspectionResult(
                         mediaFacts: metadataResult.mediaFacts,
                         metadata: metadataResult.metadata
                     ),
-                    CMTime.zero,
-                    nil
+                    duration: CMTime.zero,
+                    error: nil
                 )
             case 1:
                 self.inspectSingleVideoTrack(
@@ -90,16 +180,16 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     videoTrack: videoTracks[0],
                     audioMetadata: audioMetadata,
                     maximumResolution: maximumResolution,
-                    completionHandler: completionHandler
+                    operation: operation
                 )
             default:
-                completionHandler(
+                operation.complete(
                     self.makeVideoInspectionFailureResult(
                         videoTrackCount: videoTracks.count,
                         audioMetadata: audioMetadata
                     ),
-                    CMTime.zero,
-                    UploadInputInspectionError.inspectionFailure
+                    duration: CMTime.zero,
+                    error: UploadInputInspectionError.inspectionFailure
                 )
             }
         }
@@ -110,9 +200,10 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
         videoTrack: AVAssetTrack,
         audioMetadata: [AVFoundationAudioTrackMetadata]?,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        completionHandler: @escaping UploadInputInspectionCompletionHandler
+        operation: UploadInputInspectionOperation
     ) {
         sourceInput.loadValuesAsynchronously(forKeys: ["duration"]) {
+            guard !operation.isCancelled else { return }
             let sourceInputDuration = sourceInput.duration
             videoTrack.loadValuesAsynchronously(
                 forKeys: [
@@ -122,16 +213,17 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     "estimatedDataRate"
                 ]
             ) {
+                guard !operation.isCancelled else { return }
                 guard let formatDescriptions = videoTrack.formatDescriptions
                     as? [CMFormatDescription],
                       let formatDescription = formatDescriptions.first else {
-                    completionHandler(
+                    operation.complete(
                         self.makeVideoInspectionFailureResult(
                             videoTrackCount: 1,
                             audioMetadata: audioMetadata
                         ),
-                        sourceInputDuration,
-                        UploadInputInspectionError.inspectionFailure
+                        duration: sourceInputDuration,
+                        error: UploadInputInspectionError.inspectionFailure
                     )
                     return
                 }
@@ -147,6 +239,16 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     ],
                     audioTracks: audioMetadata
                 )
+                var mediaFacts = metadataResult.mediaFacts
+                let sampleFacts = AVFoundationUploadInputSampleReader.inspect(
+                    asset: sourceInput,
+                    videoTrack: videoTrack,
+                    codec: mediaFacts.videoCodec,
+                    operation: operation
+                )
+                guard !operation.isCancelled else { return }
+                mediaFacts.mergeGOPFacts(from: sampleFacts)
+
                 let videoDimensions = CMVideoFormatDescriptionGetDimensions(
                     formatDescription
                 )
@@ -157,18 +259,18 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     estimatedBitrate: videoTrack.estimatedDataRate
                 )
 
-                completionHandler(
+                operation.complete(
                     UploadInputFormatInspectionResult(
                         nonStandardInputReasons: nonStandardReasons,
-                        mediaFacts: metadataResult.mediaFacts,
+                        mediaFacts: mediaFacts,
                         metadata: metadataResult.metadata,
                         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails(
                             maximumDesiredResolutionPreset: maximumResolution,
                             recordedResolution: videoDimensions
                         )
                     ),
-                    sourceInputDuration,
-                    nil
+                    duration: sourceInputDuration,
+                    error: nil
                 )
             }
         }
@@ -192,6 +294,7 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
 
     private func loadAudioMetadata(
         _ tracks: [AVAssetTrack]?,
+        operation: UploadInputInspectionOperation,
         index: Int = 0,
         accumulated: [AVFoundationAudioTrackMetadata] = [],
         completionHandler: @escaping ([AVFoundationAudioTrackMetadata]?) -> Void
@@ -208,10 +311,12 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
 
         let track = tracks[index]
         track.loadValuesAsynchronously(forKeys: ["formatDescriptions"]) {
+            guard !operation.isCancelled else { return }
             let formatDescriptions = track.formatDescriptions as? [CMFormatDescription]
                 ?? []
             self.loadAudioMetadata(
                 tracks,
+                operation: operation,
                 index: index + 1,
                 accumulated: accumulated + [
                     AVFoundationAudioTrackMetadata(

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -76,6 +76,62 @@ final class UploadInputInspectionOperation {
     }
 }
 
+final class UploadInputInspectionOperationRegistry: @unchecked Sendable {
+    struct Token: Equatable, Sendable {
+        private let id: UUID
+
+        init() {
+            self.id = UUID()
+        }
+    }
+
+    private struct Registration {
+        let token: Token
+        let operation: UploadInputInspectionOperation
+    }
+
+    private let lock = NSLock()
+    private var registration: Registration?
+
+    func register(
+        _ operation: UploadInputInspectionOperation,
+        for token: Token
+    ) {
+        lock.lock()
+        let previousOperation = registration?.operation
+        registration = Registration(
+            token: token,
+            operation: operation
+        )
+        lock.unlock()
+
+        previousOperation?.cancel()
+    }
+
+    @discardableResult
+    func claimCompletion(for token: Token) -> Bool {
+        lock.lock()
+        guard registration?.token == token else {
+            lock.unlock()
+            return false
+        }
+        registration = nil
+        lock.unlock()
+        return true
+    }
+
+    @discardableResult
+    func cancelActive() -> Bool {
+        lock.lock()
+        let operation = registration?.operation
+        registration = nil
+        lock.unlock()
+
+        operation?.cancel()
+        return operation != nil
+    }
+}
+
 protocol UploadInputInspector {
     func performInspection(
         sourceInput: AVAsset,

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputSampleInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputSampleInspection.swift
@@ -1,0 +1,439 @@
+//
+//  UploadInputSampleInspection.swift
+//
+
+import AVFoundation
+import CoreMedia
+import Foundation
+
+struct UploadInputCompressedSampleObservation: Equatable {
+    enum SyncState: Equatable {
+        case sync
+        case notSync
+        case unknown
+    }
+
+    enum RandomAccessKind: Equatable {
+        case idr
+        case openGOP
+        case unknown
+    }
+
+    let presentationTime: TimeInterval
+    let duration: TimeInterval
+    let byteCount: Int64
+    let syncState: SyncState
+    let randomAccessKind: RandomAccessKind
+    let dependsOnOthers: Bool?
+}
+
+enum UploadInputCompressedSampleAggregator {
+    static func inspect(
+        _ samples: [UploadInputCompressedSampleObservation]
+    ) -> StandardInputMediaFacts {
+        var accumulator = Accumulator()
+        for sample in samples {
+            accumulator.append(sample)
+        }
+        return accumulator.finish()
+    }
+
+    struct Accumulator {
+        private var isUsable = true
+        private var hasSamples = false
+        private var currentStart: TimeInterval = 0
+        private var currentEnd: TimeInterval = 0
+        private var currentBytes: Int64 = 0
+        private var maximumBytes: Int64 = 0
+        private var maximumDuration: TimeInterval = 0
+        private var maximumBitrate: Double = 0
+        private var hasUnknownRandomAccessKind = false
+        private var hasOpenRandomAccessPoint = false
+
+        mutating func append(_ sample: UploadInputCompressedSampleObservation) {
+            guard isUsable,
+                  UploadInputCompressedSampleAggregator.isValid(sample),
+                  hasSamples || sample.syncState == .sync else {
+                isUsable = false
+                return
+            }
+
+            if sample.syncState == .sync {
+                // Compressed samples arrive in decode order. A full sync sample closes
+                // the preceding byte window, while presentation times define its duration.
+                if currentBytes > 0,
+                   !UploadInputCompressedSampleAggregator.finalizeGOP(
+                    byteCount: currentBytes,
+                    duration: sample.presentationTime - currentStart,
+                    maximumBytes: &maximumBytes,
+                    maximumDuration: &maximumDuration,
+                    maximumBitrate: &maximumBitrate
+                   ) {
+                    isUsable = false
+                    return
+                }
+                currentStart = sample.presentationTime
+                currentEnd = sample.presentationTime + sample.duration
+                currentBytes = 0
+                switch sample.dependsOnOthers == true ? .unknown : sample.randomAccessKind {
+                case .idr:
+                    break
+                case .openGOP:
+                    hasOpenRandomAccessPoint = true
+                case .unknown:
+                    hasUnknownRandomAccessKind = true
+                }
+            } else if sample.syncState == .unknown {
+                isUsable = false
+                return
+            }
+
+            let (nextBytes, overflow) = currentBytes.addingReportingOverflow(
+                sample.byteCount
+            )
+            guard !overflow else {
+                isUsable = false
+                return
+            }
+            currentBytes = nextBytes
+            currentEnd = max(currentEnd, sample.presentationTime + sample.duration)
+            hasSamples = true
+        }
+
+        mutating func finish() -> StandardInputMediaFacts {
+            var facts = StandardInputMediaFacts()
+            guard isUsable,
+                  hasSamples,
+                  UploadInputCompressedSampleAggregator.finalizeGOP(
+                    byteCount: currentBytes,
+                    duration: currentEnd - currentStart,
+                    maximumBytes: &maximumBytes,
+                    maximumDuration: &maximumDuration,
+                    maximumBitrate: &maximumBitrate
+                  ),
+                  maximumBitrate <= Double(Int64.max) else {
+                return facts
+            }
+
+            facts.maximumKeyframeInterval = .known(maximumDuration)
+            // Open GOPs can contain leading pictures that follow a random-access
+            // sample in decode order while preceding it in presentation order.
+            // Their bytes cannot be assigned reliably to either adjacent GOP.
+            if !hasOpenRandomAccessPoint {
+                facts.maximumGOPByteSize = .known(maximumBytes)
+                facts.maximumGOPBitrate = .known(Int64(maximumBitrate.rounded()))
+            }
+            if !hasUnknownRandomAccessKind {
+                facts.gopStructure = hasOpenRandomAccessPoint
+                    ? .known(.open) : .known(.closedWithIDR)
+            }
+            return facts
+        }
+    }
+
+    private static func isValid(
+        _ sample: UploadInputCompressedSampleObservation
+    ) -> Bool {
+        // Edit-list preroll may have negative presentation timestamps. The
+        // interval remains measurable when a preceding sync boundary is present.
+        sample.presentationTime.isFinite
+            && sample.duration.isFinite
+            && sample.duration > 0
+            && sample.byteCount > 0
+    }
+
+    private static func finalizeGOP(
+        byteCount: Int64,
+        duration: TimeInterval,
+        maximumBytes: inout Int64,
+        maximumDuration: inout TimeInterval,
+        maximumBitrate: inout Double
+    ) -> Bool {
+        guard byteCount > 0, duration.isFinite, duration > 0 else {
+            return false
+        }
+
+        maximumBytes = max(maximumBytes, byteCount)
+        maximumDuration = max(maximumDuration, duration)
+        maximumBitrate = max(
+            maximumBitrate,
+            Double(byteCount) * 8 / duration
+        )
+        return maximumBitrate.isFinite
+    }
+
+}
+
+enum AVFoundationUploadInputSampleReader {
+    static func inspect(
+        asset: AVAsset,
+        videoTrack: AVAssetTrack,
+        codec: StandardInputFact<StandardInputVideoCodec>,
+        operation: UploadInputInspectionOperation? = nil
+    ) -> StandardInputMediaFacts {
+        guard operation?.isCancelled != true else { return StandardInputMediaFacts() }
+        guard let codec = codec.value,
+              codec == .h264 || codec == .hevc else {
+            return StandardInputMediaFacts()
+        }
+        guard let reader = try? AVAssetReader(asset: asset) else {
+            return StandardInputMediaFacts()
+        }
+
+        let output = AVAssetReaderTrackOutput(track: videoTrack, outputSettings: nil)
+        // Nil output settings preserve the stored compressed representation and avoid
+        // decoding. NAL data is copied only for the relatively infrequent sync samples.
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else {
+            return StandardInputMediaFacts()
+        }
+        reader.add(output)
+        guard reader.startReading() else {
+            return StandardInputMediaFacts()
+        }
+        guard operation?.register(assetReader: reader) ?? true else {
+            return StandardInputMediaFacts()
+        }
+
+        var accumulator = UploadInputCompressedSampleAggregator.Accumulator()
+        while operation?.isCancelled != true,
+              let sampleBuffer = output.copyNextSampleBuffer() {
+            // Readers may vend zero-sample marker buffers before media samples.
+            if CMSampleBufferGetNumSamples(sampleBuffer) == 0 {
+                continue
+            }
+            autoreleasepool {
+                if let observation = makeObservation(
+                    sampleBuffer,
+                    codec: codec
+                ) {
+                    accumulator.append(observation)
+                } else {
+                    reader.cancelReading()
+                }
+            }
+            if reader.status == .cancelled {
+                return StandardInputMediaFacts()
+            }
+        }
+
+        guard operation?.isCancelled != true else {
+            reader.cancelReading()
+            return StandardInputMediaFacts()
+        }
+        guard reader.status == .completed else {
+            return StandardInputMediaFacts()
+        }
+        return accumulator.finish()
+    }
+
+    private static func makeObservation(
+        _ sampleBuffer: CMSampleBuffer,
+        codec: StandardInputVideoCodec
+    ) -> UploadInputCompressedSampleObservation? {
+        guard CMSampleBufferGetNumSamples(sampleBuffer) == 1,
+              let attachments = CMSampleBufferGetSampleAttachmentsArray(
+                sampleBuffer,
+                createIfNecessary: false
+              ),
+              let attachment = (attachments as NSArray).firstObject
+                as? NSDictionary else {
+            return nil
+        }
+
+        let presentationTime = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let duration = CMSampleBufferGetDuration(sampleBuffer)
+        let isNotSync = boolean(
+            attachment[kCMSampleAttachmentKey_NotSync]
+        ) ?? false
+        let isPartialSync = boolean(
+            attachment[kCMSampleAttachmentKey_PartialSync]
+        ) ?? false
+        let syncState: UploadInputCompressedSampleObservation.SyncState =
+            isNotSync || isPartialSync ? .notSync : .sync
+
+        let randomAccessKind: UploadInputCompressedSampleObservation.RandomAccessKind
+        if syncState == .sync {
+            randomAccessKind = inspectRandomAccessKind(
+                sampleBuffer,
+                codec: codec,
+                attachment: attachment
+            )
+        } else {
+            randomAccessKind = .unknown
+        }
+
+        return UploadInputCompressedSampleObservation(
+            presentationTime: CMTimeGetSeconds(presentationTime),
+            duration: CMTimeGetSeconds(duration),
+            byteCount: Int64(CMSampleBufferGetTotalSampleSize(sampleBuffer)),
+            syncState: syncState,
+            randomAccessKind: randomAccessKind,
+            dependsOnOthers: boolean(
+                attachment[kCMSampleAttachmentKey_DependsOnOthers]
+            )
+        )
+    }
+
+    private static func inspectRandomAccessKind(
+        _ sampleBuffer: CMSampleBuffer,
+        codec: StandardInputVideoCodec,
+        attachment: NSDictionary
+    ) -> UploadInputCompressedSampleObservation.RandomAccessKind {
+        let attachmentKind: UploadInputCompressedSampleObservation.RandomAccessKind?
+        if codec == .hevc,
+           let nalUnitType = (attachment[
+            kCMSampleAttachmentKey_HEVCSyncSampleNALUnitType
+           ] as? NSNumber)?.intValue {
+            attachmentKind = randomAccessKind(codec: codec, nalUnitTypes: [nalUnitType])
+        } else {
+            attachmentKind = nil
+        }
+
+        guard let data = compressedData(sampleBuffer),
+              let formatDescription = CMSampleBufferGetFormatDescription(sampleBuffer),
+              let lengthFieldSize = nalUnitLengthFieldSize(formatDescription, codec: codec),
+              let nalUnitTypes = nalUnitTypes(
+                in: data,
+                lengthFieldSize: lengthFieldSize,
+                codec: codec
+              ) else {
+            return attachmentKind ?? .unknown
+        }
+
+        let parsedKind = randomAccessKind(codec: codec, nalUnitTypes: nalUnitTypes)
+        guard let attachmentKind else {
+            return parsedKind
+        }
+        return attachmentKind == parsedKind ? parsedKind : .unknown
+    }
+
+    static func nalUnitTypes(
+        in data: Data,
+        lengthFieldSize: Int,
+        codec: StandardInputVideoCodec
+    ) -> [Int]? {
+        guard (1...4).contains(lengthFieldSize) else {
+            return nil
+        }
+
+        var offset = 0
+        var types: [Int] = []
+        while offset < data.count {
+            guard data.count - offset >= lengthFieldSize else {
+                return nil
+            }
+            var nalUnitLength = 0
+            for index in 0..<lengthFieldSize {
+                nalUnitLength = (nalUnitLength << 8) | Int(data[offset + index])
+            }
+            offset += lengthFieldSize
+            guard nalUnitLength > 0,
+                  nalUnitLength <= data.count - offset else {
+                return nil
+            }
+
+            let firstByte = data[offset]
+            switch codec {
+            case .h264:
+                types.append(Int(firstByte & 0x1f))
+            case .hevc:
+                guard nalUnitLength >= 2 else {
+                    return nil
+                }
+                types.append(Int((firstByte >> 1) & 0x3f))
+            case .other:
+                return nil
+            }
+            offset += nalUnitLength
+        }
+        return types
+    }
+
+    static func randomAccessKind(
+        codec: StandardInputVideoCodec,
+        nalUnitTypes: [Int]
+    ) -> UploadInputCompressedSampleObservation.RandomAccessKind {
+        switch codec {
+        case .h264:
+            let vclTypes = nalUnitTypes.filter { (1...5).contains($0) }
+            guard !vclTypes.isEmpty else {
+                return .unknown
+            }
+            return vclTypes.contains(5) ? .idr : .openGOP
+        case .hevc:
+            let vclTypes = nalUnitTypes.filter { (0...31).contains($0) }
+            guard !vclTypes.isEmpty else {
+                return .unknown
+            }
+            if vclTypes.contains(where: { (19...20).contains($0) }) {
+                return vclTypes.contains(where: { (16...18).contains($0) || $0 == 21 })
+                    ? .unknown : .idr
+            }
+            return vclTypes.contains(where: { (16...18).contains($0) || $0 == 21 })
+                ? .openGOP : .unknown
+        case .other:
+            return .unknown
+        }
+    }
+
+    private static func nalUnitLengthFieldSize(
+        _ formatDescription: CMFormatDescription,
+        codec: StandardInputVideoCodec
+    ) -> Int? {
+        let extensions = CMFormatDescriptionGetExtensions(formatDescription)
+            as NSDictionary?
+        let atoms = extensions?[
+            kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms
+        ] as? NSDictionary
+        let atomName = codec == .h264 ? "avcC" : "hvcC"
+        guard let configuration = atoms?[atomName] as? Data else {
+            return nil
+        }
+
+        switch codec {
+        case .h264 where configuration.count > 4:
+            return Int(configuration[4] & 0x03) + 1
+        case .hevc where configuration.count > 21:
+            return Int(configuration[21] & 0x03) + 1
+        default:
+            return nil
+        }
+    }
+
+    private static func compressedData(_ sampleBuffer: CMSampleBuffer) -> Data? {
+        guard let blockBuffer = CMSampleBufferGetDataBuffer(sampleBuffer) else {
+            return nil
+        }
+        let length = CMBlockBufferGetDataLength(blockBuffer)
+        guard length > 0 else {
+            return nil
+        }
+        var data = Data(count: length)
+        let status = data.withUnsafeMutableBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                return kCMBlockBufferBadPointerParameterErr
+            }
+            return CMBlockBufferCopyDataBytes(
+                blockBuffer,
+                atOffset: 0,
+                dataLength: length,
+                destination: baseAddress
+            )
+        }
+        return status == kCMBlockBufferNoErr ? data : nil
+    }
+
+    private static func boolean(_ value: Any?) -> Bool? {
+        (value as? NSNumber)?.boolValue
+    }
+}
+
+extension StandardInputMediaFacts {
+    mutating func mergeGOPFacts(from other: StandardInputMediaFacts) {
+        maximumGOPBitrate = other.maximumGOPBitrate
+        maximumGOPByteSize = other.maximumGOPByteSize
+        maximumKeyframeInterval = other.maximumKeyframeInterval
+        gopStructure = other.gopStructure
+    }
+}

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -187,6 +187,7 @@ public final class DirectUpload {
     }
     private let uploadManager: DirectUploadManager
     private let inputInspector: UploadInputInspector
+    private var inputInspectionOperation: UploadInputInspectionOperation?
     private let inputStandardizer: UploadInputStandardizing
     
     internal var fileWorker: ChunkedFileUploader?
@@ -416,10 +417,10 @@ public final class DirectUpload {
             )) ?? 0
 
             input.status = .underInspection(input.sourceAsset, uploadInfo)
-            inputInspector.performInspection(
-                sourceInput: input.sourceAsset, 
-                maximumResolution: uploadInfo.options.inputStandardization.maximumResolution
-            ) { inspectionResult, inputDuration, inspectionError in
+            let operation = UploadInputInspectionOperation {
+                [weak self] inspectionResult, inputDuration, inspectionError in
+                guard let self else { return }
+                self.inputInspectionOperation = nil
                 self.inspectionResult = inspectionResult
 
                 switch (inspectionResult, inspectionError) {
@@ -579,6 +580,12 @@ public final class DirectUpload {
                     )
                 }
             }
+            inputInspectionOperation = operation
+            inputInspector.performInspection(
+                sourceInput: input.sourceAsset,
+                maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
+                operation: operation
+            )
         }
     }
 
@@ -742,6 +749,8 @@ public final class DirectUpload {
             ))
         }
         
+        inputInspectionOperation?.cancel()
+        inputInspectionOperation = nil
         fileWorker?.cancel()
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -187,7 +187,7 @@ public final class DirectUpload {
     }
     private let uploadManager: DirectUploadManager
     private let inputInspector: UploadInputInspector
-    private var inputInspectionOperation: UploadInputInspectionOperation?
+    private let inputInspectionOperations = UploadInputInspectionOperationRegistry()
     private let inputStandardizer: UploadInputStandardizing
     
     internal var fileWorker: ChunkedFileUploader?
@@ -417,10 +417,13 @@ public final class DirectUpload {
             )) ?? 0
 
             input.status = .underInspection(input.sourceAsset, uploadInfo)
+            let inspectionToken = UploadInputInspectionOperationRegistry.Token()
             let operation = UploadInputInspectionOperation {
                 [weak self] inspectionResult, inputDuration, inspectionError in
                 guard let self else { return }
-                self.inputInspectionOperation = nil
+                guard self.inputInspectionOperations.claimCompletion(
+                    for: inspectionToken
+                ) else { return }
                 self.inspectionResult = inspectionResult
 
                 switch (inspectionResult, inspectionError) {
@@ -580,7 +583,10 @@ public final class DirectUpload {
                     )
                 }
             }
-            inputInspectionOperation = operation
+            inputInspectionOperations.register(
+                operation,
+                for: inspectionToken
+            )
             inputInspector.performInspection(
                 sourceInput: input.sourceAsset,
                 maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
@@ -749,8 +755,7 @@ public final class DirectUpload {
             ))
         }
         
-        inputInspectionOperation?.cancel()
-        inputInspectionOperation = nil
+        inputInspectionOperations.cancelActive()
         fileWorker?.cancel()
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
@@ -22,6 +22,8 @@ class MockUploadInputInspector: UploadInputInspector {
     var mockInspectionError: Error?
     var mockInspectionResult: UploadInputFormatInspectionResult
     var duration: CMTime
+    var shouldDeferCompletion = false
+    private(set) var operation: UploadInputInspectionOperation?
 
     init() {
         self.mockInspectionResult = UploadInputFormatInspectionResult(
@@ -43,9 +45,26 @@ class MockUploadInputInspector: UploadInputInspector {
     func performInspection(
         sourceInput: AVAsset,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        completionHandler: @escaping UploadInputInspectionCompletionHandler
+        operation: UploadInputInspectionOperation
     ) {
-        completionHandler(mockInspectionResult, duration, mockInspectionError)
+        if shouldDeferCompletion {
+            self.operation = operation
+        } else {
+            operation.complete(
+                mockInspectionResult,
+                duration: duration,
+                error: mockInspectionError
+            )
+        }
+    }
+
+    func completeDeferredInspection() {
+        operation?.complete(
+            mockInspectionResult,
+            duration: duration,
+            error: mockInspectionError
+        )
+        operation = nil
     }
 
 }

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputSampleInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputSampleInspectionTests.swift
@@ -1,0 +1,369 @@
+//
+//  UploadInputSampleInspectionTests.swift
+//
+
+import AVFoundation
+import Foundation
+import XCTest
+@testable import MuxUploadSDK
+
+final class UploadInputSampleInspectionTests: XCTestCase {
+    func testMeasuresCompleteAndTerminalGOPs() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 1, bytes: 100, sync: true, kind: .idr),
+            sample(time: 1, duration: 1, bytes: 100),
+            sample(time: 2, duration: 0.5, bytes: 300, sync: true, kind: .idr),
+            sample(time: 2.5, duration: 1.5, bytes: 100)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .known(400))
+        XCTAssertEqual(facts.maximumGOPBitrate, .known(1_600))
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(2))
+        XCTAssertEqual(facts.gopStructure, .known(.closedWithIDR))
+    }
+
+    func testUsesPresentationTimingForVariableFrameRateIntervals() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 0.04, bytes: 10, sync: true, kind: .idr),
+            sample(time: 0.04, duration: 0.06, bytes: 10),
+            sample(time: 0.1, duration: 0.04, bytes: 10, sync: true, kind: .idr),
+            sample(time: 0.14, duration: 0.11, bytes: 10)
+        ])
+
+        XCTAssertEqual(facts.maximumKeyframeInterval.value ?? 0, 0.15, accuracy: 0.000_001)
+    }
+
+    func testTerminalGOPCanProvideMaximumBitrate() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 1, bytes: 100, sync: true, kind: .idr),
+            sample(time: 1, duration: 1, bytes: 100),
+            sample(time: 2, duration: 0.5, bytes: 400, sync: true, kind: .idr)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .known(400))
+        XCTAssertEqual(facts.maximumGOPBitrate, .known(6_400))
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(2))
+    }
+
+    func testEditListPrerollUsesStoredClosedGOPTiming() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: -1.9, duration: 0.1, bytes: 100, sync: true, kind: .idr),
+            sample(time: -0.9, duration: 0.1, bytes: 100),
+            sample(time: 0.1, duration: 0.1, bytes: 300, sync: true, kind: .idr),
+            sample(time: 0.4, duration: 0.1, bytes: 100)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .known(400))
+        XCTAssertEqual(facts.maximumGOPBitrate, .known(8_000))
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(2))
+        XCTAssertEqual(facts.gopStructure, .known(.closedWithIDR))
+    }
+
+    func testOpenRandomAccessPointMakesGOPStructureOpen() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 1, bytes: 100, sync: true, kind: .idr),
+            sample(time: 1, duration: 1, bytes: 100),
+            sample(time: 2, duration: 1, bytes: 100, sync: true, kind: .openGOP)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .unknown)
+        XCTAssertEqual(facts.maximumGOPBitrate, .unknown)
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(2))
+        XCTAssertEqual(facts.gopStructure, .known(.open))
+    }
+
+    func testOpenGOPLeadingPicturesDoNotProduceMisleadingByteFacts() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 0.5, bytes: 100, sync: true, kind: .idr),
+            sample(time: 0.5, duration: 0.5, bytes: 100),
+            sample(time: 1, duration: 0.1, bytes: 1_000, sync: true, kind: .openGOP),
+            // This leading picture follows the CRA in decode order but precedes
+            // it in presentation order, so its bytes cross the apparent boundary.
+            sample(time: 0.9, duration: 0.1, bytes: 10_000)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .unknown)
+        XCTAssertEqual(facts.maximumGOPBitrate, .unknown)
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(1))
+        XCTAssertEqual(facts.gopStructure, .known(.open))
+    }
+
+    func testContradictoryDependencyAttachmentMakesStructureUnknown() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(
+                time: 0,
+                duration: 1,
+                bytes: 100,
+                sync: true,
+                kind: .idr,
+                dependsOnOthers: true
+            )
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .known(100))
+        XCTAssertEqual(facts.gopStructure, .unknown)
+    }
+
+    func testMissingRandomAccessEvidenceOnlyMakesStructureUnknown() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 1, bytes: 100, sync: true, kind: .unknown),
+            sample(time: 1, duration: 1, bytes: 100)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .known(200))
+        XCTAssertEqual(facts.maximumGOPBitrate, .known(800))
+        XCTAssertEqual(facts.maximumKeyframeInterval, .known(2))
+        XCTAssertEqual(facts.gopStructure, .unknown)
+    }
+
+    func testInitialPartialGOPKeepsAllGOPFactsUnknown() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: 1, bytes: 100),
+            sample(time: 1, duration: 1, bytes: 100, sync: true, kind: .idr)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .unknown)
+        XCTAssertEqual(facts.maximumGOPBitrate, .unknown)
+        XCTAssertEqual(facts.maximumKeyframeInterval, .unknown)
+        XCTAssertEqual(facts.gopStructure, .unknown)
+    }
+
+    func testInvalidTimingKeepsAllGOPFactsUnknown() {
+        let facts = UploadInputCompressedSampleAggregator.inspect([
+            sample(time: 0, duration: .nan, bytes: 100, sync: true, kind: .idr)
+        ])
+
+        XCTAssertEqual(facts.maximumGOPByteSize, .unknown)
+        XCTAssertEqual(facts.maximumGOPBitrate, .unknown)
+        XCTAssertEqual(facts.maximumKeyframeInterval, .unknown)
+        XCTAssertEqual(facts.gopStructure, .unknown)
+    }
+
+    func testParsesLengthPrefixedH264NALUnitTypes() throws {
+        let data = lengthPrefixed([
+            Data([0x67, 0x01]),
+            Data([0x65, 0x02, 0x03])
+        ])
+
+        let types = try XCTUnwrap(
+            AVFoundationUploadInputSampleReader.nalUnitTypes(
+                in: data,
+                lengthFieldSize: 4,
+                codec: .h264
+            )
+        )
+        XCTAssertEqual(types, [7, 5])
+        XCTAssertEqual(
+            AVFoundationUploadInputSampleReader.randomAccessKind(
+                codec: .h264,
+                nalUnitTypes: types
+            ),
+            .idr
+        )
+    }
+
+    func testParsesHEVCIDRAndCRAAccessUnits() throws {
+        let idrTypes = try XCTUnwrap(
+            AVFoundationUploadInputSampleReader.nalUnitTypes(
+                in: lengthPrefixed([Data([19 << 1, 0x01, 0x02])]),
+                lengthFieldSize: 4,
+                codec: .hevc
+            )
+        )
+        let craTypes = try XCTUnwrap(
+            AVFoundationUploadInputSampleReader.nalUnitTypes(
+                in: lengthPrefixed([Data([21 << 1, 0x01, 0x02])]),
+                lengthFieldSize: 4,
+                codec: .hevc
+            )
+        )
+
+        XCTAssertEqual(
+            AVFoundationUploadInputSampleReader.randomAccessKind(
+                codec: .hevc,
+                nalUnitTypes: idrTypes
+            ),
+            .idr
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputSampleReader.randomAccessKind(
+                codec: .hevc,
+                nalUnitTypes: craTypes
+            ),
+            .openGOP
+        )
+    }
+
+    func testRejectsMalformedLengthPrefixedSample() {
+        XCTAssertNil(
+            AVFoundationUploadInputSampleReader.nalUnitTypes(
+                in: Data([0, 0, 0, 8, 0x65]),
+                lengthFieldSize: 4,
+                codec: .h264
+            )
+        )
+    }
+
+    // Manual integration hook. It skips unless a developer or CI job provisions
+    // the external media package and supplies its catalog; media remains outside Git.
+    func testCatalogMediaFixturesWhenConfigured() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let directory = environment["MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY"],
+              let catalogPath = environment["MUX_UPLOAD_MEDIA_FIXTURE_CATALOG"] else {
+            throw XCTSkip(
+                "Set MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY and "
+                    + "MUX_UPLOAD_MEDIA_FIXTURE_CATALOG for catalog-backed "
+                    + "real-media validation"
+            )
+        }
+
+        let catalogData = try Data(contentsOf: URL(fileURLWithPath: catalogPath))
+        let catalog = try JSONDecoder().decode(MediaFixtureCatalog.self, from: catalogData)
+        let fixturesByFilename = Dictionary(
+            uniqueKeysWithValues: catalog.fixtures.map { ($0.canonicalFilename, $0) }
+        )
+
+        let urls = try FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: directory),
+            includingPropertiesForKeys: nil
+        ).filter { ["mov", "mp4"].contains($0.pathExtension.lowercased()) }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertFalse(urls.isEmpty)
+        XCTAssertEqual(
+            Set(urls.map(\.lastPathComponent)),
+            Set(fixturesByFilename.keys),
+            "The configured directory must contain exactly the cataloged media fixtures"
+        )
+
+        for url in urls {
+            guard let fixture = fixturesByFilename[url.lastPathComponent] else {
+                XCTFail("No catalog entry for \(url.lastPathComponent)")
+                continue
+            }
+            let completion = expectation(description: url.lastPathComponent)
+            let asset = AVURLAsset(url: url)
+            AVFoundationUploadInputInspector().performInspection(
+                sourceInput: asset,
+                maximumResolution: .preset3840x2160
+            ) { result, _, error in
+                XCTAssertNil(error, url.lastPathComponent)
+                XCTAssertNotNil(result, url.lastPathComponent)
+                if let codec = result?.mediaFacts.videoCodec.value,
+                   codec == .h264 || codec == .hevc {
+                    if let expectedBitrate = fixture.facts.maximumGOPBitrate {
+                        XCTAssertEqual(
+                            result?.mediaFacts.maximumGOPBitrate,
+                            .known(expectedBitrate),
+                            url.lastPathComponent
+                        )
+                    }
+                    if let expectedInterval = fixture.facts.maximumKeyframeIntervalSeconds {
+                        XCTAssertEqual(
+                            result?.mediaFacts.maximumKeyframeInterval.value ?? 0,
+                            expectedInterval,
+                            accuracy: 0.000_001,
+                            url.lastPathComponent
+                        )
+                    }
+                    switch fixture.facts.gopStructure {
+                    case "closedWithIDR":
+                        XCTAssertEqual(
+                            result?.mediaFacts.gopStructure,
+                            .known(.closedWithIDR),
+                            url.lastPathComponent
+                        )
+                    case "open":
+                        XCTAssertEqual(
+                            result?.mediaFacts.gopStructure,
+                            .known(.open),
+                            url.lastPathComponent
+                        )
+                        XCTAssertEqual(
+                            result?.mediaFacts.maximumGOPByteSize,
+                            .unknown,
+                            url.lastPathComponent
+                        )
+                        XCTAssertEqual(
+                            result?.mediaFacts.maximumGOPBitrate,
+                            .unknown,
+                            url.lastPathComponent
+                        )
+                    default:
+                        break
+                    }
+                }
+                asset.loadTracks(withMediaType: .video) { tracks, trackError in
+                    XCTAssertNil(trackError, url.lastPathComponent)
+                    guard let track = tracks?.first, tracks?.count == 1 else {
+                        completion.fulfill()
+                        return
+                    }
+                    let startedAt = CFAbsoluteTimeGetCurrent()
+                    let sampleFacts = AVFoundationUploadInputSampleReader.inspect(
+                        asset: asset,
+                        videoTrack: track,
+                        codec: result?.mediaFacts.videoCodec ?? .unknown
+                    )
+                    let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
+                    XCTAssertEqual(
+                        sampleFacts.maximumGOPBitrate,
+                        result?.mediaFacts.maximumGOPBitrate,
+                        url.lastPathComponent
+                    )
+                    print(
+                        "Catalog real media:",
+                        url.lastPathComponent,
+                        "compressedSampleSeconds=\(String(format: "%.3f", elapsed))",
+                        "maxGOPBytes=\(String(describing: sampleFacts.maximumGOPByteSize.value))",
+                        "maxGOPBitrate=\(String(describing: sampleFacts.maximumGOPBitrate.value))",
+                        "maxKeyframeInterval=\(String(describing: sampleFacts.maximumKeyframeInterval.value))",
+                        "gopStructure=\(String(describing: sampleFacts.gopStructure.value))"
+                    )
+                    completion.fulfill()
+                }
+            }
+            wait(for: [completion], timeout: 120)
+        }
+    }
+
+    private func sample(
+        time: TimeInterval,
+        duration: TimeInterval,
+        bytes: Int64,
+        sync: Bool = false,
+        kind: UploadInputCompressedSampleObservation.RandomAccessKind = .unknown,
+        dependsOnOthers: Bool? = nil
+    ) -> UploadInputCompressedSampleObservation {
+        UploadInputCompressedSampleObservation(
+            presentationTime: time,
+            duration: duration,
+            byteCount: bytes,
+            syncState: sync ? .sync : .notSync,
+            randomAccessKind: kind,
+            dependsOnOthers: dependsOnOthers
+        )
+    }
+
+    private func lengthPrefixed(_ nalUnits: [Data]) -> Data {
+        nalUnits.reduce(into: Data()) { result, nalUnit in
+            var length = UInt32(nalUnit.count).bigEndian
+            withUnsafeBytes(of: &length) { result.append(contentsOf: $0) }
+            result.append(nalUnit)
+        }
+    }
+
+    private struct MediaFixtureCatalog: Decodable {
+        let fixtures: [MediaFixture]
+    }
+
+    private struct MediaFixture: Decodable {
+        let canonicalFilename: String
+        let facts: Facts
+
+        struct Facts: Decodable {
+            let maximumGOPBitrate: Int64?
+            let maximumKeyframeIntervalSeconds: TimeInterval?
+            let gopStructure: String?
+        }
+    }
+}

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -130,6 +130,35 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
+    func testConcurrentInspectionCancellationAndCompletionAreMutuallyExclusive() async {
+        for _ in 0..<250 {
+            let registry = UploadInputInspectionOperationRegistry()
+            let token = UploadInputInspectionOperationRegistry.Token()
+            let operation = UploadInputInspectionOperation { _, _, _ in }
+            registry.register(operation, for: token)
+
+            let completionTask = Task.detached {
+                registry.claimCompletion(for: token)
+            }
+            let cancellationTask = Task.detached {
+                registry.cancelActive()
+            }
+            let completionClaimed = await completionTask.value
+            let cancellationClaimed = await cancellationTask.value
+
+            XCTAssertNotEqual(
+                completionClaimed,
+                cancellationClaimed,
+                "Exactly one concurrent caller must claim the active inspection"
+            )
+            XCTAssertEqual(
+                operation.isCancelled,
+                cancellationClaimed,
+                "Cancellation must reach the operation only when it wins the claim"
+            )
+        }
+    }
+
     func testInputInspectionFailure() throws {
         let input = try UploadInput.mockReadyInput()
 

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -81,6 +81,55 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
+    func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() throws {
+        let input = try UploadInput.mockReadyInput()
+        let inspector = MockUploadInputInspector()
+        inspector.shouldDeferCompletion = true
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: inspector
+        )
+        let cancellationExpectation = expectation(
+            description: "Expected cancellation result during inspection"
+        )
+        let transportExpectation = expectation(
+            description: "Cancelled inspection must not start transport"
+        )
+        transportExpectation.isInverted = true
+        upload.resultHandler = { result in
+            guard case .failure = result else {
+                return XCTFail("Expected cancellation failure")
+            }
+            cancellationExpectation.fulfill()
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status {
+                transportExpectation.fulfill()
+            }
+        }
+
+        upload.start()
+
+        guard case .preparing = upload.inputStatus else {
+            return XCTFail("Expected inspection to remain in progress")
+        }
+        let operation = try XCTUnwrap(inspector.operation)
+
+        upload.cancel()
+        inspector.completeDeferredInspection()
+
+        XCTAssertTrue(operation.isCancelled)
+        XCTAssertNil(upload.fileWorker)
+        guard case .ready = upload.inputStatus else {
+            return XCTFail("Expected cancellation to reset the upload to ready")
+        }
+        wait(
+            for: [cancellationExpectation, transportExpectation],
+            timeout: 0.1
+        )
+    }
+
     func testInputInspectionFailure() throws {
         let input = try UploadInput.mockReadyInput()
 


### PR DESCRIPTION
## Summary

- inspect compressed H.264 and HEVC samples without decoding video frames
- report the largest group size, highest group bitrate, longest keyframe interval, and whether groups are open or closed when the samples provide reliable evidence
- make inspection cancellation safe when it races with completion: cancellation stops the active reader, suppresses late completion, and prevents upload transport from starting
- add focused synthetic coverage plus an optional catalog-backed real-media validation hook

## How it behaves

A group of pictures (GOP) is the set of video frames between two keyframes.

- When each group starts with a fully independent keyframe, the SDK reports the largest group size, highest group bitrate, longest keyframe interval, and a closed structure.
- When a keyframe may depend on frames from the previous group, the SDK reports an open structure. It does not report group size or bitrate because those values cannot be assigned reliably.
- When the compressed samples or timing do not prove an answer, the SDK leaves that value unknown instead of guessing.
- Trimmed videos are measured when the samples still contain a complete starting boundary. Otherwise the measurements remain unknown. A final partial group is measured using its actual duration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the upload prepare path and async AVFoundation inspection with new full-file sample reads; cancellation logic is concurrency-sensitive though heavily tested.
> 
> **Overview**
> Adds **compressed-sample inspection** for H.264/HEVC during upload input inspection: an `AVAssetReader` pass (no decode) aggregates sync boundaries into `StandardInputMediaFacts` for max GOP size/bitrate, max keyframe interval, and open vs closed GOP, with **unknown** values when evidence is insufficient (e.g. open GOP byte attribution).
> 
> Refactors inspection around **`UploadInputInspectionOperation`** and a **`UploadInputInspectionOperationRegistry`** so `DirectUpload` can cancel in-flight work, stop the reader, and use token-gated completion so late callbacks cannot start transport after cancel.
> 
> Includes synthetic aggregator/NAL tests, cancel/race tests on `DirectUpload`, and an optional env-driven catalog media integration test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3810905dd02a679ebcd06eb0e9c247583f64a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


