### PR TITLE
NAT-235: Make DirectUploadManager thread safe

### DIFF
--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -44,22 +44,13 @@ public final class DirectUploadManager {
         }
     }
     
-    /// Guards ``uploadsByID`` and ``uploadsUpdateDelegatesByToken``. Both are
-    /// touched from arbitrary threads: uploads register themselves from
-    /// AVFoundation's inspection queue, while readers like
-    /// ``allManagedDirectUploads()`` are usually called from the main thread.
-    ///
-    /// The lock is not recursive. Nothing that calls back out of this class,
-    /// including delegate callbacks and ``ChunkedFileUploader`` methods, may
-    /// run while it is held.
+    /// Guards ``uploadsByID`` and ``uploadsUpdateDelegatesByToken``, both of
+    /// which are touched from arbitrary threads. Not recursive: never call out
+    /// of this class while holding it.
     private let lock = NSLock()
 
-    /// Runs `body` holding ``lock``.
-    ///
-    /// Always synchronous, and deliberately so: taking the lock directly in an
-    /// `async` function risks suspending while holding it, which the Swift 6
-    /// language mode rejects outright. Keep `body` to plain state access, and
-    /// call out to anything else after this returns.
+    /// Synchronous on purpose. Taking the lock inside an `async` function risks
+    /// suspending while holding it, which Swift 6 rejects outright.
     @discardableResult
     private func withLock<T>(_ body: () -> T) -> T {
         lock.lock()
@@ -71,10 +62,9 @@ public final class DirectUploadManager {
     private var uploadsUpdateDelegatesByToken: [ObjectIdentifier : any DirectUploadManagerDelegate] = [:]
     private let uploadActor: UploadCacheActor
 
-    /// Deliberately not a `lazy var`: lazy initialization is not atomic, so
-    /// concurrent registrations could race on first access.
-    /// ``FileUploaderDelegate`` is a single-field struct, so making a new one
-    /// per call costs nothing and keeps this free of shared mutable state.
+    /// Not a `lazy var`: lazy initialization is not atomic, so concurrent
+    /// registrations raced on first access. The struct is one field, so
+    /// rebuilding it per call is free.
     private var uploaderDelegate: FileUploaderDelegate {
         FileUploaderDelegate(manager: self)
     }
@@ -168,8 +158,8 @@ public final class DirectUploadManager {
             uploadsByID.removeValue(forKey: id)?.upload
         }
 
-        // Cancelling reenters this class by way of the uploader's delegate
-        // callbacks, so it has to happen after unlocking.
+        // Reenters this class via the uploader's delegate callbacks, so it has
+        // to happen after unlocking.
         upload?.fileWorker?.cancel()
 
         Task.detached {
@@ -213,14 +203,10 @@ public final class DirectUploadManager {
     
     private func notifyDelegates() {
         Task { @MainActor in
-            // Snapshot and deliver without an await in between. The main actor
-            // runs these serially, so whichever notification reaches it last
-            // also took the most recent snapshot, and delegates never see the
-            // upload list move backwards.
-            //
-            // Snapshotting before the hop to the main actor would reintroduce
-            // that: two notifications could snapshot in one order and deliver
-            // in the other.
+            // No await between snapshot and delivery: the main actor is serial,
+            // so the last notification to arrive also holds the newest
+            // snapshot. Snapshotting before the hop lets notifications deliver
+            // out of order and the upload list appear to move backwards.
             let (delegates, allManagedUploads) = self.withLock {
                 (
                     Array(self.uploadsUpdateDelegatesByToken.values),
@@ -228,8 +214,7 @@ public final class DirectUploadManager {
                 )
             }
 
-            // The lock is released by this point, so a delegate is free to
-            // call back into the manager.
+            // Unlocked by now, so a delegate may call back in.
             for delegate in delegates {
                 delegate.didUpdate(managedDirectUploads: allManagedUploads)
             }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -212,11 +212,15 @@ public final class DirectUploadManager {
     }
     
     private func notifyDelegates() {
-        Task.detached {
-            // Snapshot both collections in one critical section so delegates
-            // always see a list of uploads consistent with the notification,
-            // then release the lock before calling out: delegate callbacks are
-            // arbitrary caller code and must not run while it is held.
+        Task { @MainActor in
+            // Snapshot and deliver without an await in between. The main actor
+            // runs these serially, so whichever notification reaches it last
+            // also took the most recent snapshot, and delegates never see the
+            // upload list move backwards.
+            //
+            // Snapshotting before the hop to the main actor would reintroduce
+            // that: two notifications could snapshot in one order and deliver
+            // in the other.
             let (delegates, allManagedUploads) = self.withLock {
                 (
                     Array(self.uploadsUpdateDelegatesByToken.values),
@@ -224,10 +228,10 @@ public final class DirectUploadManager {
                 )
             }
 
-            await MainActor.run {
-                for delegate in delegates {
-                    delegate.didUpdate(managedDirectUploads: allManagedUploads)
-                }
+            // The lock is released by this point, so a delegate is free to
+            // call back into the manager.
+            for delegate in delegates {
+                delegate.didUpdate(managedDirectUploads: allManagedUploads)
             }
         }
     }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -106,9 +106,7 @@ public final class DirectUploadManager {
         /// function risks suspending while holding it, which Swift 6 rejects.
         @discardableResult
         private func withLock<T>(_ body: () -> T) -> T {
-            lock.lock()
-            defer { lock.unlock() }
-            return body()
+            lock.withLock(body)
         }
     }
 

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -44,10 +44,40 @@ public final class DirectUploadManager {
         }
     }
     
+    /// Guards ``uploadsByID`` and ``uploadsUpdateDelegatesByToken``. Both are
+    /// touched from arbitrary threads: uploads register themselves from
+    /// AVFoundation's inspection queue, while readers like
+    /// ``allManagedDirectUploads()`` are usually called from the main thread.
+    ///
+    /// The lock is not recursive. Nothing that calls back out of this class,
+    /// including delegate callbacks and ``ChunkedFileUploader`` methods, may
+    /// run while it is held.
+    private let lock = NSLock()
+
+    /// Runs `body` holding ``lock``.
+    ///
+    /// Always synchronous, and deliberately so: taking the lock directly in an
+    /// `async` function risks suspending while holding it, which the Swift 6
+    /// language mode rejects outright. Keep `body` to plain state access, and
+    /// call out to anything else after this returns.
+    @discardableResult
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+
     private var uploadsByID: [String : UploadStorage] = [:]
     private var uploadsUpdateDelegatesByToken: [ObjectIdentifier : any DirectUploadManagerDelegate] = [:]
     private let uploadActor: UploadCacheActor
-    private lazy var uploaderDelegate: FileUploaderDelegate = FileUploaderDelegate(manager: self)
+
+    /// Deliberately not a `lazy var`: lazy initialization is not atomic, so
+    /// concurrent registrations could race on first access.
+    /// ``FileUploaderDelegate`` is a single-field struct, so making a new one
+    /// per call costs nothing and keeps this free of shared mutable state.
+    private var uploaderDelegate: FileUploaderDelegate {
+        FileUploaderDelegate(manager: self)
+    }
 
     init(uploadActor: UploadCacheActor = UploadCacheActor()) {
         self.uploadActor = uploadActor
@@ -57,13 +87,15 @@ public final class DirectUploadManager {
     /// to track and control its state.
     /// Returns nil if there was no upload in progress for the given file.
     public func startedDirectUpload(ofFile url: URL) -> DirectUpload? {
-        for upload in uploadsByID.values.map(\.upload) {
-            if upload.videoFile == url {
-                return upload
+        withLock {
+            for upload in uploadsByID.values.map(\.upload) {
+                if upload.videoFile == url {
+                    return upload
+                }
             }
-        }
 
-        return nil
+            return nil
+        }
     }
     
     /// Returns all currently-managed uploads that are
@@ -72,7 +104,9 @@ public final class DirectUploadManager {
     /// application termination are omitted.
     public func allManagedDirectUploads() -> [DirectUpload] {
         // Sort upload list for consistent ordering
-        return Array(uploadsByID.values.map(\.upload))
+        withLock {
+            Array(uploadsByID.values.map(\.upload))
+        }
     }
 
     /// Attempts to resume an upload that was previously paused or interrupted by process death.
@@ -82,7 +116,11 @@ public final class DirectUploadManager {
         if let nonNilUploader = fileUploader {
             nonNilUploader.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
             let upload = DirectUpload(wrapping: nonNilUploader, uploadManager: self)
-            uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
+
+            withLock {
+                uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
+            }
+
             notifyDelegates()
             return upload
         } else {
@@ -113,19 +151,27 @@ public final class DirectUploadManager {
     
     /// Adds a ``DirectUploadManagerDelegate``. You can add as many of these as you like.
     public func addDelegate<Delegate: DirectUploadManagerDelegate>(_ delegate: Delegate) {
-        uploadsUpdateDelegatesByToken[ObjectIdentifier(delegate)] = delegate
+        withLock {
+            uploadsUpdateDelegatesByToken[ObjectIdentifier(delegate)] = delegate
+        }
     }
-    
+
     /// Removes an ``DirectUploadManagerDelegate``
     public func removeDelegate<Delegate: DirectUploadManagerDelegate>(_ delegate: Delegate) {
-        uploadsUpdateDelegatesByToken.removeValue(forKey: ObjectIdentifier(delegate))
-    }
-    
-    internal func acknowledgeUpload(id: String) {
-        if let upload = uploadsByID[id]?.upload {
-            uploadsByID.removeValue(forKey: id)
-            upload.fileWorker?.cancel()
+        withLock {
+            uploadsUpdateDelegatesByToken.removeValue(forKey: ObjectIdentifier(delegate))
         }
+    }
+
+    internal func acknowledgeUpload(id: String) {
+        let upload = withLock {
+            uploadsByID.removeValue(forKey: id)?.upload
+        }
+
+        // Cancelling reenters this class by way of the uploader's delegate
+        // callbacks, so it has to happen after unlocking.
+        upload?.fileWorker?.cancel()
+
         Task.detached {
             await self.uploadActor.remove(uploadID: id)
             self.notifyDelegates()
@@ -150,7 +196,10 @@ public final class DirectUploadManager {
             return
         }
 
-        uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
+        withLock {
+            uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
+        }
+
         fileWorker.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
         self.notifyDelegates()
         Task.detached {
@@ -164,10 +213,18 @@ public final class DirectUploadManager {
     
     private func notifyDelegates() {
         Task.detached {
-            await MainActor.run {
-                let delegates = self.uploadsUpdateDelegatesByToken.values
-                let allManagedUploads = self.allManagedDirectUploads()
+            // Snapshot both collections in one critical section so delegates
+            // always see a list of uploads consistent with the notification,
+            // then release the lock before calling out: delegate callbacks are
+            // arbitrary caller code and must not run while it is held.
+            let (delegates, allManagedUploads) = self.withLock {
+                (
+                    Array(self.uploadsUpdateDelegatesByToken.values),
+                    Array(self.uploadsByID.values.map(\.upload))
+                )
+            }
 
+            await MainActor.run {
                 for delegate in delegates {
                     delegate.didUpdate(managedDirectUploads: allManagedUploads)
                 }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUploadManager.swift
@@ -43,29 +43,82 @@ public final class DirectUploadManager {
             hasher.combine(ObjectIdentifier(upload))
         }
     }
-    
-    /// Guards ``uploadsByID`` and ``uploadsUpdateDelegatesByToken``, both of
-    /// which are touched from arbitrary threads. Not recursive: never call out
-    /// of this class while holding it.
-    private let lock = NSLock()
 
-    /// Synchronous on purpose. Taking the lock inside an `async` function risks
-    /// suspending while holding it, which Swift 6 rejects outright.
-    @discardableResult
-    private func withLock<T>(_ body: () -> T) -> T {
-        lock.lock()
-        defer { lock.unlock() }
-        return body()
+    private struct NotificationSnapshot {
+        let delegates: [any DirectUploadManagerDelegate]
+        let uploads: [DirectUpload]
     }
 
-    private var uploadsByID: [String : UploadStorage] = [:]
-    private var uploadsUpdateDelegatesByToken: [ObjectIdentifier : any DirectUploadManagerDelegate] = [:]
+    /// Owns the manager's shared in-memory state and makes synchronized access
+    /// the only available access. The lock is not recursive, so methods return
+    /// snapshots and never call upload workers or delegates while holding it.
+    private final class LockedStorage {
+        private let lock = NSLock()
+        private var _unsafeUploadsByID: [String: UploadStorage] = [:]
+        private var _unsafeDelegatesByToken: [ObjectIdentifier: any DirectUploadManagerDelegate] = [:]
+
+        func upload(ofFile url: URL) -> DirectUpload? {
+            allUploads().first { $0.videoFile == url }
+        }
+
+        func allUploads() -> [DirectUpload] {
+            withLock {
+                Array(_unsafeUploadsByID.values.map(\.upload))
+            }
+        }
+
+        func insert(_ upload: DirectUpload) {
+            withLock {
+                _unsafeUploadsByID[upload.id] = UploadStorage(upload: upload)
+            }
+        }
+
+        func removeUpload(forID id: String) -> DirectUpload? {
+            withLock {
+                _unsafeUploadsByID.removeValue(forKey: id)?.upload
+            }
+        }
+
+        func addDelegate(_ delegate: any DirectUploadManagerDelegate) {
+            withLock {
+                _unsafeDelegatesByToken[ObjectIdentifier(delegate)] = delegate
+            }
+        }
+
+        func removeDelegate(_ delegate: any DirectUploadManagerDelegate) {
+            withLock {
+                _unsafeDelegatesByToken.removeValue(
+                    forKey: ObjectIdentifier(delegate)
+                )
+            }
+        }
+
+        func notificationSnapshot() -> NotificationSnapshot {
+            withLock {
+                NotificationSnapshot(
+                    delegates: Array(_unsafeDelegatesByToken.values),
+                    uploads: Array(_unsafeUploadsByID.values.map(\.upload))
+                )
+            }
+        }
+
+        /// Synchronous on purpose. Taking a lock directly in an `async`
+        /// function risks suspending while holding it, which Swift 6 rejects.
+        @discardableResult
+        private func withLock<T>(_ body: () -> T) -> T {
+            lock.lock()
+            defer { lock.unlock() }
+            return body()
+        }
+    }
+
+    private let storage = LockedStorage()
     private let uploadActor: UploadCacheActor
 
-    /// Not a `lazy var`: lazy initialization is not atomic, so concurrent
-    /// registrations raced on first access. The struct is one field, so
-    /// rebuilding it per call is free.
-    private var uploaderDelegate: FileUploaderDelegate {
+    /// A function makes it explicit that every call creates a new value. A
+    /// shared `lazy var` would be unsafe because lazy initialization is not
+    /// atomic.
+    private func makeUploaderDelegate() -> FileUploaderDelegate {
         FileUploaderDelegate(manager: self)
     }
 
@@ -77,15 +130,7 @@ public final class DirectUploadManager {
     /// to track and control its state.
     /// Returns nil if there was no upload in progress for the given file.
     public func startedDirectUpload(ofFile url: URL) -> DirectUpload? {
-        withLock {
-            for upload in uploadsByID.values.map(\.upload) {
-                if upload.videoFile == url {
-                    return upload
-                }
-            }
-
-            return nil
-        }
+        storage.upload(ofFile: url)
     }
     
     /// Returns all currently-managed uploads that are
@@ -93,10 +138,7 @@ public final class DirectUploadManager {
     /// or uploads that completed before the most recent
     /// application termination are omitted.
     public func allManagedDirectUploads() -> [DirectUpload] {
-        // Sort upload list for consistent ordering
-        withLock {
-            Array(uploadsByID.values.map(\.upload))
-        }
+        storage.allUploads()
     }
 
     /// Attempts to resume an upload that was previously paused or interrupted by process death.
@@ -104,12 +146,13 @@ public final class DirectUploadManager {
     public func resumeDirectUpload(ofFile url: URL) async -> DirectUpload? {
         let fileUploader = await uploadActor.getUpload(ofFileAt: url)
         if let nonNilUploader = fileUploader {
-            nonNilUploader.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
+            nonNilUploader.addDelegate(
+                withToken: UUID().uuidString,
+                makeUploaderDelegate()
+            )
             let upload = DirectUpload(wrapping: nonNilUploader, uploadManager: self)
 
-            withLock {
-                uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
-            }
+            storage.insert(upload)
 
             notifyDelegates()
             return upload
@@ -134,29 +177,26 @@ public final class DirectUploadManager {
     public func resumeAllDirectUploads() {
         Task.detached { [self] in
             for upload in await uploadActor.getAllUploads() {
-                upload.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
+                upload.addDelegate(
+                    withToken: UUID().uuidString,
+                    makeUploaderDelegate()
+                )
             }
         }
     }
     
     /// Adds a ``DirectUploadManagerDelegate``. You can add as many of these as you like.
     public func addDelegate<Delegate: DirectUploadManagerDelegate>(_ delegate: Delegate) {
-        withLock {
-            uploadsUpdateDelegatesByToken[ObjectIdentifier(delegate)] = delegate
-        }
+        storage.addDelegate(delegate)
     }
 
     /// Removes an ``DirectUploadManagerDelegate``
     public func removeDelegate<Delegate: DirectUploadManagerDelegate>(_ delegate: Delegate) {
-        withLock {
-            uploadsUpdateDelegatesByToken.removeValue(forKey: ObjectIdentifier(delegate))
-        }
+        storage.removeDelegate(delegate)
     }
 
     internal func acknowledgeUpload(id: String) {
-        let upload = withLock {
-            uploadsByID.removeValue(forKey: id)?.upload
-        }
+        let upload = storage.removeUpload(forID: id)
 
         // Reenters this class via the uploader's delegate callbacks, so it has
         // to happen after unlocking.
@@ -186,11 +226,12 @@ public final class DirectUploadManager {
             return
         }
 
-        withLock {
-            uploadsByID.updateValue(UploadStorage(upload: upload), forKey: upload.id)
-        }
+        storage.insert(upload)
 
-        fileWorker.addDelegate(withToken: UUID().uuidString, uploaderDelegate)
+        fileWorker.addDelegate(
+            withToken: UUID().uuidString,
+            makeUploaderDelegate()
+        )
         self.notifyDelegates()
         Task.detached {
             await self.uploadActor.updateUpload(
@@ -207,16 +248,11 @@ public final class DirectUploadManager {
             // so the last notification to arrive also holds the newest
             // snapshot. Snapshotting before the hop lets notifications deliver
             // out of order and the upload list appear to move backwards.
-            let (delegates, allManagedUploads) = self.withLock {
-                (
-                    Array(self.uploadsUpdateDelegatesByToken.values),
-                    Array(self.uploadsByID.values.map(\.upload))
-                )
-            }
+            let snapshot = self.storage.notificationSnapshot()
 
             // Unlocked by now, so a delegate may call back in.
-            for delegate in delegates {
-                delegate.didUpdate(managedDirectUploads: allManagedUploads)
+            for delegate in snapshot.delegates {
+                delegate.didUpdate(managedDirectUploads: snapshot.uploads)
             }
         }
     }

--- a/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
+++ b/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
@@ -220,6 +220,73 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         )
     }
 
+    /// Delegates are told about every change, so the sequence they observe has
+    /// to make sense. In a workload that only ever adds uploads, the list they
+    /// receive must never shrink.
+    ///
+    /// `notifyDelegates()` guarantees this by snapshotting and delivering in
+    /// one main-actor step: the main actor is serial, so the notification that
+    /// reaches it last also took the most recent snapshot. Snapshotting before
+    /// the hop would let two notifications snapshot in one order and deliver in
+    /// the other.
+    ///
+    /// A caveat worth knowing before trusting this test: it does *not* fail
+    /// against the snapshot-before-hop version. Registrations serialize behind
+    /// ``UploadCacheActor``, so each notification is enqueued before the next
+    /// is created and the order comes out right by accident. Adding main-actor
+    /// contention did not change that. It is a guard on the invariant, not a
+    /// reproducer for the bug.
+    func testDelegateNotificationsNeverGoBackwards() async throws {
+        let inputFileURLs = try inputFileURLs(
+            count: Self.concurrentOperationCount
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(
+                persistence: try makePersistence(inputFileURLs: inputFileURLs)
+            )
+        )
+
+        let recorder = RecordingDirectUploadManagerDelegate()
+        uploadManager.addDelegate(recorder)
+
+        await withTaskGroup(of: Void.self) { group in
+            for inputFileURL in inputFileURLs {
+                group.addTask {
+                    _ = await uploadManager.resumeDirectUpload(ofFile: inputFileURL)
+                }
+            }
+        }
+
+        // Notifications are delivered asynchronously, so wait for the stream to
+        // reach the final count, then keep waiting briefly: a late-arriving
+        // stale notification is precisely the failure being tested for.
+        var observed = await recorder.observedUploadCounts()
+        for _ in 0..<200 where observed.last != inputFileURLs.count {
+            try await Task.sleep(nanoseconds: 10_000_000)
+            observed = await recorder.observedUploadCounts()
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        observed = await recorder.observedUploadCounts()
+
+        XCTAssertFalse(
+            observed.isEmpty,
+            "Delegate should have been notified at least once"
+        )
+        XCTAssertEqual(
+            observed.last,
+            inputFileURLs.count,
+            "The last notification should reflect every registered upload"
+        )
+
+        let firstRegression = zip(observed, observed.dropFirst())
+            .enumerated()
+            .first { $0.element.0 > $0.element.1 }
+        XCTAssertNil(
+            firstRegression,
+            "Upload count went backwards. Full sequence: \(observed)"
+        )
+    }
+
 }
 
 private class CountingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
@@ -227,4 +294,22 @@ private class CountingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
         // Body intentionally empty. These tests are about the manager's
         // internal state, not what it reports.
     }
+}
+
+/// Records the size of every upload list it is handed, in delivery order.
+///
+/// `didUpdate(managedDirectUploads:)` is always called on the main actor, so
+/// `counts` is only ever touched there.
+private class RecordingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
+
+    private var counts: [Int] = []
+
+    func didUpdate(managedDirectUploads: [DirectUpload]) {
+        counts.append(managedDirectUploads.count)
+    }
+
+    func observedUploadCounts() async -> [Int] {
+        await MainActor.run { counts }
+    }
+
 }

--- a/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
+++ b/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
@@ -8,22 +8,11 @@ import XCTest
 
 @testable import MuxUploadSDK
 
-/// Regression tests for the data race described in
-/// https://github.com/muxinc/swift-upload-sdk/issues/122.
+/// Regression tests for https://github.com/muxinc/swift-upload-sdk/issues/122,
+/// where unsynchronized access to the manager's dictionaries crashed.
 ///
-/// `DirectUploadManager` keeps its uploads and its delegates in plain
-/// dictionaries that are reached from arbitrary threads: uploads register
-/// themselves from AVFoundation's inspection queue, while readers like
-/// `allManagedDirectUploads()` are typically called from the main thread.
-/// Without synchronization, concurrent access crashed inside
-/// `swift_isUniquelyReferenced_nonNull_native` — the copy-on-write uniqueness
-/// check `Dictionary.updateValue` performs before mutating.
-///
-/// These tests are only meaningful with Thread Sanitizer enabled:
-///
-///     swift test --sanitize=thread
-///
-/// Without TSan a surviving race is timing-dependent and will usually pass.
+/// Only meaningful under `swift test --sanitize=thread`. Without TSan a
+/// surviving race is timing-dependent and will usually pass.
 class UploadManagerThreadSafetyTests: XCTestCase {
 
     private static let concurrentOperationCount = 50
@@ -67,8 +56,7 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         }
     }
 
-    /// Registers many uploads concurrently. This is the crashing path from the
-    /// original report, minus the network transport.
+    /// The crashing path from the original report, minus network transport.
     func testConcurrentRegistrationDoesNotRaceOnUploadStorage() async throws {
         let inputFileURLs = try inputFileURLs(
             count: Self.concurrentOperationCount
@@ -94,8 +82,7 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         )
     }
 
-    /// Interleaves registration with the reads a UI layer would be making at
-    /// the same time. A read racing a write is as much a crash as two writes.
+    /// A read racing a write is as much a crash as two writes.
     func testConcurrentRegistrationAndReadsDoNotRace() async throws {
         let inputFileURLs = try inputFileURLs(
             count: Self.concurrentOperationCount
@@ -126,9 +113,8 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         )
     }
 
-    /// `uploadsUpdateDelegatesByToken` has the same exposure: `notifyDelegates()`
-    /// reads it from a detached task while `addDelegate`/`removeDelegate` can be
-    /// called from any thread.
+    /// The delegate map is exposed too: `notifyDelegates()` reads it off-main
+    /// while `addDelegate`/`removeDelegate` run on any thread.
     func testConcurrentDelegateMutationDoesNotRace() async throws {
         let inputFileURLs = try inputFileURLs(
             count: Self.concurrentOperationCount
@@ -139,8 +125,7 @@ class UploadManagerThreadSafetyTests: XCTestCase {
             )
         )
 
-        // Held for the duration so the delegates stay registered while
-        // registrations are notifying them.
+        // Held for the duration so they stay registered while notifying.
         let delegates = (0..<Self.concurrentOperationCount).map { _ in
             CountingDirectUploadManagerDelegate()
         }
@@ -170,8 +155,8 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         )
     }
 
-    /// Acknowledgement removes from the same dictionary registration writes to,
-    /// and is reached off-main from uploader state callbacks.
+    /// Acknowledgement removes from the dictionary registration writes to, and
+    /// is reached off-main from uploader state callbacks.
     func testConcurrentRegistrationAndAcknowledgementDoNotRace() async throws {
         let inputFileURLs = try inputFileURLs(
             count: Self.concurrentOperationCount
@@ -220,22 +205,12 @@ class UploadManagerThreadSafetyTests: XCTestCase {
         )
     }
 
-    /// Delegates are told about every change, so the sequence they observe has
-    /// to make sense. In a workload that only ever adds uploads, the list they
-    /// receive must never shrink.
+    /// In an add-only workload the list delegates receive must never shrink.
     ///
-    /// `notifyDelegates()` guarantees this by snapshotting and delivering in
-    /// one main-actor step: the main actor is serial, so the notification that
-    /// reaches it last also took the most recent snapshot. Snapshotting before
-    /// the hop would let two notifications snapshot in one order and deliver in
-    /// the other.
-    ///
-    /// A caveat worth knowing before trusting this test: it does *not* fail
-    /// against the snapshot-before-hop version. Registrations serialize behind
-    /// ``UploadCacheActor``, so each notification is enqueued before the next
-    /// is created and the order comes out right by accident. Adding main-actor
-    /// contention did not change that. It is a guard on the invariant, not a
-    /// reproducer for the bug.
+    /// Caveat: this does *not* fail against the snapshot-before-hop version.
+    /// Registrations serialize behind ``UploadCacheActor``, so notifications
+    /// are enqueued in order anyway. It guards the invariant, it does not
+    /// reproduce the bug.
     func testDelegateNotificationsNeverGoBackwards() async throws {
         let inputFileURLs = try inputFileURLs(
             count: Self.concurrentOperationCount
@@ -257,9 +232,8 @@ class UploadManagerThreadSafetyTests: XCTestCase {
             }
         }
 
-        // Notifications are delivered asynchronously, so wait for the stream to
-        // reach the final count, then keep waiting briefly: a late-arriving
-        // stale notification is precisely the failure being tested for.
+        // Wait for the final count, then a little longer: a late stale
+        // notification is the failure being tested for.
         var observed = await recorder.observedUploadCounts()
         for _ in 0..<200 where observed.last != inputFileURLs.count {
             try await Task.sleep(nanoseconds: 10_000_000)
@@ -291,15 +265,12 @@ class UploadManagerThreadSafetyTests: XCTestCase {
 
 private class CountingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
     func didUpdate(managedDirectUploads: [DirectUpload]) {
-        // Body intentionally empty. These tests are about the manager's
-        // internal state, not what it reports.
+        // Intentionally empty; these tests check internal state, not reports.
     }
 }
 
-/// Records the size of every upload list it is handed, in delivery order.
-///
-/// `didUpdate(managedDirectUploads:)` is always called on the main actor, so
-/// `counts` is only ever touched there.
+/// Records the size of every upload list handed over, in delivery order.
+/// `didUpdate` always runs on the main actor, so `counts` is only touched there.
 private class RecordingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
 
     private var counts: [Int] = []

--- a/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
+++ b/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerThreadSafetyTests.swift
@@ -1,0 +1,230 @@
+//
+//  UploadManagerThreadSafetyTests.swift
+//
+
+import AVFoundation
+import Foundation
+import XCTest
+
+@testable import MuxUploadSDK
+
+/// Regression tests for the data race described in
+/// https://github.com/muxinc/swift-upload-sdk/issues/122.
+///
+/// `DirectUploadManager` keeps its uploads and its delegates in plain
+/// dictionaries that are reached from arbitrary threads: uploads register
+/// themselves from AVFoundation's inspection queue, while readers like
+/// `allManagedDirectUploads()` are typically called from the main thread.
+/// Without synchronization, concurrent access crashed inside
+/// `swift_isUniquelyReferenced_nonNull_native` — the copy-on-write uniqueness
+/// check `Dictionary.updateValue` performs before mutating.
+///
+/// These tests are only meaningful with Thread Sanitizer enabled:
+///
+///     swift test --sanitize=thread
+///
+/// Without TSan a surviving race is timing-dependent and will usually pass.
+class UploadManagerThreadSafetyTests: XCTestCase {
+
+    private static let concurrentOperationCount = 50
+
+    /// Builds persistence pre-seeded with one resumable entry per input URL.
+    private func makePersistence(
+        inputFileURLs: [URL]
+    ) throws -> UploadPersistence {
+        let persistence = UploadPersistence(
+            innerFile: FakeUploadsFile.simiulatedStorage(),
+            atURL: try XCTUnwrap(inputFileURLs.first)
+        )
+
+        for inputFileURL in inputFileURLs {
+            let uploadInfo = UploadInfo(
+                id: UUID().uuidString,
+                uploadURL: try XCTUnwrap(
+                    URL(string: "https://www.example.com/upload/\(UUID().uuidString)")
+                ),
+                options: .inputStandardizationSkipped
+            )
+
+            try persistence.write(
+                entry: PersistenceEntry(
+                    savedAt: Date().timeIntervalSince1970,
+                    stateCode: .wasInProgress,
+                    lastSuccessfulByte: 1234,
+                    uploadInfo: uploadInfo,
+                    inputFileURL: inputFileURL
+                ),
+                for: uploadInfo.id
+            )
+        }
+
+        return persistence
+    }
+
+    private func inputFileURLs(count: Int) throws -> [URL] {
+        try (0..<count).map { index in
+            try XCTUnwrap(URL(string: "file://path/to/dummy/file/\(index)"))
+        }
+    }
+
+    /// Registers many uploads concurrently. This is the crashing path from the
+    /// original report, minus the network transport.
+    func testConcurrentRegistrationDoesNotRaceOnUploadStorage() async throws {
+        let inputFileURLs = try inputFileURLs(
+            count: Self.concurrentOperationCount
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(
+                persistence: try makePersistence(inputFileURLs: inputFileURLs)
+            )
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            for inputFileURL in inputFileURLs {
+                group.addTask {
+                    _ = await uploadManager.resumeDirectUpload(ofFile: inputFileURL)
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            uploadManager.allManagedDirectUploads().count,
+            inputFileURLs.count,
+            "Every concurrently resumed upload should survive registration"
+        )
+    }
+
+    /// Interleaves registration with the reads a UI layer would be making at
+    /// the same time. A read racing a write is as much a crash as two writes.
+    func testConcurrentRegistrationAndReadsDoNotRace() async throws {
+        let inputFileURLs = try inputFileURLs(
+            count: Self.concurrentOperationCount
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(
+                persistence: try makePersistence(inputFileURLs: inputFileURLs)
+            )
+        )
+
+        await withTaskGroup(of: Void.self) { group in
+            for inputFileURL in inputFileURLs {
+                group.addTask {
+                    _ = await uploadManager.resumeDirectUpload(ofFile: inputFileURL)
+                }
+                group.addTask {
+                    _ = uploadManager.allManagedDirectUploads()
+                }
+                group.addTask {
+                    _ = uploadManager.startedDirectUpload(ofFile: inputFileURL)
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            uploadManager.allManagedDirectUploads().count,
+            inputFileURLs.count
+        )
+    }
+
+    /// `uploadsUpdateDelegatesByToken` has the same exposure: `notifyDelegates()`
+    /// reads it from a detached task while `addDelegate`/`removeDelegate` can be
+    /// called from any thread.
+    func testConcurrentDelegateMutationDoesNotRace() async throws {
+        let inputFileURLs = try inputFileURLs(
+            count: Self.concurrentOperationCount
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(
+                persistence: try makePersistence(inputFileURLs: inputFileURLs)
+            )
+        )
+
+        // Held for the duration so the delegates stay registered while
+        // registrations are notifying them.
+        let delegates = (0..<Self.concurrentOperationCount).map { _ in
+            CountingDirectUploadManagerDelegate()
+        }
+
+        await withTaskGroup(of: Void.self) { group in
+            for (index, delegate) in delegates.enumerated() {
+                group.addTask {
+                    uploadManager.addDelegate(delegate)
+                }
+                group.addTask {
+                    _ = await uploadManager.resumeDirectUpload(
+                        ofFile: inputFileURLs[index]
+                    )
+                }
+                // Churn the map: half the delegates come straight back out.
+                if index.isMultiple(of: 2) {
+                    group.addTask {
+                        uploadManager.removeDelegate(delegate)
+                    }
+                }
+            }
+        }
+
+        XCTAssertEqual(
+            uploadManager.allManagedDirectUploads().count,
+            inputFileURLs.count
+        )
+    }
+
+    /// Acknowledgement removes from the same dictionary registration writes to,
+    /// and is reached off-main from uploader state callbacks.
+    func testConcurrentRegistrationAndAcknowledgementDoNotRace() async throws {
+        let inputFileURLs = try inputFileURLs(
+            count: Self.concurrentOperationCount
+        )
+        let uploadManager = DirectUploadManager(
+            uploadActor: UploadCacheActor(
+                persistence: try makePersistence(inputFileURLs: inputFileURLs)
+            )
+        )
+
+        let uploads = await withTaskGroup(
+            of: DirectUpload?.self,
+            returning: [DirectUpload].self
+        ) { group in
+            for inputFileURL in inputFileURLs {
+                group.addTask {
+                    await uploadManager.resumeDirectUpload(ofFile: inputFileURL)
+                }
+            }
+
+            var resumed: [DirectUpload] = []
+            for await upload in group {
+                if let upload {
+                    resumed.append(upload)
+                }
+            }
+            return resumed
+        }
+
+        XCTAssertEqual(uploads.count, inputFileURLs.count)
+
+        await withTaskGroup(of: Void.self) { group in
+            for upload in uploads {
+                group.addTask {
+                    uploadManager.acknowledgeUpload(id: upload.id)
+                }
+                group.addTask {
+                    _ = uploadManager.allManagedDirectUploads()
+                }
+            }
+        }
+
+        XCTAssertTrue(
+            uploadManager.allManagedDirectUploads().isEmpty,
+            "Acknowledging every upload should empty the manager"
+        )
+    }
+
+}
+
+private class CountingDirectUploadManagerDelegate: DirectUploadManagerDelegate {
+    func didUpdate(managedDirectUploads: [DirectUpload]) {
+        // Body intentionally empty. These tests are about the manager's
+        // internal state, not what it reports.
+    }
+}


### PR DESCRIPTION
Fixes #122 / [NAT-235](https://mux1.atlassian.net/browse/NAT-235).

## The bug

`DirectUploadManager` keeps its uploads and delegates in plain dictionaries reached from arbitrary threads, unsynchronized. `UploadInputInspector` fires its completion handler off AVFoundation's internal queue, leading to `registerUpload` → an unguarded `uploadsByID.updateValue()`. Two uploads starting in parallel means two threads writing the same dictionary.

The Crashlytics trace on #122 confirms it: crashed on `com.apple.avfoundation.avassettrack.completionsQueue`, top frame `swift_isUniquelyReferenced_nonNull_native` in `registerUpload` — the copy-on-write check `updateValue` runs before mutating. `acknowledgeUpload` and the delegate map are exposed the same way.

## The fix

Both dictionaries are now owned by a private `LockedStorage` type guarded by `NSLock`. It exposes only synchronized operations and snapshots, so `DirectUploadManager` cannot access the underlying state without locking.

`acknowledgeUpload` and `notifyDelegates` can call back into the manager, so the required state is captured under the lock and all external calls happen after releasing it. `notifyDelegates` snapshots uploads and delegates together on the main actor immediately before delivery, preventing notifications from arriving out of order.

Also replaced `lazy var uploaderDelegate` with an explicit `makeUploaderDelegate()` factory. Lazy initialization is not atomic, so concurrent registrations could race on first access.

No public API change. An `actor` would be cleaner long-term but would require making two public methods `async`.

## Testing

`UploadManagerThreadSafetyTests` covers concurrent registration, reads racing writes, delegate churn, acknowledgement, and notification ordering. The race tests were verified to fail before the fix — the old code reports Swift access races under TSan and segfaults. All 31 tests pass.

One caveat: under `--sanitize=thread` the full suite is **intermittently dirty**, roughly 2 runs in 3. The reported race is not in this change — it's `ChunkedFileUploader.currentState`, written on main by `notifyStateFromMain` and read off-main by the pre-existing `Task.detached` in `registerUpload`. The existing tests alone don't surface it; the concurrency load from these new tests does.


[NAT-235]: https://mux1.atlassian.net/browse/NAT-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core upload lifecycle and global delegate delivery on arbitrary threads; behavior is intentionally changed for thread safety and notification ordering, though the public API is unchanged.
> 
> **Overview**
> Fixes crashes from unsynchronized dictionary access when uploads register from AVFoundation completion queues (issue #122).
> 
> **`DirectUploadManager`** now routes all in-memory upload and delegate state through a private **`LockedStorage`** (`NSLock`), returning snapshots so work like `cancel()` and delegate callbacks never run while holding the lock. **`acknowledgeUpload`** removes an upload under the lock, then cancels the worker afterward.
> 
> Delegate updates **`notifyDelegates`** now hop to the main actor and take a single **`notificationSnapshot()`** immediately before delivery, so observers do not see upload lists shrink when notifications arrive out of order.
> 
> The shared **`lazy var uploaderDelegate`** is replaced with **`makeUploaderDelegate()`** so concurrent first-use initialization cannot race.
> 
> Adds **`UploadManagerThreadSafetyTests`** for concurrent resume/register, read/write races, delegate churn, acknowledgement, and monotonic delegate list sizes (intended for `swift test --sanitize=thread`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03fe0d9aacf429eca045d69c296b0dd028c14b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

