### PR TITLE
NAT-486: Plan and validate input standardization

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -121,8 +121,12 @@ final class UploadInputInspectionOperationRegistry: @unchecked Sendable {
     }
 
     @discardableResult
-    func cancelActive() -> Bool {
+    func cancel(for token: Token) -> Bool {
         lock.lock()
+        guard registration?.token == token else {
+            lock.unlock()
+            return false
+        }
         let operation = registration?.operation
         registration = nil
         lock.unlock()

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
@@ -1,0 +1,272 @@
+//
+//  StandardInputOutputValidator.swift
+//
+
+import Foundation
+
+struct StandardInputTimelineFacts: Equatable {
+    enum AudioVideoStartOffset: Equatable {
+        case notApplicable
+        case seconds(TimeInterval)
+    }
+
+    var duration: StandardInputFact<TimeInterval> = .unknown
+    var audioVideoStartOffset: StandardInputFact<AudioVideoStartOffset> = .unknown
+}
+
+struct StandardInputOutputValidation: Equatable {
+    enum PlanExpectation: Hashable {
+        case videoCodec
+        case dynamicRange
+        case displayAspectRatio
+        case duration
+        case audioVideoStartOffset
+    }
+
+    enum RejectionReason: Equatable {
+        case nonCompliant(Set<StandardInputPolicyEvaluation.Requirement>)
+        case insufficientPolicyEvidence(
+            Set<StandardInputPolicyEvaluation.Requirement>
+        )
+        case insufficientPlanEvidence(Set<PlanExpectation>)
+        case doesNotMatchPlan(Set<PlanExpectation>)
+    }
+
+    enum Disposition: Equatable {
+        case accepted
+        case rejected(RejectionReason)
+    }
+
+    let disposition: Disposition
+    let evaluation: StandardInputPolicyEvaluation
+
+    var isAccepted: Bool {
+        disposition == .accepted
+    }
+}
+
+struct StandardInputOutputValidator {
+    /// NAT-480 accepted duration changes within one output frame or 50ms,
+    /// whichever is larger. A/V-start-offset changes remain bounded at 50ms.
+    static let minimumDurationDelta: TimeInterval = 0.050
+    static let maximumAudioVideoStartOffsetDelta: TimeInterval = 0.050
+
+    /// Video encoders commonly align dimensions to even pixel counts. Permit
+    /// that rounding on both projected output axes without accepting a material
+    /// aspect-ratio change.
+    static let maximumAspectRatioDimensionError = 2.0
+
+    let evaluator: StandardInputPolicyEvaluator
+
+    init(evaluator: StandardInputPolicyEvaluator = StandardInputPolicyEvaluator()) {
+        self.evaluator = evaluator
+    }
+
+    func validatePolicyCompliance(
+        facts: StandardInputMediaFacts,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution
+    ) -> StandardInputOutputValidation {
+        validate(
+            facts: facts,
+            selection: StandardInputPolicySelection(
+                maximumResolution: maximumResolution
+            ),
+            expectedCodec: nil,
+            expectedDynamicRange: nil,
+            sourceTimeline: nil,
+            outputTimeline: nil,
+            sourceDisplayDimensions: nil
+        )
+    }
+
+    func validateGeneratedOutput(
+        facts: StandardInputMediaFacts,
+        sourceTimeline: StandardInputTimelineFacts,
+        outputTimeline: StandardInputTimelineFacts,
+        for conversion: StandardInputConversion
+    ) -> StandardInputOutputValidation {
+        validate(
+            facts: facts,
+            selection: conversion.selection,
+            expectedCodec: conversion.outputCodec,
+            expectedDynamicRange: conversion.toneMapsToSDR
+                ? .sdr
+                : conversion.sourceDynamicRange,
+            sourceTimeline: sourceTimeline,
+            outputTimeline: outputTimeline,
+            sourceDisplayDimensions: conversion.sourceDisplayDimensions
+        )
+    }
+
+    private func validate(
+        facts: StandardInputMediaFacts,
+        selection: StandardInputPolicySelection,
+        expectedCodec: StandardInputVideoCodec?,
+        expectedDynamicRange: StandardInputDynamicRange?,
+        sourceTimeline: StandardInputTimelineFacts?,
+        outputTimeline: StandardInputTimelineFacts?,
+        sourceDisplayDimensions: StandardInputFact<StandardInputDisplayDimensions>?
+    ) -> StandardInputOutputValidation {
+        let evaluation = evaluator.evaluate(
+            facts,
+            selection: selection,
+            role: .generatedOutput
+        )
+
+        if !evaluation.nonCompliantRequirements.isEmpty {
+            return StandardInputOutputValidation(
+                disposition: .rejected(
+                    .nonCompliant(Set(evaluation.nonCompliantRequirements))
+                ),
+                evaluation: evaluation
+            )
+        }
+        if !evaluation.unknownRequirements.isEmpty {
+            return StandardInputOutputValidation(
+                disposition: .rejected(
+                    .insufficientPolicyEvidence(
+                        Set(evaluation.unknownRequirements)
+                    )
+                ),
+                evaluation: evaluation
+            )
+        }
+
+        var insufficientEvidence: Set<StandardInputOutputValidation.PlanExpectation> = []
+        var mismatches: Set<StandardInputOutputValidation.PlanExpectation> = []
+
+        if let expectedCodec, facts.videoCodec.value != expectedCodec {
+            mismatches.insert(.videoCodec)
+        }
+        if let expectedDynamicRange,
+           facts.dynamicRange.value != expectedDynamicRange {
+            mismatches.insert(.dynamicRange)
+        }
+
+        if let sourceDisplayDimensions {
+            if let sourceDimensions = validDimensions(sourceDisplayDimensions),
+               let outputDimensions = validDimensions(facts.displayDimensions) {
+                if !preservesAspectRatio(
+                    source: sourceDimensions,
+                    output: outputDimensions
+                ) {
+                    mismatches.insert(.displayAspectRatio)
+                }
+            } else {
+                insufficientEvidence.insert(.displayAspectRatio)
+            }
+        }
+
+        if let sourceTimeline, let outputTimeline {
+            compareTimeline(
+                source: sourceTimeline,
+                output: outputTimeline,
+                outputFrameRate: facts.frameRate,
+                insufficientEvidence: &insufficientEvidence,
+                mismatches: &mismatches
+            )
+        }
+
+        return result(
+            evaluation: evaluation,
+            insufficientEvidence: insufficientEvidence,
+            mismatches: mismatches
+        )
+    }
+
+    private func compareTimeline(
+        source: StandardInputTimelineFacts,
+        output: StandardInputTimelineFacts,
+        outputFrameRate: StandardInputFact<Double>,
+        insufficientEvidence: inout Set<StandardInputOutputValidation.PlanExpectation>,
+        mismatches: inout Set<StandardInputOutputValidation.PlanExpectation>
+    ) {
+        if let sourceDuration = positiveFinite(source.duration),
+           let outputDuration = positiveFinite(output.duration),
+           let frameRate = positiveFinite(outputFrameRate) {
+            let maximumDurationDelta = max(
+                Self.minimumDurationDelta,
+                1.0 / frameRate
+            )
+            if abs(sourceDuration - outputDuration) > maximumDurationDelta {
+                mismatches.insert(.duration)
+            }
+        } else {
+            insufficientEvidence.insert(.duration)
+        }
+
+        guard let sourceOffset = source.audioVideoStartOffset.value,
+              let outputOffset = output.audioVideoStartOffset.value else {
+            insufficientEvidence.insert(.audioVideoStartOffset)
+            return
+        }
+
+        switch (sourceOffset, outputOffset) {
+        case (.notApplicable, .notApplicable):
+            break
+        case (.seconds(let source), .seconds(let output))
+            where source.isFinite && output.isFinite:
+            if abs(source - output)
+                > Self.maximumAudioVideoStartOffsetDelta {
+                mismatches.insert(.audioVideoStartOffset)
+            }
+        default:
+            mismatches.insert(.audioVideoStartOffset)
+        }
+    }
+
+    private func result(
+        evaluation: StandardInputPolicyEvaluation,
+        insufficientEvidence: Set<StandardInputOutputValidation.PlanExpectation>,
+        mismatches: Set<StandardInputOutputValidation.PlanExpectation>
+    ) -> StandardInputOutputValidation {
+        let disposition: StandardInputOutputValidation.Disposition
+        if !mismatches.isEmpty {
+            disposition = .rejected(.doesNotMatchPlan(mismatches))
+        } else if !insufficientEvidence.isEmpty {
+            disposition = .rejected(
+                .insufficientPlanEvidence(insufficientEvidence)
+            )
+        } else {
+            disposition = .accepted
+        }
+        return StandardInputOutputValidation(
+            disposition: disposition,
+            evaluation: evaluation
+        )
+    }
+
+    private func validDimensions(
+        _ fact: StandardInputFact<StandardInputDisplayDimensions>
+    ) -> StandardInputDisplayDimensions? {
+        guard let dimensions = fact.value,
+              dimensions.width > 0,
+              dimensions.height > 0 else {
+            return nil
+        }
+        return dimensions
+    }
+
+    private func positiveFinite(
+        _ fact: StandardInputFact<TimeInterval>
+    ) -> TimeInterval? {
+        guard let value = fact.value, value.isFinite, value > 0 else {
+            return nil
+        }
+        return value
+    }
+
+    private func preservesAspectRatio(
+        source: StandardInputDisplayDimensions,
+        output: StandardInputDisplayDimensions
+    ) -> Bool {
+        let projectedWidth = Double(source.width) * Double(output.height)
+            / Double(source.height)
+        let projectedHeight = Double(source.height) * Double(output.width)
+            / Double(source.width)
+        return abs(projectedWidth - Double(output.width))
+                <= Self.maximumAspectRatioDimensionError
+            && abs(projectedHeight - Double(output.height))
+                <= Self.maximumAspectRatioDimensionError
+    }
+}

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
@@ -52,7 +52,7 @@ struct StandardInputOutputValidator {
     static let maximumAudioVideoStartOffsetDelta: TimeInterval = 0.050
 
     /// Video encoders commonly align dimensions to even pixel counts. Permit
-    /// that rounding on both projected output axes without accepting a material
+    /// that rounding on both output axes without accepting a material
     /// aspect-ratio change.
     static let maximumAspectRatioDimensionError = 2.0
 
@@ -260,13 +260,20 @@ struct StandardInputOutputValidator {
         source: StandardInputDisplayDimensions,
         output: StandardInputDisplayDimensions
     ) -> Bool {
-        let projectedWidth = Double(source.width) * Double(output.height)
-            / Double(source.height)
-        let projectedHeight = Double(source.height) * Double(output.width)
-            / Double(source.width)
-        return abs(projectedWidth - Double(output.width))
-                <= Self.maximumAspectRatioDimensionError
-            && abs(projectedHeight - Double(output.height))
-                <= Self.maximumAspectRatioDimensionError
+        let dimensionError = Self.maximumAspectRatioDimensionError
+        let widthScaleRange = (
+            lower: (Double(output.width) - dimensionError) / Double(source.width),
+            upper: (Double(output.width) + dimensionError) / Double(source.width)
+        )
+        let heightScaleRange = (
+            lower: (Double(output.height) - dimensionError) / Double(source.height),
+            upper: (Double(output.height) + dimensionError) / Double(source.height)
+        )
+        let minimumScale = max(
+            0,
+            max(widthScaleRange.lower, heightScaleRange.lower)
+        )
+        let maximumScale = min(widthScaleRange.upper, heightScaleRange.upper)
+        return minimumScale <= maximumScale
     }
 }

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
@@ -46,8 +46,8 @@ struct StandardInputOutputValidation: Equatable {
 }
 
 struct StandardInputOutputValidator {
-    /// NAT-480 accepted duration changes within one output frame or 50ms,
-    /// whichever is larger. A/V-start-offset changes remain bounded at 50ms.
+    /// Duration may change by one output frame or 50ms, whichever is larger.
+    /// A/V-start-offset changes remain bounded at 50ms.
     static let minimumDurationDelta: TimeInterval = 0.050
     static let maximumAudioVideoStartOffsetDelta: TimeInterval = 0.050
 

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
@@ -1,0 +1,260 @@
+//
+//  StandardInputPlanner.swift
+//
+
+import Foundation
+
+struct StandardInputPlanningCapabilities: Equatable {
+    /// Capabilities are supplied for the current source and device. This keeps
+    /// hardware probing and asset-specific decode checks outside the pure planner.
+    var sourceIsDecodable: Bool
+    var encodableVideoCodecs: Set<StandardInputVideoCodec>
+    var remediableRequirements: Set<StandardInputPolicyEvaluation.Requirement>
+    var toneMappableDynamicRanges: Set<StandardInputDynamicRange>
+
+    /// HDR ranges eligible for intentional unchanged upload. The caller owns
+    /// server/configuration eligibility, especially for PQ input.
+    var preservableHDRDynamicRanges: Set<StandardInputDynamicRange>
+
+    func supports(_ conversion: StandardInputConversion) -> Bool {
+        sourceIsDecodable
+            && encodableVideoCodecs.contains(conversion.outputCodec)
+            && remediableRequirements.isSuperset(
+                of: conversion.requirementsToRemediate
+            )
+            && (!conversion.toneMapsToSDR
+                || toneMappableDynamicRanges.contains(conversion.sourceDynamicRange))
+    }
+}
+
+struct StandardInputConversion: Equatable {
+    let sourceCodec: StandardInputVideoCodec
+    let outputCodec: StandardInputVideoCodec
+    let sourceDynamicRange: StandardInputDynamicRange
+    let sourceDisplayDimensions: StandardInputFact<StandardInputDisplayDimensions>
+    let toneMapsToSDR: Bool
+    let selection: StandardInputPolicySelection
+    let requirementsToRemediate: Set<StandardInputPolicyEvaluation.Requirement>
+}
+
+struct StandardInputPlan: Equatable {
+    enum UploadOriginalReason: Equatable {
+        case standardizationNotRequested
+        case standardInput
+        case noKnownStandardInputViolation
+        case preserveHDR(StandardInputDynamicRange)
+    }
+
+    enum FallbackReason: Equatable {
+        case insufficientEvidenceForConversion
+        case unsupportedConversion(StandardInputConversion)
+        case unsupportedHDR(StandardInputDynamicRange)
+        case hdrPreservationUnavailable(StandardInputDynamicRange)
+        case nonStandardHDR(
+            StandardInputDynamicRange,
+            Set<StandardInputPolicyEvaluation.Requirement>
+        )
+    }
+
+    enum Action: Equatable {
+        case uploadOriginal(UploadOriginalReason)
+        case convert(StandardInputConversion)
+        case fallback(FallbackReason)
+    }
+
+    let action: Action
+    let evaluation: StandardInputPolicyEvaluation
+}
+
+struct StandardInputPlanner {
+    let evaluator: StandardInputPolicyEvaluator
+
+    init(evaluator: StandardInputPolicyEvaluator = StandardInputPolicyEvaluator()) {
+        self.evaluator = evaluator
+    }
+
+    func plan(
+        facts: StandardInputMediaFacts,
+        options: DirectUploadOptions.InputStandardization,
+        capabilities: StandardInputPlanningCapabilities
+    ) -> StandardInputPlan {
+        let selection = StandardInputPolicySelection(
+            maximumResolution: options.maximumResolution
+        )
+        let evaluation = evaluator.evaluate(
+            facts,
+            selection: selection,
+            role: .sourceInput
+        )
+
+        guard options.isRequested else {
+            return StandardInputPlan(
+                action: .uploadOriginal(.standardizationNotRequested),
+                evaluation: evaluation
+            )
+        }
+
+        var requirementsToRemediate = Set(
+            evaluation.nonCompliantRequirements
+        )
+        if let dimensions = facts.displayDimensions.value,
+           dimensions.width > 0,
+           dimensions.height > 0,
+           !dimensions.fitsWithin(selection.generatedOutputDimensions) {
+            requirementsToRemediate.insert(.videoResolution)
+        }
+
+        switch facts.dynamicRange.value {
+        case .hlg?:
+            return planHDR(
+                dynamicRange: .hlg,
+                facts: facts,
+                options: options,
+                capabilities: capabilities,
+                selection: selection,
+                evaluation: evaluation,
+                requirementsToRemediate: requirementsToRemediate
+            )
+        case .pq?:
+            return planHDR(
+                dynamicRange: .pq,
+                facts: facts,
+                options: options,
+                capabilities: capabilities,
+                selection: selection,
+                evaluation: evaluation,
+                requirementsToRemediate: requirementsToRemediate
+            )
+        case .otherHDR?:
+            return StandardInputPlan(
+                action: .fallback(.unsupportedHDR(.otherHDR)),
+                evaluation: evaluation
+            )
+        case .sdr?:
+            break
+        case nil:
+            guard requirementsToRemediate.isEmpty else {
+                return StandardInputPlan(
+                    action: .fallback(.insufficientEvidenceForConversion),
+                    evaluation: evaluation
+                )
+            }
+        }
+
+        guard !requirementsToRemediate.isEmpty else {
+            let reason: StandardInputPlan.UploadOriginalReason =
+                evaluation.outcome == .compliant
+                    ? .standardInput
+                    : .noKnownStandardInputViolation
+            return StandardInputPlan(
+                action: .uploadOriginal(reason),
+                evaluation: evaluation
+            )
+        }
+
+        return planConversion(
+            facts: facts,
+            capabilities: capabilities,
+            selection: selection,
+            evaluation: evaluation,
+            requirementsToRemediate: requirementsToRemediate,
+            toneMapsToSDR: false
+        )
+    }
+
+    private func planHDR(
+        dynamicRange: StandardInputDynamicRange,
+        facts: StandardInputMediaFacts,
+        options: DirectUploadOptions.InputStandardization,
+        capabilities: StandardInputPlanningCapabilities,
+        selection: StandardInputPolicySelection,
+        evaluation: StandardInputPolicyEvaluation,
+        requirementsToRemediate: Set<StandardInputPolicyEvaluation.Requirement>
+    ) -> StandardInputPlan {
+        switch options.hdrHandling {
+        case .preserve:
+            guard evaluation.status(for: .dynamicRange) == .compliant else {
+                return StandardInputPlan(
+                    action: .fallback(.unsupportedHDR(dynamicRange)),
+                    evaluation: evaluation
+                )
+            }
+            guard capabilities.preservableHDRDynamicRanges.contains(dynamicRange) else {
+                return StandardInputPlan(
+                    action: .fallback(.hdrPreservationUnavailable(dynamicRange)),
+                    evaluation: evaluation
+                )
+            }
+            guard requirementsToRemediate.isEmpty else {
+                return StandardInputPlan(
+                    action: .fallback(
+                        .nonStandardHDR(dynamicRange, requirementsToRemediate)
+                    ),
+                    evaluation: evaluation
+                )
+            }
+            return StandardInputPlan(
+                action: .uploadOriginal(.preserveHDR(dynamicRange)),
+                evaluation: evaluation
+            )
+        case .toneMapToSDR:
+            guard facts.videoCodec.value == .h264
+                    || facts.videoCodec.value == .hevc else {
+                return StandardInputPlan(
+                    action: .fallback(.unsupportedHDR(dynamicRange)),
+                    evaluation: evaluation
+                )
+            }
+            return planConversion(
+                facts: facts,
+                capabilities: capabilities,
+                selection: selection,
+                evaluation: evaluation,
+                requirementsToRemediate: requirementsToRemediate,
+                toneMapsToSDR: true
+            )
+        }
+    }
+
+    private func planConversion(
+        facts: StandardInputMediaFacts,
+        capabilities: StandardInputPlanningCapabilities,
+        selection: StandardInputPolicySelection,
+        evaluation: StandardInputPolicyEvaluation,
+        requirementsToRemediate: Set<StandardInputPolicyEvaluation.Requirement>,
+        toneMapsToSDR: Bool
+    ) -> StandardInputPlan {
+        guard let sourceCodec = facts.videoCodec.value,
+              let sourceDynamicRange = facts.dynamicRange.value else {
+            return StandardInputPlan(
+                action: .fallback(.insufficientEvidenceForConversion),
+                evaluation: evaluation
+            )
+        }
+
+        let outputCodec: StandardInputVideoCodec
+        switch sourceCodec {
+        case .h264, .hevc:
+            outputCodec = sourceCodec
+        case .other:
+            outputCodec = .h264
+        }
+
+        let conversion = StandardInputConversion(
+            sourceCodec: sourceCodec,
+            outputCodec: outputCodec,
+            sourceDynamicRange: sourceDynamicRange,
+            sourceDisplayDimensions: facts.displayDimensions,
+            toneMapsToSDR: toneMapsToSDR,
+            selection: selection,
+            requirementsToRemediate: requirementsToRemediate
+        )
+
+        return StandardInputPlan(
+            action: capabilities.supports(conversion)
+                ? .convert(conversion)
+                : .fallback(.unsupportedConversion(conversion)),
+            evaluation: evaluation
+        )
+    }
+}

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
@@ -239,7 +239,7 @@ extension StandardInputPolicyProfile {
 }
 
 struct StandardInputPolicyEvaluation: Equatable {
-    enum Requirement: CaseIterable, Equatable {
+    enum Requirement: CaseIterable, Hashable {
         case videoCodec
         case videoResolution
         case frameRate

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -195,6 +195,7 @@ public final class DirectUpload {
 
     private struct UploadAttempt: Equatable {
         let id = UUID()
+        let inspectionToken = UploadInputInspectionOperationRegistry.Token()
     }
 
     typealias FileWorkerFactory = (
@@ -496,12 +497,11 @@ public final class DirectUpload {
                 atPath: input.sourceAsset.url.absoluteString
             )) ?? 0
 
-            let inspectionToken = UploadInputInspectionOperationRegistry.Token()
             let operation = UploadInputInspectionOperation {
                 [weak self] inspectionResult, inputDuration, inspectionError in
                 guard let self else { return }
                 guard self.inputInspectionOperations.claimCompletion(
-                    for: inspectionToken
+                    for: attempt.inspectionToken
                 ) else { return }
                 guard self.isActive(attempt) else { return }
                 self.inspectionResult = inspectionResult
@@ -689,7 +689,7 @@ public final class DirectUpload {
             }
             inputInspectionOperations.register(
                 operation,
-                for: inspectionToken
+                for: attempt.inspectionToken
             )
             lifecycleLock.unlock()
 
@@ -909,6 +909,7 @@ public final class DirectUpload {
         progressHandler = nil
         resultHandler = nil
 
+        let cancelledAttempt = activeAttempt
         activeAttempt = nil
         let fileWorker = self.fileWorker
         self.fileWorker = nil
@@ -918,7 +919,9 @@ public final class DirectUpload {
         }
         lifecycleLock.unlock()
 
-        inputInspectionOperations.cancelActive()
+        if let cancelledAttempt {
+            inputInspectionOperations.cancel(for: cancelledAttempt.inspectionToken)
+        }
         fileWorker?.cancel()
         cancellationNotification?()
 

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -189,6 +189,15 @@ public final class DirectUpload {
     private let inputInspector: UploadInputInspector
     private let inputInspectionOperations = UploadInputInspectionOperationRegistry()
     private let inputStandardizer: UploadInputStandardizing
+    private let lifecycleLock = NSRecursiveLock()
+    private let fileWorkerFactory: FileWorkerFactory
+
+    typealias FileWorkerFactory = (
+        UploadInfo,
+        URL,
+        ChunkedFile,
+        UInt64
+    ) -> ChunkedFileUploader
     
     internal var fileWorker: ChunkedFileUploader?
 
@@ -244,13 +253,15 @@ public final class DirectUpload {
         manage: Bool = true,
         uploadManager: DirectUploadManager,
         inputInspector: AVFoundationUploadInputInspector = .shared,
-        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer()
+        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer(),
+        fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
         self.manageBySDK = manage
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         self.inputStandardizer = inputStandardizer
+        self.fileWorkerFactory = fileWorkerFactory
     }
 
     init(
@@ -258,13 +269,29 @@ public final class DirectUpload {
         manage: Bool = true,
         uploadManager: DirectUploadManager,
         inputInspector: UploadInputInspector,
-        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer()
+        inputStandardizer: UploadInputStandardizing = UploadInputStandardizer(),
+        fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
         self.manageBySDK = manage
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         self.inputStandardizer = inputStandardizer
+        self.fileWorkerFactory = fileWorkerFactory
+    }
+
+    private static func makeFileWorker(
+        uploadInfo: UploadInfo,
+        inputFileURL: URL,
+        file: ChunkedFile,
+        startingByte: UInt64
+    ) -> ChunkedFileUploader {
+        ChunkedFileUploader(
+            uploadInfo: uploadInfo,
+            inputFileURL: inputFileURL,
+            file: file,
+            startingByte: startingByte
+        )
     }
 
     internal convenience init(
@@ -654,6 +681,9 @@ public final class DirectUpload {
     func startNetworkTransport(
         videoFile: URL
     ) {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
         guard readyForTransport() else {
             SDKLogger.logger?.info("Tried to start network transport before being ready")
             return
@@ -663,11 +693,11 @@ public final class DirectUpload {
 
         let completedUnitCount = UInt64(uploadStatus?.progress?.completedUnitCount ?? 0)
 
-        let fileWorker = ChunkedFileUploader(
-            uploadInfo: input.uploadInfo,
-            inputFileURL: videoFile,
-            file: ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
-            startingByte: completedUnitCount
+        let fileWorker = fileWorkerFactory(
+            input.uploadInfo,
+            videoFile,
+            ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
+            completedUnitCount
         )
         fileWorker.addDelegate(
             withToken: id,
@@ -692,18 +722,20 @@ public final class DirectUpload {
         videoFile: URL,
         duration: CMTime
     ) {
-        
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
         guard readyForTransport() else {
             return
         }
 
         let completedUnitCount = UInt64(uploadStatus?.progress?.completedUnitCount ?? 0)
 
-        let fileWorker = ChunkedFileUploader(
-            uploadInfo: input.uploadInfo,
-            inputFileURL: videoFile,
-            file: ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
-            startingByte: completedUnitCount
+        let fileWorker = fileWorkerFactory(
+            input.uploadInfo,
+            videoFile,
+            ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
+            completedUnitCount
         )
         fileWorker.addDelegate(
             withToken: id,
@@ -754,9 +786,13 @@ public final class DirectUpload {
                 )
             ))
         }
-        
+
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+
         inputInspectionOperations.cancelActive()
         fileWorker?.cancel()
+        fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()
         

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -190,8 +190,12 @@ public final class DirectUpload {
     private let inputInspectionOperations = UploadInputInspectionOperationRegistry()
     private let inputStandardizer: UploadInputStandardizing
     private let lifecycleLock = NSLock()
-    private var cancellationRequested = false
+    private var activeAttempt: UploadAttempt?
     private let fileWorkerFactory: FileWorkerFactory
+
+    private struct UploadAttempt: Equatable {
+        let id = UUID()
+    }
 
     typealias FileWorkerFactory = (
         UploadInfo,
@@ -293,6 +297,31 @@ public final class DirectUpload {
             file: file,
             startingByte: startingByte
         )
+    }
+
+    private func isActive(_ attempt: UploadAttempt) -> Bool {
+        lifecycleLock.lock()
+        defer { lifecycleLock.unlock() }
+        return activeAttempt == attempt
+    }
+
+    /// Mutates input state while lifecycle ownership is locked, then returns
+    /// the corresponding client notification for delivery after unlocking.
+    private func transitionInputWithoutNotifying(
+        _ transition: (inout UploadInput) -> Void
+    ) -> (() -> Void)? {
+        let previousStatus = input.status
+        let statusHandler = inputStatusHandler
+        inputStatusHandler = nil
+        transition(&input)
+        inputStatusHandler = statusHandler
+
+        guard previousStatus != input.status, let statusHandler else {
+            return nil
+        }
+
+        let status = inputStatus
+        return { statusHandler(status) }
     }
 
     internal convenience init(
@@ -417,22 +446,42 @@ public final class DirectUpload {
 
         // Start a new upload
 
+        let attempt = UploadAttempt()
+        lifecycleLock.lock()
+        let canStart: Bool
+        let startNotification: (() -> Void)?
         if case UploadInput.Status.ready = input.status {
-            lifecycleLock.lock()
-            cancellationRequested = false
-            lifecycleLock.unlock()
-            input.status = .started(input.sourceAsset, uploadInfo)
-            startInspection(sourceAsset: input.sourceAsset)
+            activeAttempt = attempt
+            startNotification = transitionInputWithoutNotifying { input in
+                input.status = .started(input.sourceAsset, input.uploadInfo)
+            }
+            canStart = true
+        } else {
+            startNotification = nil
+            canStart = false
+        }
+        lifecycleLock.unlock()
+
+        if canStart {
+            startNotification?()
+            startInspection(
+                sourceAsset: input.sourceAsset,
+                attempt: attempt
+            )
         } else if forceRestart {
             cancel(notifyCaller: false)
         }
     }
 
-    func startInspection(
-        sourceAsset: AVURLAsset
+    private func startInspection(
+        sourceAsset: AVURLAsset,
+        attempt: UploadAttempt
     ) {
         if !uploadInfo.options.inputStandardization.isRequested {
-            startNetworkTransport(videoFile: sourceAsset.url)
+            startNetworkTransport(
+                videoFile: sourceAsset.url,
+                attempt: attempt
+            )
         } else {
             let inputStandardizationStartTime = Date()
             let reporter = Reporter.shared
@@ -447,7 +496,6 @@ public final class DirectUpload {
                 atPath: input.sourceAsset.url.absoluteString
             )) ?? 0
 
-            input.status = .underInspection(input.sourceAsset, uploadInfo)
             let inspectionToken = UploadInputInspectionOperationRegistry.Token()
             let operation = UploadInputInspectionOperation {
                 [weak self] inspectionResult, inputDuration, inspectionError in
@@ -455,6 +503,7 @@ public final class DirectUpload {
                 guard self.inputInspectionOperations.claimCompletion(
                     for: inspectionToken
                 ) else { return }
+                guard self.isActive(attempt) else { return }
                 self.inspectionResult = inspectionResult
 
                 switch (inspectionResult, inspectionError) {
@@ -465,7 +514,8 @@ public final class DirectUpload {
                         inputDuration: inputDuration,
                         inputSize: inputSize,
                         inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset
+                        sourceAsset: sourceAsset,
+                        attempt: attempt
                     )
                 case (.none, .some(let error)):
                     self.handleInspectionFailure(
@@ -473,7 +523,8 @@ public final class DirectUpload {
                         inputDuration: inputDuration,
                         inputSize: inputSize,
                         inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset
+                        sourceAsset: sourceAsset,
+                        attempt: attempt
                     )
                 case (.some(let result), .none):
                     if result.isStandardInput {
@@ -499,6 +550,11 @@ public final class DirectUpload {
                                 outputURL: outputURL
                             ) { sourceAsset, standardizedAsset, error in
 
+                                guard self.isActive(attempt) else {
+                                    self.inputStandardizer.acknowledgeCompletion(id: self.id)
+                                    return
+                                }
+
                                 if let _ = error {
                                     // Request upload confirmation
                                     // before proceeding. If handler unset,
@@ -508,17 +564,17 @@ public final class DirectUpload {
 
                                     if !shouldCancelUpload {
                                         self.startNetworkTransport(
-                                            videoFile: sourceAsset.url
+                                            videoFile: sourceAsset.url,
+                                            attempt: attempt
                                         )
                                     } else {
-                                        self.fileWorker?.cancel()
-                                        self.uploadManager.acknowledgeUpload(id: self.id)
-                                        self.input.processUploadCancellation()
+                                        self.cancelPreparation(for: attempt)
                                     }
                                 } else {
                                     self.startNetworkTransport(
                                         videoFile: outputURL,
-                                        duration: inputDuration
+                                        duration: inputDuration,
+                                        attempt: attempt
                                     )
                                 }
 
@@ -527,7 +583,8 @@ public final class DirectUpload {
 
                         } else {
                             self.startNetworkTransport(
-                                videoFile: sourceAsset.url
+                                videoFile: sourceAsset.url,
+                                attempt: attempt
                             )
                         }
                     } else {
@@ -556,6 +613,11 @@ public final class DirectUpload {
                             outputURL: outputURL
                         ) { sourceAsset, standardizedAsset, error in
 
+                            guard self.isActive(attempt) else {
+                                self.inputStandardizer.acknowledgeCompletion(id: self.id)
+                                return
+                            }
+
                             if let error {
                                 // Request upload confirmation
                                 // before proceeding. If handler unset,
@@ -577,12 +639,11 @@ public final class DirectUpload {
 
                                 if !shouldCancelUpload {
                                     self.startNetworkTransport(
-                                        videoFile: sourceAsset.url
+                                        videoFile: sourceAsset.url,
+                                        attempt: attempt
                                     )
                                 } else {
-                                    self.fileWorker?.cancel()
-                                    self.uploadManager.acknowledgeUpload(id: self.id)
-                                    self.input.processUploadCancellation()
+                                    self.cancelPreparation(for: attempt)
                                 }
                             } else {
                                 reporter.reportUploadInputStandardizationSuccess(
@@ -597,7 +658,8 @@ public final class DirectUpload {
 
                                 self.startNetworkTransport(
                                     videoFile: outputURL,
-                                    duration: inputDuration
+                                    duration: inputDuration,
+                                    attempt: attempt
                                 )
                             }
 
@@ -610,14 +672,28 @@ public final class DirectUpload {
                         inputDuration: inputDuration,
                         inputSize: inputSize,
                         inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset
+                        sourceAsset: sourceAsset,
+                        attempt: attempt
                     )
                 }
+            }
+
+            lifecycleLock.lock()
+            guard activeAttempt == attempt else {
+                lifecycleLock.unlock()
+                operation.cancel()
+                return
+            }
+            let inspectionNotification = transitionInputWithoutNotifying { input in
+                input.status = .underInspection(input.sourceAsset, input.uploadInfo)
             }
             inputInspectionOperations.register(
                 operation,
                 for: inspectionToken
             )
+            lifecycleLock.unlock()
+
+            inspectionNotification?()
             inputInspector.performInspection(
                 sourceInput: input.sourceAsset,
                 maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
@@ -626,13 +702,15 @@ public final class DirectUpload {
         }
     }
 
-    func handleInspectionFailure(
+    private func handleInspectionFailure(
         inspectionError: Error,
         inputDuration: CMTime,
         inputSize: UInt64,
         inputStandardizationStartTime: Date,
-        sourceAsset: AVURLAsset
+        sourceAsset: AVURLAsset,
+        attempt: UploadAttempt
     ) {
+        guard isActive(attempt) else { return }
         let reporter = Reporter.shared
         // Request upload confirmation
         // before proceeding. If handler unset,
@@ -654,13 +732,32 @@ public final class DirectUpload {
 
         if !shouldCancelUpload {
             self.startNetworkTransport(
-                videoFile: sourceAsset.url
+                videoFile: sourceAsset.url,
+                attempt: attempt
             )
         } else {
-            self.fileWorker?.cancel()
-            self.uploadManager.acknowledgeUpload(id: self.id)
-            self.input.processUploadCancellation()
+            cancelPreparation(for: attempt)
         }
+    }
+
+    private func cancelPreparation(for attempt: UploadAttempt) {
+        lifecycleLock.lock()
+        guard activeAttempt == attempt else {
+            lifecycleLock.unlock()
+            return
+        }
+
+        activeAttempt = nil
+        let fileWorker = self.fileWorker
+        self.fileWorker = nil
+        uploadManager.acknowledgeUpload(id: id)
+        let cancellationNotification = transitionInputWithoutNotifying { input in
+            input.processUploadCancellation()
+        }
+        lifecycleLock.unlock()
+
+        fileWorker?.cancel()
+        cancellationNotification?()
     }
 
     func readyForTransport() -> Bool {
@@ -682,10 +779,11 @@ public final class DirectUpload {
         }
     }
 
-    func startNetworkTransport(
-        videoFile: URL
+    private func startNetworkTransport(
+        videoFile: URL,
+        attempt: UploadAttempt
     ) {
-        guard readyForTransport() else {
+        guard isActive(attempt), readyForTransport() else {
             SDKLogger.logger?.info("Tried to start network transport before being ready")
             return
         }
@@ -702,7 +800,7 @@ public final class DirectUpload {
         )
 
         lifecycleLock.lock()
-        guard !cancellationRequested && readyForTransport() else {
+        guard activeAttempt == attempt && readyForTransport() else {
             lifecycleLock.unlock()
             fileWorker.cancel()
             return
@@ -712,9 +810,6 @@ public final class DirectUpload {
             InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
         )
         self.fileWorker = fileWorker
-        fileWorker.start()
-        lifecycleLock.unlock()
-
         uploadManager.registerUpload(self)
         let transportStatus = TransportStatus(
             progress: fileWorker.currentState.progress ?? Progress(),
@@ -722,16 +817,23 @@ public final class DirectUpload {
             startTime: Date().timeIntervalSince1970,
             isPaused: false
         )
-        self.input.processStartNetworkTransport(
-            startingTransportStatus: transportStatus
-        )
+        let transportNotification = transitionInputWithoutNotifying { input in
+            input.processStartNetworkTransport(
+                startingTransportStatus: transportStatus
+            )
+        }
+        lifecycleLock.unlock()
+
+        fileWorker.start()
+        transportNotification?()
     }
 
-    func startNetworkTransport(
+    private func startNetworkTransport(
         videoFile: URL,
-        duration: CMTime
+        duration: CMTime,
+        attempt: UploadAttempt
     ) {
-        guard readyForTransport() else {
+        guard isActive(attempt), readyForTransport() else {
             return
         }
 
@@ -745,7 +847,7 @@ public final class DirectUpload {
         )
 
         lifecycleLock.lock()
-        guard !cancellationRequested && readyForTransport() else {
+        guard activeAttempt == attempt && readyForTransport() else {
             lifecycleLock.unlock()
             fileWorker.cancel()
             return
@@ -755,9 +857,6 @@ public final class DirectUpload {
             InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
         )
         self.fileWorker = fileWorker
-        fileWorker.start(duration: duration)
-        lifecycleLock.unlock()
-
         uploadManager.registerUpload(self)
         let transportStatus = TransportStatus(
             progress: fileWorker.currentState.progress ?? Progress(),
@@ -765,9 +864,15 @@ public final class DirectUpload {
             startTime: Date().timeIntervalSince1970,
             isPaused: false
         )
-        self.input.processStartNetworkTransport(
-            startingTransportStatus: transportStatus
-        )
+        let transportNotification = transitionInputWithoutNotifying { input in
+            input.processStartNetworkTransport(
+                startingTransportStatus: transportStatus
+            )
+        }
+        lifecycleLock.unlock()
+
+        fileWorker.start(duration: duration)
+        transportNotification?()
     }
     
     
@@ -790,6 +895,7 @@ public final class DirectUpload {
     }
     
     private func cancel(notifyCaller: Bool) {
+        lifecycleLock.lock()
         let cancellationHandler = notifyCaller && !isUploadComplete() && isUploadStarted()
             ? resultHandler
             : nil
@@ -803,16 +909,18 @@ public final class DirectUpload {
         progressHandler = nil
         resultHandler = nil
 
-        lifecycleLock.lock()
-        cancellationRequested = true
+        activeAttempt = nil
         let fileWorker = self.fileWorker
         self.fileWorker = nil
+        uploadManager.acknowledgeUpload(id: id)
+        let cancellationNotification = transitionInputWithoutNotifying { input in
+            input.processUploadCancellation()
+        }
         lifecycleLock.unlock()
 
         inputInspectionOperations.cancelActive()
         fileWorker?.cancel()
-        uploadManager.acknowledgeUpload(id: id)
-        input.processUploadCancellation()
+        cancellationNotification?()
 
         cancellationHandler?(.failure(cancellationError))
     }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -189,7 +189,8 @@ public final class DirectUpload {
     private let inputInspector: UploadInputInspector
     private let inputInspectionOperations = UploadInputInspectionOperationRegistry()
     private let inputStandardizer: UploadInputStandardizing
-    private let lifecycleLock = NSRecursiveLock()
+    private let lifecycleLock = NSLock()
+    private var cancellationRequested = false
     private let fileWorkerFactory: FileWorkerFactory
 
     typealias FileWorkerFactory = (
@@ -417,6 +418,9 @@ public final class DirectUpload {
         // Start a new upload
 
         if case UploadInput.Status.ready = input.status {
+            lifecycleLock.lock()
+            cancellationRequested = false
+            lifecycleLock.unlock()
             input.status = .started(input.sourceAsset, uploadInfo)
             startInspection(sourceAsset: input.sourceAsset)
         } else if forceRestart {
@@ -681,9 +685,6 @@ public final class DirectUpload {
     func startNetworkTransport(
         videoFile: URL
     ) {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
         guard readyForTransport() else {
             SDKLogger.logger?.info("Tried to start network transport before being ready")
             return
@@ -699,13 +700,22 @@ public final class DirectUpload {
             ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
             completedUnitCount
         )
+
+        lifecycleLock.lock()
+        guard !cancellationRequested && readyForTransport() else {
+            lifecycleLock.unlock()
+            fileWorker.cancel()
+            return
+        }
         fileWorker.addDelegate(
             withToken: id,
             InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
         )
         self.fileWorker = fileWorker
-        uploadManager.registerUpload(self)
         fileWorker.start()
+        lifecycleLock.unlock()
+
+        uploadManager.registerUpload(self)
         let transportStatus = TransportStatus(
             progress: fileWorker.currentState.progress ?? Progress(),
             updatedTime: Date().timeIntervalSince1970,
@@ -715,16 +725,12 @@ public final class DirectUpload {
         self.input.processStartNetworkTransport(
             startingTransportStatus: transportStatus
         )
-        inputStatusHandler?(inputStatus)
     }
 
     func startNetworkTransport(
         videoFile: URL,
         duration: CMTime
     ) {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-
         guard readyForTransport() else {
             return
         }
@@ -737,13 +743,22 @@ public final class DirectUpload {
             ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
             completedUnitCount
         )
+
+        lifecycleLock.lock()
+        guard !cancellationRequested && readyForTransport() else {
+            lifecycleLock.unlock()
+            fileWorker.cancel()
+            return
+        }
         fileWorker.addDelegate(
             withToken: id,
             InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
         )
         self.fileWorker = fileWorker
-        uploadManager.registerUpload(self)
         fileWorker.start(duration: duration)
+        lifecycleLock.unlock()
+
+        uploadManager.registerUpload(self)
         let transportStatus = TransportStatus(
             progress: fileWorker.currentState.progress ?? Progress(),
             updatedTime: Date().timeIntervalSince1970,
@@ -753,7 +768,6 @@ public final class DirectUpload {
         self.input.processStartNetworkTransport(
             startingTransportStatus: transportStatus
         )
-        inputStatusHandler?(inputStatus)
     }
     
     
@@ -776,28 +790,31 @@ public final class DirectUpload {
     }
     
     private func cancel(notifyCaller: Bool) {
-        if notifyCaller && !isUploadComplete() && isUploadStarted() {
-            resultHandler?(.failure(
-                DirectUploadError(
-                    lastStatus: uploadStatus,
-                    kind: .cancelled,
-                    message: "Upload was cancelled by caller",
-                    reason: nil
-                )
-            ))
-        }
+        let cancellationHandler = notifyCaller && !isUploadComplete() && isUploadStarted()
+            ? resultHandler
+            : nil
+        let cancellationError = DirectUploadError(
+            lastStatus: uploadStatus,
+            kind: .cancelled,
+            message: "Upload was cancelled by caller",
+            reason: nil
+        )
+
+        progressHandler = nil
+        resultHandler = nil
 
         lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
+        cancellationRequested = true
+        let fileWorker = self.fileWorker
+        self.fileWorker = nil
+        lifecycleLock.unlock()
 
         inputInspectionOperations.cancelActive()
         fileWorker?.cancel()
-        fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
         input.processUploadCancellation()
-        
-        progressHandler = nil
-        resultHandler = nil
+
+        cancellationHandler?(.failure(cancellationError))
     }
     
     private func isUploadStarted() -> Bool {

--- a/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
+++ b/Sources/MuxUploadSDK/Upload/ChunkedFileUploader.swift
@@ -91,6 +91,9 @@ class ChunkedFileUploader {
         case .uploading(_): do {
             notifyStateFromMain(.canceled)
         }
+        case .ready: fallthrough
+        case .paused:
+            currentState = .canceled
         default: do {}
         }
     }

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
@@ -431,7 +431,7 @@ final class StandardInputOutputValidatorTests: XCTestCase {
         )
     }
 
-    func testGeneratedOutputAcceptsDurationAndAVOffsetWithinNAT480Bounds() throws {
+    func testGeneratedOutputAcceptsDurationAndAVOffsetWithinBounds() throws {
         var sourceFacts = compliantFacts(codec: .hevc)
         sourceFacts.maximumKeyframeInterval = .known(11)
         let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
@@ -446,7 +446,7 @@ final class StandardInputOutputValidatorTests: XCTestCase {
         XCTAssertEqual(validation.disposition, .accepted)
     }
 
-    func testGeneratedOutputRejectsDurationOutsideNAT480Bound() throws {
+    func testGeneratedOutputRejectsDurationOutsideBound() throws {
         var sourceFacts = compliantFacts(codec: .hevc)
         sourceFacts.maximumKeyframeInterval = .known(11)
         let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
@@ -479,7 +479,7 @@ final class StandardInputOutputValidatorTests: XCTestCase {
         XCTAssertEqual(validation.disposition, .accepted)
     }
 
-    func testGeneratedOutputRejectsAVOffsetOutsideNAT480Bound() throws {
+    func testGeneratedOutputRejectsAVOffsetOutsideBound() throws {
         var sourceFacts = compliantFacts(codec: .hevc)
         sourceFacts.maximumKeyframeInterval = .known(11)
         let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
@@ -1,0 +1,734 @@
+//
+//  StandardInputPlannerTests.swift
+//
+
+import XCTest
+@testable import MuxUploadSDK
+
+final class StandardInputPlannerTests: XCTestCase {
+    private let planner = StandardInputPlanner()
+
+    func testCompliantH264UploadsOriginal() {
+        let plan = planner.plan(
+            facts: compliantFacts(),
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(plan.action, .uploadOriginal(.standardInput))
+    }
+
+    func testUnknownFactAloneDoesNotTriggerConversion() {
+        var facts = compliantFacts()
+        facts.maximumGOPBitrate = .unknown
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(
+            plan.action,
+            .uploadOriginal(.noKnownStandardInputViolation)
+        )
+        XCTAssertEqual(plan.evaluation.outcome, .unknown)
+    }
+
+    func testKnownH264ViolationSelectsH264Conversion() throws {
+        var facts = compliantFacts()
+        facts.frameRate = .known(121)
+
+        let conversion = try XCTUnwrap(conversion(for: facts))
+
+        XCTAssertEqual(conversion.sourceCodec, .h264)
+        XCTAssertEqual(conversion.outputCodec, .h264)
+        XCTAssertEqual(conversion.requirementsToRemediate, [.frameRate])
+        XCTAssertFalse(conversion.toneMapsToSDR)
+    }
+
+    func testSelectedMaximumResolutionTriggersConversionBelowPublishedSourceLimit() throws {
+        let facts = compliantFacts(
+            dimensions: .init(width: 2048, height: 1152)
+        )
+
+        let conversion = try XCTUnwrap(conversion(for: facts))
+
+        XCTAssertEqual(conversion.requirementsToRemediate, [.videoResolution])
+        XCTAssertEqual(
+            conversion.selection.generatedOutputDimensions,
+            .init(width: 1920, height: 1080)
+        )
+        XCTAssertEqual(conversion.outputCodec, .h264)
+    }
+
+    func testKnownHEVCViolationSelectsHEVCConversion() throws {
+        var facts = compliantFacts(codec: .hevc)
+        facts.maximumKeyframeInterval = .known(11)
+
+        let conversion = try XCTUnwrap(conversion(for: facts))
+
+        XCTAssertEqual(conversion.sourceCodec, .hevc)
+        XCTAssertEqual(conversion.outputCodec, .hevc)
+        XCTAssertEqual(conversion.requirementsToRemediate, [.keyframeInterval])
+    }
+
+    func testLocallyDecodableOtherCodecSelectsH264Conversion() throws {
+        var facts = compliantFacts(codec: .other)
+        facts.pixelFormat = .known(
+            .init(bitDepth: 10, chromaSubsampling: .other)
+        )
+
+        let conversion = try XCTUnwrap(conversion(for: facts))
+
+        XCTAssertEqual(conversion.sourceCodec, .other)
+        XCTAssertEqual(conversion.outputCodec, .h264)
+        XCTAssertTrue(conversion.requirementsToRemediate.contains(.videoCodec))
+    }
+
+    func testUnsupportedConversionSelectsFallback() {
+        var facts = compliantFacts(codec: .hevc)
+        facts.maximumKeyframeInterval = .known(11)
+        var capabilities = fullCapabilities()
+        capabilities.encodableVideoCodecs.remove(.hevc)
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: capabilities
+        )
+
+        guard case .fallback(.unsupportedConversion(let conversion)) = plan.action else {
+            return XCTFail("Expected unsupported-conversion fallback")
+        }
+        XCTAssertEqual(conversion.outputCodec, .hevc)
+    }
+
+    func testUndecodableSourceSelectsFallback() {
+        var facts = compliantFacts(codec: .other)
+        facts.pixelFormat = .known(
+            .init(bitDepth: 10, chromaSubsampling: .other)
+        )
+        var capabilities = fullCapabilities()
+        capabilities.sourceIsDecodable = false
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: capabilities
+        )
+
+        guard case .fallback(.unsupportedConversion(let conversion)) = plan.action else {
+            return XCTFail("Expected unsupported-conversion fallback")
+        }
+        XCTAssertEqual(conversion.sourceCodec, .other)
+    }
+
+    func testUnremediableViolationSelectsFallback() {
+        var facts = compliantFacts()
+        facts.editList = .known(.complex)
+        var capabilities = fullCapabilities()
+        capabilities.remediableRequirements.remove(.editList)
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: capabilities
+        )
+
+        guard case .fallback(.unsupportedConversion(let conversion)) = plan.action else {
+            return XCTFail("Expected unsupported-conversion fallback")
+        }
+        XCTAssertEqual(conversion.requirementsToRemediate, [.editList])
+    }
+
+    func testSkippedStandardizationUploadsOriginalWithoutPlanningConversion() {
+        var facts = compliantFacts()
+        facts.frameRate = .known(121)
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .skipped,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(
+            plan.action,
+            .uploadOriginal(.standardizationNotRequested)
+        )
+        XCTAssertEqual(plan.evaluation.outcome, .nonCompliant)
+    }
+
+    func testMissingCodecOrDynamicRangeUsesFallbackWhenConversionIsNeeded() {
+        var missingCodec = compliantFacts()
+        missingCodec.videoCodec = .unknown
+        missingCodec.frameRate = .known(121)
+
+        var missingDynamicRange = compliantFacts()
+        missingDynamicRange.dynamicRange = .unknown
+        missingDynamicRange.frameRate = .known(121)
+
+        for facts in [missingCodec, missingDynamicRange] {
+            let plan = planner.plan(
+                facts: facts,
+                options: .default,
+                capabilities: fullCapabilities()
+            )
+            XCTAssertEqual(
+                plan.action,
+                .fallback(.insufficientEvidenceForConversion)
+            )
+        }
+    }
+
+    func testEligiblePreservedHDRUploadsOriginalIntentionally() {
+        for dynamicRange in [StandardInputDynamicRange.hlg, .pq] {
+            let plan = planner.plan(
+                facts: compliantHDRFacts(dynamicRange: dynamicRange),
+                options: .default,
+                capabilities: fullCapabilities()
+            )
+
+            XCTAssertEqual(
+                plan.action,
+                .uploadOriginal(.preserveHDR(dynamicRange))
+            )
+        }
+    }
+
+    func testPreservedHDRWithNonColorViolationUsesFallback() {
+        var facts = compliantHDRFacts(dynamicRange: .hlg)
+        facts.averageBitrate = .known(8_000_001)
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(
+            plan.action,
+            .fallback(.nonStandardHDR(.hlg, [.averageBitrate]))
+        )
+    }
+
+    func testUnavailableHDRPreservationUsesFallback() {
+        let plan = planner.plan(
+            facts: compliantHDRFacts(dynamicRange: .pq),
+            options: .default,
+            capabilities: fullCapabilities(preservableHDR: [.hlg])
+        )
+
+        XCTAssertEqual(
+            plan.action,
+            .fallback(.hdrPreservationUnavailable(.pq))
+        )
+    }
+
+    func testHDRWithUnknownEligibilityUsesFallback() {
+        var facts = compliantHDRFacts(dynamicRange: .hlg)
+        facts.pixelFormat = .unknown
+
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(plan.action, .fallback(.unsupportedHDR(.hlg)))
+    }
+
+    func testToneMappingPreservesHEVCCodecFamily() throws {
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .default,
+            hdrHandling: .toneMapToSDR
+        )
+        let plan = planner.plan(
+            facts: compliantHDRFacts(dynamicRange: .hlg),
+            options: options,
+            capabilities: fullCapabilities()
+        )
+
+        guard case .convert(let conversion) = plan.action else {
+            return XCTFail("Expected tone-map conversion")
+        }
+        XCTAssertEqual(conversion.sourceCodec, .hevc)
+        XCTAssertEqual(conversion.outputCodec, .hevc)
+        XCTAssertEqual(conversion.sourceDynamicRange, .hlg)
+        XCTAssertTrue(conversion.toneMapsToSDR)
+    }
+
+    func testUnsupportedToneMappingUsesFallback() {
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .default,
+            hdrHandling: .toneMapToSDR
+        )
+        let plan = planner.plan(
+            facts: compliantHDRFacts(dynamicRange: .pq),
+            options: options,
+            capabilities: fullCapabilities(toneMappableHDR: [.hlg])
+        )
+
+        guard case .fallback(.unsupportedConversion(let conversion)) = plan.action else {
+            return XCTFail("Expected unsupported-conversion fallback")
+        }
+        XCTAssertTrue(conversion.toneMapsToSDR)
+    }
+
+    func testUnknownOrUnsupportedHDRUsesFallback() {
+        var otherHDRFacts = compliantFacts()
+        otherHDRFacts.dynamicRange = .known(.otherHDR)
+
+        let plan = planner.plan(
+            facts: otherHDRFacts,
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+
+        XCTAssertEqual(plan.action, .fallback(.unsupportedHDR(.otherHDR)))
+    }
+
+    private func conversion(
+        for facts: StandardInputMediaFacts
+    ) -> StandardInputConversion? {
+        let plan = planner.plan(
+            facts: facts,
+            options: .default,
+            capabilities: fullCapabilities()
+        )
+        guard case .convert(let conversion) = plan.action else {
+            return nil
+        }
+        return conversion
+    }
+
+    private func fullCapabilities(
+        toneMappableHDR: Set<StandardInputDynamicRange> = [.hlg, .pq],
+        preservableHDR: Set<StandardInputDynamicRange> = [.hlg, .pq]
+    ) -> StandardInputPlanningCapabilities {
+        StandardInputPlanningCapabilities(
+            sourceIsDecodable: true,
+            encodableVideoCodecs: [.h264, .hevc],
+            remediableRequirements: Set(
+                StandardInputPolicyEvaluation.Requirement.allCases
+            ),
+            toneMappableDynamicRanges: toneMappableHDR,
+            preservableHDRDynamicRanges: preservableHDR
+        )
+    }
+}
+
+final class StandardInputOutputValidatorTests: XCTestCase {
+    private let validator = StandardInputOutputValidator()
+
+    func testFullyCompliantPolicyOutputIsAccepted() {
+        let validation = validator.validatePolicyCompliance(
+            facts: compliantFacts(),
+            maximumResolution: .default
+        )
+
+        XCTAssertTrue(validation.isAccepted)
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testKnownGeneratedOutputViolationIsRejected() {
+        var facts = compliantFacts()
+        facts.displayDimensions = .known(.init(width: 2048, height: 1152))
+
+        let validation = validator.validatePolicyCompliance(
+            facts: facts,
+            maximumResolution: .default
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.nonCompliant([.videoResolution]))
+        )
+    }
+
+    func testInsufficientGeneratedOutputEvidenceIsRejected() {
+        var facts = compliantFacts()
+        facts.maximumGOPBitrate = .unknown
+
+        let validation = validator.validatePolicyCompliance(
+            facts: facts,
+            maximumResolution: .default
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.insufficientPolicyEvidence([.maximumGOPBitrate]))
+        )
+    }
+
+    func testHighResolutionOutputDoesNotRequireUnpublishedGOPBitrateLimit() {
+        var facts = compliantFacts(
+            codec: .hevc,
+            dimensions: .init(width: 3840, height: 2160),
+            frameRate: 60,
+            averageBitrate: 20_000_000,
+            maximumKeyframeInterval: 6
+        )
+        facts.maximumGOPBitrate = .unknown
+
+        let validation = validator.validatePolicyCompliance(
+            facts: facts,
+            maximumResolution: .preset3840x2160
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testGeneratedOutputMustPreservePlannedCodec() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(codec: .h264)
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.videoCodec]))
+        )
+    }
+
+    func testToneMappedOutputMustBeSDR() throws {
+        let sourceFacts = compliantHDRFacts(dynamicRange: .hlg)
+        let options = DirectUploadOptions.InputStandardization(
+            maximumResolution: .default,
+            hdrHandling: .toneMapToSDR
+        )
+        let plan = StandardInputPlanner().plan(
+            facts: sourceFacts,
+            options: options,
+            capabilities: fullTestCapabilities()
+        )
+        guard case .convert(let conversion) = plan.action else {
+            return XCTFail("Expected tone-map conversion")
+        }
+
+        let outputFacts = compliantFacts(codec: .hevc)
+        var unexpectedHDROutput = outputFacts
+        unexpectedHDROutput.pixelFormat = sourceFacts.pixelFormat
+        unexpectedHDROutput.dynamicRange = sourceFacts.dynamicRange
+
+        let validation = validator.validateGeneratedOutput(
+            facts: unexpectedHDROutput,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.dynamicRange]))
+        )
+    }
+
+    func testGeneratedOutputAcceptsDurationAndAVOffsetWithinNAT480Bounds() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc),
+            sourceTimeline: validTimeline(duration: 10, offset: 0.010),
+            outputTimeline: validTimeline(duration: 10.049, offset: 0.059),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testGeneratedOutputRejectsDurationOutsideNAT480Bound() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc),
+            sourceTimeline: validTimeline(duration: 8.115),
+            outputTimeline: validTimeline(duration: 8.166667),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.duration]))
+        )
+    }
+
+    func testGeneratedOutputUsesOneFrameDurationBoundBelow20FPS() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc, frameRate: 15),
+            sourceTimeline: validTimeline(duration: 10),
+            outputTimeline: validTimeline(duration: 10.060),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testGeneratedOutputRejectsAVOffsetOutsideNAT480Bound() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc),
+            sourceTimeline: validTimeline(offset: -0.071),
+            outputTimeline: validTimeline(offset: -0.020),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.audioVideoStartOffset]))
+        )
+    }
+
+    func testGeneratedOutputRejectsMissingIntegrityEvidence() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc),
+            sourceTimeline: StandardInputTimelineFacts(),
+            outputTimeline: StandardInputTimelineFacts(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(
+                .insufficientPlanEvidence([
+                    .duration,
+                    .audioVideoStartOffset
+                ])
+            )
+        )
+    }
+
+    func testGeneratedOutputReportsKnownMismatchBeforeMissingEvidence() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .h264),
+            sourceTimeline: StandardInputTimelineFacts(),
+            outputTimeline: StandardInputTimelineFacts(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.videoCodec]))
+        )
+    }
+
+    func testGeneratedOutputRejectsChangedDisplayAspectRatio() throws {
+        var sourceFacts = compliantFacts()
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(
+            dimensions: .init(width: 1440, height: 1080)
+        )
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.displayAspectRatio]))
+        )
+    }
+
+    func testGeneratedOutputAcceptsPreservedPortraitAspectRatio() throws {
+        var sourceFacts = compliantFacts(
+            dimensions: .init(width: 1080, height: 1920)
+        )
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(
+            dimensions: .init(width: 720, height: 1280)
+        )
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testGeneratedOutputAcceptsEvenAlignedAspectRatioRounding() throws {
+        var sourceFacts = compliantFacts(
+            dimensions: .init(width: 1918, height: 1080)
+        )
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(
+            dimensions: .init(width: 1280, height: 720)
+        )
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    func testGeneratedOutputRejectsMissingSourceAspectRatioEvidence() throws {
+        var sourceFacts = compliantFacts()
+        sourceFacts.displayDimensions = .unknown
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(),
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.insufficientPlanEvidence([.displayAspectRatio]))
+        )
+    }
+
+    func testGeneratedOutputRejectsChangedAVApplicability() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+
+        let validation = validator.validateGeneratedOutput(
+            facts: compliantFacts(codec: .hevc),
+            sourceTimeline: validTimeline(offset: nil),
+            outputTimeline: validTimeline(offset: 0),
+            for: conversion
+        )
+
+        XCTAssertEqual(
+            validation.disposition,
+            .rejected(.doesNotMatchPlan([.audioVideoStartOffset]))
+        )
+    }
+
+    func testGeneratedVideoOnlyOutputDoesNotRequireAVOffset() throws {
+        var sourceFacts = compliantFacts(codec: .hevc)
+        sourceFacts.maximumKeyframeInterval = .known(11)
+        sourceFacts.audio = .known(.none)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        var outputFacts = compliantFacts(codec: .hevc)
+        outputFacts.audio = .known(.none)
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(offset: nil),
+            outputTimeline: validTimeline(offset: nil),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
+    private func makeConversion(
+        facts: StandardInputMediaFacts
+    ) -> StandardInputConversion? {
+        let plan = StandardInputPlanner().plan(
+            facts: facts,
+            options: .default,
+            capabilities: fullTestCapabilities()
+        )
+        guard case .convert(let conversion) = plan.action else {
+            return nil
+        }
+        return conversion
+    }
+
+    private func validTimeline(
+        duration: TimeInterval = 10,
+        offset: TimeInterval? = 0
+    ) -> StandardInputTimelineFacts {
+        StandardInputTimelineFacts(
+            duration: .known(duration),
+            audioVideoStartOffset: .known(
+                offset.map(StandardInputTimelineFacts.AudioVideoStartOffset.seconds)
+                    ?? .notApplicable
+            )
+        )
+    }
+}
+
+private func compliantHDRFacts(
+    dynamicRange: StandardInputDynamicRange
+) -> StandardInputMediaFacts {
+    compliantFacts(
+        codec: .hevc,
+        maximumKeyframeInterval: 10,
+        pixelFormat: .init(bitDepth: 10, chromaSubsampling: .yuv420),
+        dynamicRange: dynamicRange
+    )
+}
+
+private func compliantFacts(
+    codec: StandardInputVideoCodec = .h264,
+    dimensions: StandardInputDisplayDimensions = .init(width: 1920, height: 1080),
+    frameRate: Double = 30,
+    averageBitrate: Int64 = 4_000_000,
+    maximumKeyframeInterval: TimeInterval = 2,
+    pixelFormat: StandardInputPixelFormat = .init(
+        bitDepth: 8,
+        chromaSubsampling: .yuv420
+    ),
+    dynamicRange: StandardInputDynamicRange = .sdr
+) -> StandardInputMediaFacts {
+    StandardInputMediaFacts(
+        videoCodec: .known(codec),
+        displayDimensions: .known(dimensions),
+        frameRate: .known(frameRate),
+        averageBitrate: .known(averageBitrate),
+        maximumGOPBitrate: .known(5_000_000),
+        maximumGOPByteSize: .unknown,
+        maximumKeyframeInterval: .known(maximumKeyframeInterval),
+        gopStructure: .known(.closedWithIDR),
+        pixelFormat: .known(pixelFormat),
+        dynamicRange: .known(dynamicRange),
+        audio: .known(.aac(.stereo)),
+        editList: .known(.simple)
+    )
+}
+
+private func fullTestCapabilities() -> StandardInputPlanningCapabilities {
+    StandardInputPlanningCapabilities(
+        sourceIsDecodable: true,
+        encodableVideoCodecs: [.h264, .hevc],
+        remediableRequirements: Set(
+            StandardInputPolicyEvaluation.Requirement.allCases
+        ),
+        toneMappableDynamicRanges: [.hlg, .pq],
+        preservableHDRDynamicRanges: [.hlg, .pq]
+    )
+}

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
@@ -599,6 +599,26 @@ final class StandardInputOutputValidatorTests: XCTestCase {
         XCTAssertEqual(validation.disposition, .accepted)
     }
 
+    func testGeneratedOutputAcceptsPortraitAlignmentWithinPixelBudget() throws {
+        var sourceFacts = compliantFacts(
+            dimensions: .init(width: 1080, height: 1920)
+        )
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(
+            dimensions: .init(width: 718, height: 1280)
+        )
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
     func testGeneratedOutputRejectsMissingSourceAspectRatioEvidence() throws {
         var sourceFacts = compliantFacts()
         sourceFacts.displayDimensions = .unknown

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -175,6 +175,9 @@ class DirectUploadTests: XCTestCase {
         let cancellationFinished = expectation(
             description: "Cancellation finished"
         )
+        let cancellationReported = expectation(
+            description: "Cancellation was reported after cleanup"
+        )
         let allowWorkerCreation = DispatchSemaphore(value: 0)
         let upload = DirectUpload(
             input: input,
@@ -191,6 +194,17 @@ class DirectUploadTests: XCTestCase {
                 )
             }
         )
+        upload.resultHandler = { result in
+            guard case .failure(let error) = result,
+                  error.kind == .cancelled else {
+                return XCTFail("Expected cancellation failure")
+            }
+            XCTAssertNil(upload.fileWorker)
+            guard case .ready = upload.inputStatus else {
+                return XCTFail("Expected cleanup before cancellation reporting")
+            }
+            cancellationReported.fulfill()
+        }
 
         upload.start()
 
@@ -208,7 +222,7 @@ class DirectUploadTests: XCTestCase {
         wait(for: [cancellationAttempted], timeout: 1.0)
         allowWorkerCreation.signal()
         wait(
-            for: [completionFinished, cancellationFinished],
+            for: [completionFinished, cancellationFinished, cancellationReported],
             timeout: 1.0
         )
 

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -159,12 +159,12 @@ class DirectUploadTests: XCTestCase {
         }
     }
 
-    func testCancelWaitsForClaimedInspectionTransportTransition() throws {
+    func testCancelAndRestartInvalidateClaimedInspectionTransportTransition() throws {
         let input = try UploadInput.mockReadyInput()
         let inspector = MockUploadInputInspector()
         inspector.shouldDeferCompletion = true
         let factoryEntered = expectation(
-            description: "Transport passed its readiness check"
+            description: "Old attempt began worker creation"
         )
         let completionFinished = expectation(
             description: "Inspection completion finished"
@@ -179,9 +179,10 @@ class DirectUploadTests: XCTestCase {
             description: "Cancellation was reported after cleanup"
         )
         let allowWorkerCreation = DispatchSemaphore(value: 0)
+        let uploadManager = DirectUploadManager()
         let upload = DirectUpload(
             input: input,
-            uploadManager: DirectUploadManager(),
+            uploadManager: uploadManager,
             inputInspector: inspector,
             fileWorkerFactory: { uploadInfo, inputFileURL, file, startingByte in
                 factoryEntered.fulfill()
@@ -220,16 +221,25 @@ class DirectUploadTests: XCTestCase {
             cancellationFinished.fulfill()
         }
         wait(for: [cancellationAttempted], timeout: 1.0)
-        allowWorkerCreation.signal()
         wait(
-            for: [completionFinished, cancellationFinished, cancellationReported],
+            for: [cancellationFinished, cancellationReported],
             timeout: 1.0
         )
 
-        XCTAssertNil(upload.fileWorker)
-        guard case .ready = upload.inputStatus else {
-            return XCTFail("Expected cancellation to reset the upload to ready")
+        upload.start()
+        guard case .preparing = upload.inputStatus else {
+            return XCTFail("Expected the new attempt to remain under inspection")
         }
+
+        allowWorkerCreation.signal()
+        wait(for: [completionFinished], timeout: 1.0)
+
+        XCTAssertNil(upload.fileWorker)
+        XCTAssertTrue(uploadManager.allManagedDirectUploads().isEmpty)
+        guard case .preparing = upload.inputStatus else {
+            return XCTFail("Expected the old attempt not to advance the new attempt")
+        }
+        upload.cancel()
     }
 
     func testInputInspectionFailure() throws {

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -141,7 +141,7 @@ class DirectUploadTests: XCTestCase {
                 registry.claimCompletion(for: token)
             }
             let cancellationTask = Task.detached {
-                registry.cancelActive()
+                registry.cancel(for: token)
             }
             let completionClaimed = await completionTask.value
             let cancellationClaimed = await cancellationTask.value
@@ -157,6 +157,23 @@ class DirectUploadTests: XCTestCase {
                 "Cancellation must reach the operation only when it wins the claim"
             )
         }
+    }
+
+    func testCancellingPreviousInspectionDoesNotCancelReplacement() {
+        let registry = UploadInputInspectionOperationRegistry()
+        let previousToken = UploadInputInspectionOperationRegistry.Token()
+        let replacementToken = UploadInputInspectionOperationRegistry.Token()
+        let previousOperation = UploadInputInspectionOperation { _, _, _ in }
+        let replacementOperation = UploadInputInspectionOperation { _, _, _ in }
+
+        registry.register(previousOperation, for: previousToken)
+        registry.register(replacementOperation, for: replacementToken)
+
+        XCTAssertFalse(registry.cancel(for: previousToken))
+        XCTAssertTrue(previousOperation.isCancelled)
+        XCTAssertFalse(replacementOperation.isCancelled)
+        XCTAssertTrue(registry.cancel(for: replacementToken))
+        XCTAssertTrue(replacementOperation.isCancelled)
     }
 
     func testCancelAndRestartInvalidateClaimedInspectionTransportTransition() throws {

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -159,6 +159,65 @@ class DirectUploadTests: XCTestCase {
         }
     }
 
+    func testCancelWaitsForClaimedInspectionTransportTransition() throws {
+        let input = try UploadInput.mockReadyInput()
+        let inspector = MockUploadInputInspector()
+        inspector.shouldDeferCompletion = true
+        let factoryEntered = expectation(
+            description: "Transport passed its readiness check"
+        )
+        let completionFinished = expectation(
+            description: "Inspection completion finished"
+        )
+        let cancellationAttempted = expectation(
+            description: "Cancellation was invoked"
+        )
+        let cancellationFinished = expectation(
+            description: "Cancellation finished"
+        )
+        let allowWorkerCreation = DispatchSemaphore(value: 0)
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: inspector,
+            fileWorkerFactory: { uploadInfo, inputFileURL, file, startingByte in
+                factoryEntered.fulfill()
+                allowWorkerCreation.wait()
+                return ChunkedFileUploader(
+                    uploadInfo: uploadInfo,
+                    inputFileURL: inputFileURL,
+                    file: file,
+                    startingByte: startingByte
+                )
+            }
+        )
+
+        upload.start()
+
+        DispatchQueue.global().async {
+            inspector.completeDeferredInspection()
+            completionFinished.fulfill()
+        }
+        wait(for: [factoryEntered], timeout: 1.0)
+
+        DispatchQueue.global().async {
+            cancellationAttempted.fulfill()
+            upload.cancel()
+            cancellationFinished.fulfill()
+        }
+        wait(for: [cancellationAttempted], timeout: 1.0)
+        allowWorkerCreation.signal()
+        wait(
+            for: [completionFinished, cancellationFinished],
+            timeout: 1.0
+        )
+
+        XCTAssertNil(upload.fileWorker)
+        guard case .ready = upload.inputStatus else {
+            return XCTFail("Expected cancellation to reset the upload to ready")
+        }
+    }
+
     func testInputInspectionFailure() throws {
         let input = try UploadInput.mockReadyInput()
 

--- a/Tests/MuxUploadSDKTests/Upload Tests/ChunkedFileUploaderTests.swift
+++ b/Tests/MuxUploadSDKTests/Upload Tests/ChunkedFileUploaderTests.swift
@@ -10,6 +10,28 @@ import XCTest
 
 final class ChunkedFileUploaderTests: XCTestCase {
 
+    func testCancelBeforeStartPreventsLaterStart() throws {
+        let uploadInfo = UploadInfo(
+            uploadURL: try XCTUnwrap(URL(string: "https://www.example.com/upload")),
+            options: .default
+        )
+        let inputFileURL = try XCTUnwrap(
+            URL(string: "file://path/to/dummy/file/cancelled")
+        )
+        let uploader = ChunkedFileUploader(
+            uploadInfo: uploadInfo,
+            inputFileURL: inputFileURL,
+            file: ChunkedFile(chunkSize: 1000)
+        )
+
+        uploader.cancel()
+        uploader.start()
+
+        guard case .canceled = uploader.currentState else {
+            return XCTFail("Expected cancellation to remain terminal")
+        }
+    }
+
     func testPersistenceStateUsesLastSuccessfulByteForUploadingProgress() throws {
         let uploadInfo = UploadInfo(
             uploadURL: try XCTUnwrap(URL(string: "https://www.example.com/upload")),


### PR DESCRIPTION
## Summary

- add a pure Standard Input planner that selects original upload, same-codec conversion, H.264 conversion, or fallback from inspected facts, customer options, and source/device capabilities
- preserve eligible HLG/PQ input intentionally by default, while keeping SDR tone mapping opt-in and codec-family preserving
- add conservative generated-output validation that reuses the Standard Input policy and rejects missing evidence or mismatches in codec, dynamic range, aspect ratio, effective duration, and A/V-start offset
- allow ordinary even-dimension encoder alignment, bound duration changes to one output frame or 50 ms, and keep A/V-start-offset drift limited to 50 ms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core DirectUpload cancel/restart concurrency and the decision path for input standardization. Pure planner/validator logic is well-tested, but lifecycle races remain high-impact if mishandled.
> 
> **Overview**
> Adds a pure **Standard Input planner** and **generated-output validator**, and hardens `DirectUpload` cancel/restart so stale inspection or transport work cannot advance a newer attempt.
> 
> `StandardInputPlanner` chooses upload-original, same-codec (or H.264) conversion, or fallback from inspected facts, customer options, and device capabilities. Eligible HLG/PQ is preserved by default; SDR tone mapping stays opt-in and codec-family preserving.
> 
> `StandardInputOutputValidator` rechecks policy compliance plus plan match for codec, dynamic range, aspect ratio, duration, and A/V-start offset, with tight tolerances (one frame/50ms duration, 50ms A/V offset, even-dimension rounding).
> 
> Separately, `DirectUpload` tracks an `UploadAttempt`, scopes inspection cancel by token, and locks lifecycle transitions so cancel/restart cannot race into transport. `ChunkedFileUploader.cancel()` is now terminal before start.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bd120bc1a257d73888b00fbdf6a4eee33cf0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->