### PR TITLE
NAT-487: Build the codec-preserving reader/writer conversion pipeline

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
@@ -270,7 +270,7 @@ enum AVFoundationUploadInputMetadataReader {
         return .unknown
     }
 
-    private static func codecConfiguration(
+    static func codecConfiguration(
         codec: StandardInputVideoCodec,
         extensions: NSDictionary
     ) -> StandardInputPixelFormat? {

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -9,15 +9,14 @@ import CoreVideo
 import Foundation
 import VideoToolbox
 
-protocol UploadInputStandardizationWorking: AnyObject {
+protocol UploadInputStandardizationWorking: AnyObject, Sendable {
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
-    )
+        outputURL: URL
+    ) async throws -> AVURLAsset
 
-    func cancel()
+    func cancel() async
 }
 
 struct StandardizationError: LocalizedError {
@@ -76,9 +75,7 @@ struct StandardizationError: LocalizedError {
     )
 }
 
-final class UploadInputStandardizationWorker {
-    typealias Completion = (AVURLAsset, AVAsset?, Error?) -> Void
-
+actor UploadInputStandardizationWorker {
     private enum State {
         case active
         case cancelled
@@ -104,345 +101,215 @@ final class UploadInputStandardizationWorker {
         }
     }
 
-    private final class UncheckedSendableBox<Value>: @unchecked Sendable {
-        let value: Value
-
-        init(_ value: Value) {
-            self.value = value
-        }
+    private enum TransferError: Error {
+        case appendFailed
+        case startedMoreThanOnce
     }
 
-    final class TransferGroup {
-        private let lock = NSLock()
-        private let dispatchGroup = DispatchGroup()
-        private var unfinishedTrackIDs: Set<Int>
-        private var stopping = false
-        private var failed = false
-
-        init(trackCount: Int) {
-            unfinishedTrackIDs = Set(0..<trackCount)
-            for _ in 0..<trackCount {
-                dispatchGroup.enter()
-            }
-        }
-
-        var shouldContinue: Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return !stopping
-        }
-
-        var didFail: Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return failed
-        }
-
-        func stop(failed: Bool = false) -> [Int] {
-            lock.lock()
-            stopping = true
-            self.failed = self.failed || failed
-            let trackIDs = Array(unfinishedTrackIDs)
-            lock.unlock()
-            return trackIDs
-        }
-
-        func claimFinish(trackID: Int) -> Bool {
-            lock.lock()
-            let claimed = unfinishedTrackIDs.remove(trackID) != nil
-            lock.unlock()
-            return claimed
-        }
-
-        func leave() {
-            dispatchGroup.leave()
-        }
-
-        func notify(queue: DispatchQueue, completion: @escaping () -> Void) {
-            dispatchGroup.notify(queue: queue, execute: completion)
-        }
-    }
-
-    private final class TransferTrack {
-        let id: Int
+    /// `requestMediaDataWhenReady` is the pull-style writer API available on
+    /// the iOS 15 deployment floor. This adapter is the only unchecked
+    /// sendability boundary: it owns its AVFoundation objects, and every
+    /// access to them and to its mutable terminal state occurs on `queue`.
+    private final class LegacySampleTransfer: @unchecked Sendable {
         let output: AVAssetReaderOutput
         let input: AVAssetWriterInput
-        let queue: DispatchQueue
+        private let queue: DispatchQueue
+        private var continuation: CheckedContinuation<Void, Error>?
+        private var terminalResult: Result<Void, Error>?
+        private var didStart = false
 
         init(
-            id: Int,
             output: AVAssetReaderOutput,
             input: AVAssetWriterInput,
             queue: DispatchQueue
         ) {
-            self.id = id
             self.output = output
             self.input = input
             self.queue = queue
         }
-    }
 
-    private final class TransferCoordinator {
-        let group: TransferGroup
-        private let tracks: [TransferTrack]
-
-        init(tracks: [TransferTrack]) {
-            self.tracks = tracks
-            group = TransferGroup(trackCount: tracks.count)
-        }
-
-        func start() {
-            for track in tracks {
-                let trackBox = UncheckedSendableBox(track)
-                let coordinatorBox = UncheckedSendableBox(self)
-                track.input.requestMediaDataWhenReady(on: track.queue) {
-                    let track = trackBox.value
-                    let coordinator = coordinatorBox.value
-                    guard coordinator.group.shouldContinue else { return }
-
-                    while track.input.isReadyForMoreMediaData,
-                          coordinator.group.shouldContinue {
-                        guard let sampleBuffer = track.output.copyNextSampleBuffer() else {
-                            coordinator.finish(track: track)
-                            return
-                        }
-                        guard track.input.append(sampleBuffer) else {
-                            coordinator.stop(failed: true)
-                            return
-                        }
+        func transfer() async throws {
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { continuation in
+                    queue.async { [self] in
+                        start(continuation: continuation)
                     }
                 }
+            } onCancel: {
+                self.cancel()
             }
         }
 
-        func stop(failed: Bool = false) {
-            let unfinishedTrackIDs = group.stop(failed: failed)
-            for track in tracks where unfinishedTrackIDs.contains(track.id) {
-                let trackBox = UncheckedSendableBox(track)
-                let coordinatorBox = UncheckedSendableBox(self)
-                track.queue.async {
-                    coordinatorBox.value.finish(track: trackBox.value)
+        func cancel() {
+            queue.async { [self] in
+                finish(with: .failure(CancellationError()))
+            }
+        }
+
+        private func start(continuation: CheckedContinuation<Void, Error>) {
+            guard !didStart else {
+                continuation.resume(throwing: TransferError.startedMoreThanOnce)
+                return
+            }
+            didStart = true
+
+            if let terminalResult {
+                continuation.resume(with: terminalResult)
+                return
+            }
+
+            self.continuation = continuation
+            input.requestMediaDataWhenReady(on: queue) { [self] in
+                pump()
+            }
+        }
+
+        private func pump() {
+            guard terminalResult == nil else { return }
+
+            while input.isReadyForMoreMediaData, terminalResult == nil {
+                guard let sampleBuffer = output.copyNextSampleBuffer() else {
+                    finish(with: .success(()))
+                    return
+                }
+                guard input.append(sampleBuffer) else {
+                    finish(with: .failure(TransferError.appendFailed))
+                    return
                 }
             }
         }
 
-        private func finish(track: TransferTrack) {
-            guard group.claimFinish(trackID: track.id) else { return }
-            track.input.markAsFinished()
-            group.leave()
+        private func finish(with result: Result<Void, Error>) {
+            guard terminalResult == nil else { return }
+            terminalResult = result
+            input.markAsFinished()
+            continuation?.resume(with: result)
+            continuation = nil
         }
     }
 
-    private let stateLock = NSLock()
-    private let lifecycleQueue = DispatchQueue(
-        label: "com.mux.upload-sdk.standardization.lifecycle",
-        qos: .userInitiated
-    )
     private var state: State = .active
     private var reader: AVAssetReader?
     private var writer: AVAssetWriter?
-    private var transferCoordinator: TransferCoordinator?
+    private var transfers: [LegacySampleTransfer] = []
     private var outputURL: URL?
     private var ownsOutputFile = false
-    private let transferDidStart: (() -> Void)?
+    private let transferDidStart: (
+        @Sendable (UploadInputStandardizationWorker) async -> Void
+    )?
 
-    init(transferDidStart: (() -> Void)? = nil) {
+    init(
+        transferDidStart: (
+            @Sendable (UploadInputStandardizationWorker) async -> Void
+        )? = nil
+    ) {
         self.transferDidStart = transferDidStart
     }
 
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping Completion
-    ) {
-        stateLock.lock()
-        guard state == .active else {
-            stateLock.unlock()
-            return
-        }
+        outputURL: URL
+    ) async throws -> AVURLAsset {
+        try ensureActive()
         self.outputURL = outputURL
-        stateLock.unlock()
-
-        sourceAsset.loadTracks(withMediaType: .video) { [weak self] videoTracks, error in
-            guard let self, self.isActive else { return }
-            guard error == nil, let videoTracks else {
-                self.complete(
-                    sourceAsset: sourceAsset,
-                    error: error ?? StandardizationError.missingVideoTrack,
-                    completion: completion
-                )
-                return
-            }
+        do {
+            let videoTracks = try await sourceAsset.loadTracks(withMediaType: .video)
+            try ensureActive()
             guard videoTracks.count == 1, let videoTrack = videoTracks.first else {
-                self.complete(
-                    sourceAsset: sourceAsset,
-                    error: videoTracks.isEmpty
-                        ? StandardizationError.missingVideoTrack
-                        : StandardizationError.multipleVideoTracks,
-                    completion: completion
-                )
-                return
+                throw videoTracks.isEmpty
+                    ? StandardizationError.missingVideoTrack
+                    : StandardizationError.multipleVideoTracks
             }
 
-            sourceAsset.loadTracks(withMediaType: .audio) { audioTracks, error in
-                guard self.isActive else { return }
-                guard error == nil, let audioTracks else {
-                    self.complete(
-                        sourceAsset: sourceAsset,
-                        error: error ?? StandardizationError.missingAudioFormat,
-                        completion: completion
-                    )
-                    return
-                }
-                let audioTrack = audioTracks.first
-                self.loadAudioProperties(for: audioTrack) { audioResult in
-                    guard self.isActive else { return }
-                    guard case .success(let audioProperties) = audioResult else {
-                        if case .failure(let error) = audioResult {
-                            self.complete(
-                                sourceAsset: sourceAsset,
-                                error: error,
-                                completion: completion
-                            )
-                        }
-                        return
-                    }
-                    self.loadProperties(
-                        sourceAsset: sourceAsset,
-                        videoTrack: videoTrack
-                    ) { result in
-                        guard self.isActive else { return }
-                        switch result {
-                        case .success(let properties):
-                            self.convert(
-                                sourceAsset: sourceAsset,
-                                videoTrack: videoTrack,
-                                audioTrack: audioTrack,
-                                audioProperties: audioProperties,
-                                properties: properties,
-                                rescalingDetails: rescalingDetails,
-                                outputURL: outputURL,
-                                completion: completion
-                            )
-                        case .failure(let error):
-                            self.complete(
-                                sourceAsset: sourceAsset,
-                                error: error,
-                                completion: completion
-                            )
-                        }
-                    }
-                }
+            let audioTracks = try await sourceAsset.loadTracks(withMediaType: .audio)
+            try ensureActive()
+            let audioTrack = audioTracks.first
+            let audioProperties = try await loadAudioProperties(for: audioTrack)
+            let properties = try await loadProperties(
+                sourceAsset: sourceAsset,
+                videoTrack: videoTrack
+            )
+            let standardizedAsset = try await convert(
+                sourceAsset: sourceAsset,
+                videoTrack: videoTrack,
+                audioTrack: audioTrack,
+                audioProperties: audioProperties,
+                properties: properties,
+                rescalingDetails: rescalingDetails,
+                outputURL: outputURL
+            )
+            try ensureActive()
+            finishSuccessfully()
+            return standardizedAsset
+        } catch {
+            let finalError: Error = state == .cancelled
+                ? CancellationError()
+                : error
+            cleanupPartialOutput()
+            if state == .active {
+                state = .completed
             }
-        }
-    }
-
-    private func loadAudioProperties(
-        for track: AVAssetTrack?,
-        completion: @escaping (Result<AudioProperties?, Error>) -> Void
-    ) {
-        guard let track else {
-            completion(.success(nil))
-            return
-        }
-        track.loadValuesAsynchronously(forKeys: ["formatDescriptions"]) {
-            guard self.isActive else { return }
-            do {
-                completion(
-                    .success(
-                        try Self.audioProperties(
-                            formatDescriptions: track.formatDescriptions
-                                as? [CMAudioFormatDescription] ?? []
-                        )
-                    )
-                )
-            } catch {
-                completion(.failure(error))
-            }
+            throw finalError
         }
     }
 
     func cancel() {
-        stateLock.lock()
-        guard state == .active else {
-            stateLock.unlock()
-            return
-        }
+        guard state == .active else { return }
         state = .cancelled
-        stateLock.unlock()
 
-        let worker = UncheckedSendableBox(self)
-        lifecycleQueue.async {
-            worker.value.cancelOnLifecycleQueue()
+        if transfers.isEmpty {
+            reader?.cancelReading()
+            writer?.cancelWriting()
+        } else {
+            transfers.forEach { $0.cancel() }
         }
     }
 
-    private func cancelOnLifecycleQueue() {
-        stateLock.lock()
-        if let transferCoordinator {
-            stateLock.unlock()
-            transferCoordinator.stop()
-            return
-        }
-        let reader = self.reader
-        let writer = self.writer
-        let outputURL = self.outputURL
-        let ownsOutputFile = self.ownsOutputFile
-        self.reader = nil
-        self.writer = nil
-        self.outputURL = nil
-        self.ownsOutputFile = false
-        stateLock.unlock()
-
-        reader?.cancelReading()
-        writer?.cancelWriting()
-        if ownsOutputFile {
-            removePartialOutput(at: outputURL)
+    private func ensureActive() throws {
+        guard state == .active, !Task.isCancelled else {
+            throw CancellationError()
         }
     }
 
-    private var isActive: Bool {
-        stateLock.lock()
-        defer { stateLock.unlock() }
-        return state == .active
+    private func loadAudioProperties(
+        for track: AVAssetTrack?
+    ) async throws -> AudioProperties? {
+        guard let track else { return nil }
+        let formatDescriptions = try await track.load(.formatDescriptions)
+        try ensureActive()
+        return try Self.audioProperties(
+            formatDescriptions: formatDescriptions
+        )
     }
 
     private func loadProperties(
         sourceAsset: AVAsset,
-        videoTrack: AVAssetTrack,
-        completion: @escaping (Result<LoadedAssetProperties, Error>) -> Void
-    ) {
-        sourceAsset.loadValuesAsynchronously(forKeys: ["duration"]) {
-            guard self.isActive else { return }
-            videoTrack.loadValuesAsynchronously(
-                forKeys: [
-                    "naturalSize",
-                    "preferredTransform",
-                    "nominalFrameRate",
-                    "formatDescriptions"
-                ]
-            ) {
-                guard self.isActive else { return }
-                guard let formatDescriptions = videoTrack.formatDescriptions
-                    as? [CMFormatDescription],
-                      !formatDescriptions.isEmpty else {
-                    completion(.failure(StandardizationError.missingVideoFormat))
-                    return
-                }
-                completion(
-                    .success(
-                        LoadedAssetProperties(
-                            duration: sourceAsset.duration,
-                            naturalSize: videoTrack.naturalSize,
-                            preferredTransform: videoTrack.preferredTransform,
-                            nominalFrameRate: videoTrack.nominalFrameRate,
-                            formatDescriptions: formatDescriptions
-                        )
-                    )
-                )
-            }
+        videoTrack: AVAssetTrack
+    ) async throws -> LoadedAssetProperties {
+        let duration = try await sourceAsset.load(.duration)
+        let (
+            naturalSize,
+            preferredTransform,
+            nominalFrameRate,
+            formatDescriptions
+        ) = try await videoTrack.load(
+            .naturalSize,
+            .preferredTransform,
+            .nominalFrameRate,
+            .formatDescriptions
+        )
+        try ensureActive()
+        guard !formatDescriptions.isEmpty else {
+            throw StandardizationError.missingVideoFormat
         }
+        return LoadedAssetProperties(
+            duration: duration,
+            naturalSize: naturalSize,
+            preferredTransform: preferredTransform,
+            nominalFrameRate: nominalFrameRate,
+            formatDescriptions: formatDescriptions
+        )
     }
 
     private func convert(
@@ -452,174 +319,98 @@ final class UploadInputStandardizationWorker {
         audioProperties: AudioProperties?,
         properties: LoadedAssetProperties,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping Completion
-    ) {
-        let work = UncheckedSendableBox { [weak self] in
-            guard let self, self.isActive else { return }
-            self.convertOnLifecycleQueue(
-                sourceAsset: sourceAsset,
-                videoTrack: videoTrack,
-                audioTrack: audioTrack,
-                audioProperties: audioProperties,
-                properties: properties,
-                rescalingDetails: rescalingDetails,
-                outputURL: outputURL,
-                completion: completion
+        outputURL: URL
+    ) async throws -> AVURLAsset {
+        let renderSize = try Self.renderSize(
+            naturalSize: properties.naturalSize,
+            preferredTransform: properties.preferredTransform,
+            boundingSize: Self.boundingSize(
+                for: rescalingDetails.maximumDesiredResolutionPreset
             )
+        )
+        let reader = try AVAssetReader(asset: sourceAsset)
+        guard !FileManager.default.fileExists(atPath: outputURL.path) else {
+            throw StandardizationError.outputFileAlreadyExists
         }
-        lifecycleQueue.async {
-            work.value()
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        writer.shouldOptimizeForNetworkUse = true
+        self.reader = reader
+        self.writer = writer
+        ownsOutputFile = true
+
+        let sourceFormatDescription = properties.formatDescriptions[0]
+        let decoderPixelFormat = Self.decoderPixelFormat(
+            for: sourceFormatDescription
+        )
+
+        let videoOutput = AVAssetReaderVideoCompositionOutput(
+            videoTracks: [videoTrack],
+            videoSettings: [
+                kCVPixelBufferPixelFormatTypeKey as String:
+                    decoderPixelFormat,
+                kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+            ]
+        )
+        videoOutput.alwaysCopiesSampleData = false
+        videoOutput.videoComposition = Self.videoComposition(
+            track: videoTrack,
+            duration: properties.duration,
+            naturalSize: properties.naturalSize,
+            preferredTransform: properties.preferredTransform,
+            nominalFrameRate: properties.nominalFrameRate,
+            renderSize: renderSize
+        )
+        guard reader.canAdd(videoOutput) else {
+            throw StandardizationError.cannotAddReaderOutput
         }
-    }
+        reader.add(videoOutput)
 
-    private func convertOnLifecycleQueue(
-        sourceAsset: AVURLAsset,
-        videoTrack: AVAssetTrack,
-        audioTrack: AVAssetTrack?,
-        audioProperties: AudioProperties?,
-        properties: LoadedAssetProperties,
-        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping Completion
-    ) {
-        do {
-            let renderSize = try Self.renderSize(
-                naturalSize: properties.naturalSize,
-                preferredTransform: properties.preferredTransform,
-                boundingSize: Self.boundingSize(
-                    for: rescalingDetails.maximumDesiredResolutionPreset
-                )
-            )
-            let reader = try AVAssetReader(asset: sourceAsset)
-            guard !FileManager.default.fileExists(atPath: outputURL.path) else {
-                throw StandardizationError.outputFileAlreadyExists
-            }
-            let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
-            writer.shouldOptimizeForNetworkUse = true
-            guard register(reader: reader, writer: writer) else { return }
+        let videoSettings = Self.videoWriterSettings(
+            codec: Self.outputCodec(
+                for: sourceFormatDescription.mediaSubType
+            ),
+            renderSize: renderSize,
+            decoderPixelFormat: decoderPixelFormat
+        )
+        guard writer.canApply(
+            outputSettings: videoSettings,
+            forMediaType: .video
+        ) else {
+            throw StandardizationError.writerRejectedSettings
+        }
+        let videoInput = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: videoSettings
+        )
+        videoInput.expectsMediaDataInRealTime = false
+        guard writer.canAdd(videoInput) else {
+            throw StandardizationError.cannotAddWriterInput
+        }
+        writer.add(videoInput)
 
-            let sourceFormatDescription = properties.formatDescriptions[0]
-            let decoderPixelFormat = Self.decoderPixelFormat(
-                for: sourceFormatDescription
-            )
-
-            let videoOutput = AVAssetReaderVideoCompositionOutput(
-                videoTracks: [videoTrack],
-                videoSettings: [
-                    kCVPixelBufferPixelFormatTypeKey as String:
-                        decoderPixelFormat,
-                    kCVPixelBufferIOSurfacePropertiesKey as String: [:]
-                ]
-            )
-            videoOutput.alwaysCopiesSampleData = false
-            videoOutput.videoComposition = Self.videoComposition(
-                track: videoTrack,
-                duration: properties.duration,
-                naturalSize: properties.naturalSize,
-                preferredTransform: properties.preferredTransform,
-                nominalFrameRate: properties.nominalFrameRate,
-                renderSize: renderSize
-            )
-            guard reader.canAdd(videoOutput) else {
-                throw StandardizationError.cannotAddReaderOutput
+        let audioPair = try audioTrack.map {
+            guard let audioProperties else {
+                throw StandardizationError.missingAudioFormat
             }
-            reader.add(videoOutput)
-
-            let videoSettings = Self.videoWriterSettings(
-                codec: Self.outputCodec(
-                    for: sourceFormatDescription.mediaSubType
-                ),
-                renderSize: renderSize,
-                decoderPixelFormat: decoderPixelFormat
-            )
-            guard writer.canApply(
-                outputSettings: videoSettings,
-                forMediaType: .video
-            ) else {
-                throw StandardizationError.writerRejectedSettings
-            }
-            let videoInput = AVAssetWriterInput(
-                mediaType: .video,
-                outputSettings: videoSettings
-            )
-            videoInput.expectsMediaDataInRealTime = false
-            guard writer.canAdd(videoInput) else {
-                throw StandardizationError.cannotAddWriterInput
-            }
-            writer.add(videoInput)
-
-            let audioPair = try audioTrack.map {
-                guard let audioProperties else {
-                    throw StandardizationError.missingAudioFormat
-                }
-                return try Self.addAudioPipeline(
-                    track: $0,
-                    properties: audioProperties,
-                    reader: reader,
-                    writer: writer
-                )
-            }
-
-            guard writer.startWriting() else {
-                throw writer.error ?? StandardizationError.writerStartFailure
-            }
-            writer.startSession(atSourceTime: .zero)
-            guard reader.startReading() else {
-                writer.cancelWriting()
-                throw reader.error ?? StandardizationError.readerStartFailure
-            }
-
-            pump(
-                sourceAsset: sourceAsset,
+            return try Self.addAudioPipeline(
+                track: $0,
+                properties: audioProperties,
                 reader: reader,
-                writer: writer,
-                videoOutput: videoOutput,
-                videoInput: videoInput,
-                audioOutput: audioPair?.output,
-                audioInput: audioPair?.input,
-                completion: completion
-            )
-        } catch {
-            complete(
-                sourceAsset: sourceAsset,
-                error: error,
-                completion: completion
+                writer: writer
             )
         }
-    }
 
-    private func register(reader: AVAssetReader, writer: AVAssetWriter) -> Bool {
-        stateLock.lock()
-        let shouldStart = state == .active
-        if shouldStart {
-            self.reader = reader
-            self.writer = writer
-            ownsOutputFile = true
+        guard writer.startWriting() else {
+            throw writer.error ?? StandardizationError.writerStartFailure
         }
-        stateLock.unlock()
-
-        if !shouldStart {
-            reader.cancelReading()
+        writer.startSession(atSourceTime: .zero)
+        guard reader.startReading() else {
             writer.cancelWriting()
-            removePartialOutput(at: writer.outputURL)
+            throw reader.error ?? StandardizationError.readerStartFailure
         }
-        return shouldStart
-    }
 
-    private func pump(
-        sourceAsset: AVURLAsset,
-        reader: AVAssetReader,
-        writer: AVAssetWriter,
-        videoOutput: AVAssetReaderOutput,
-        videoInput: AVAssetWriterInput,
-        audioOutput: AVAssetReaderOutput?,
-        audioInput: AVAssetWriterInput?,
-        completion: @escaping Completion
-    ) {
-        var tracks = [
-            TransferTrack(
-                id: 0,
+        var transfers = [
+            LegacySampleTransfer(
                 output: videoOutput,
                 input: videoInput,
                 queue: DispatchQueue(
@@ -628,11 +419,10 @@ final class UploadInputStandardizationWorker {
                 )
             )
         ]
-
-        if let audioOutput, let audioInput {
-            tracks.append(
-                TransferTrack(
-                    id: tracks.count,
+        if let audioOutput = audioPair?.output,
+           let audioInput = audioPair?.input {
+            transfers.append(
+                LegacySampleTransfer(
                     output: audioOutput,
                     input: audioInput,
                     queue: DispatchQueue(
@@ -642,130 +432,65 @@ final class UploadInputStandardizationWorker {
                 )
             )
         }
-
-        let coordinator = TransferCoordinator(tracks: tracks)
-        stateLock.lock()
-        let shouldStart = state == .active
-        if shouldStart {
-            transferCoordinator = coordinator
-        }
-        stateLock.unlock()
-
-        guard shouldStart else {
-            cancelOnLifecycleQueue()
-            return
+        self.transfers = transfers
+        try ensureActive()
+        if let transferDidStart {
+            await transferDidStart(self)
         }
 
-        let worker = UncheckedSendableBox(self)
-        let coordinatorBox = UncheckedSendableBox(coordinator)
-        coordinator.group.notify(queue: lifecycleQueue) {
-            worker.value.transferDidFinish(
-                coordinator: coordinatorBox.value,
-                sourceAsset: sourceAsset,
-                reader: reader,
-                writer: writer,
-                completion: completion
-            )
-        }
-        coordinator.start()
-        transferDidStart?()
-    }
-
-    private func transferDidFinish(
-        coordinator: TransferCoordinator,
-        sourceAsset: AVURLAsset,
-        reader: AVAssetReader,
-        writer: AVAssetWriter,
-        completion: @escaping Completion
-    ) {
-        stateLock.lock()
-        if transferCoordinator === coordinator {
-            transferCoordinator = nil
-        }
-        let state = self.state
-        stateLock.unlock()
-
-        guard state == .active else {
-            if state == .cancelled {
-                cancelOnLifecycleQueue()
+        do {
+            try await withThrowingTaskGroup(of: Void.self) { group in
+                for transfer in transfers {
+                    group.addTask {
+                        try await transfer.transfer()
+                    }
+                }
+                try await group.waitForAll()
             }
-            return
+        } catch {
+            transfers.forEach { $0.cancel() }
+            throw writer.error
+                ?? reader.error
+                ?? error
         }
 
-        guard !coordinator.group.didFail,
-              reader.status == .completed else {
-            reader.cancelReading()
-            writer.cancelWriting()
-            complete(
-                sourceAsset: sourceAsset,
-                error: writer.error
-                    ?? reader.error
-                    ?? StandardizationError.conversionFailure,
-                completion: completion
-            )
-            return
+        self.transfers = []
+        try ensureActive()
+        guard reader.status == .completed else {
+            throw reader.error ?? StandardizationError.conversionFailure
         }
 
-        let worker = UncheckedSendableBox(self)
-        let sourceAssetBox = UncheckedSendableBox(sourceAsset)
-        let writerBox = UncheckedSendableBox(writer)
-        let completionBox = UncheckedSendableBox(completion)
-        writer.finishWriting {
-            worker.value.lifecycleQueue.async {
-                worker.value.finishWritingDidComplete(
-                    sourceAsset: sourceAssetBox.value,
-                    writer: writerBox.value,
-                    completion: completionBox.value
-                )
-            }
-        }
-    }
-
-    private func finishWritingDidComplete(
-        sourceAsset: AVURLAsset,
-        writer: AVAssetWriter,
-        completion: @escaping Completion
-    ) {
-        guard isActive else { return }
+        await writer.finishWriting()
+        try ensureActive()
         guard writer.status == .completed else {
-            complete(
-                sourceAsset: sourceAsset,
-                error: writer.error ?? StandardizationError.conversionFailure,
-                completion: completion
-            )
-            return
+            throw writer.error ?? StandardizationError.conversionFailure
         }
-        complete(
-            sourceAsset: sourceAsset,
-            standardizedAsset: AVURLAsset(url: writer.outputURL),
-            completion: completion
-        )
+        return AVURLAsset(url: writer.outputURL)
     }
 
-    private func complete(
-        sourceAsset: AVURLAsset,
-        standardizedAsset: AVAsset? = nil,
-        error: Error? = nil,
-        completion: @escaping Completion
-    ) {
-        stateLock.lock()
-        guard state == .active else {
-            stateLock.unlock()
-            return
-        }
+    private func finishSuccessfully() {
         state = .completed
+        reader = nil
+        writer = nil
+        transfers = []
+        outputURL = nil
+        ownsOutputFile = false
+    }
+
+    private func cleanupPartialOutput() {
+        transfers.forEach { $0.cancel() }
+        transfers = []
+        reader?.cancelReading()
+        writer?.cancelWriting()
         reader = nil
         writer = nil
         let outputURL = self.outputURL
         let ownsOutputFile = self.ownsOutputFile
         self.outputURL = nil
         self.ownsOutputFile = false
-        stateLock.unlock()
-
-        if error != nil, ownsOutputFile {
+        if ownsOutputFile {
             removePartialOutput(at: outputURL)
         }
-        completion(sourceAsset, standardizedAsset, error)
     }
 
     private func removePartialOutput(at url: URL?) {

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -1,22 +1,23 @@
 //
 //  UploadInputStandardizationWorker.swift
-//  
+//
 
 import AVFoundation
+import AudioToolbox
+import CoreMedia
+import CoreVideo
 import Foundation
+import VideoToolbox
 
-protocol Standardizable { }
+protocol UploadInputStandardizationWorking: AnyObject {
+    func standardize(
+        sourceAsset: AVURLAsset,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL,
+        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
+    )
 
-extension AVAsset: Standardizable { }
-
-enum StandardizationResult {
-    case success(standardizedAsset: AVAsset)
-    case failure(error: Error)
-}
-
-enum StandardizationStrategy {
-    // Prefer using export session whenever possible
-    case exportSession
+    func cancel()
 }
 
 struct StandardizationError: LocalizedError {
@@ -26,86 +27,799 @@ struct StandardizationError: LocalizedError {
         localizedDescription
     }
 
-    static var missingExportPreset = StandardizationError(
-        localizedDescription: "Missing export session preset"
+    static let missingVideoTrack = StandardizationError(
+        localizedDescription: "The input does not contain a video track"
     )
 
-    static var unsupportedResolutionTier = StandardizationError(
-        localizedDescription: "Resolution tier is not supported by the export-session standardizer"
+    static let multipleVideoTracks = StandardizationError(
+        localizedDescription: "Inputs with multiple video tracks cannot be standardized"
     )
 
-    static var exportSessionInitializationFailure = StandardizationError(
-        localizedDescription: "Export session failed to initialize"
+    static let missingVideoFormat = StandardizationError(
+        localizedDescription: "The input video format could not be read"
     )
 
-    static var standardizedAssetExportFailure = StandardizationError(
-        localizedDescription: "Failed to export standardized asset"
+    static let missingAudioFormat = StandardizationError(
+        localizedDescription: "The input audio format could not be read"
+    )
+
+    static let invalidVideoDimensions = StandardizationError(
+        localizedDescription: "The input video dimensions are invalid"
+    )
+
+    static let cannotAddReaderOutput = StandardizationError(
+        localizedDescription: "The asset reader rejected an output"
+    )
+
+    static let cannotAddWriterInput = StandardizationError(
+        localizedDescription: "The asset writer rejected an input"
+    )
+
+    static let writerRejectedSettings = StandardizationError(
+        localizedDescription: "The asset writer rejected the output settings"
+    )
+
+    static let readerStartFailure = StandardizationError(
+        localizedDescription: "The asset reader failed to start"
+    )
+
+    static let writerStartFailure = StandardizationError(
+        localizedDescription: "The asset writer failed to start"
+    )
+
+    static let conversionFailure = StandardizationError(
+        localizedDescription: "Failed to convert the input"
+    )
+
+    static let outputFileAlreadyExists = StandardizationError(
+        localizedDescription: "The standardization output file already exists"
     )
 }
 
-class UploadInputStandardizationWorker {
+final class UploadInputStandardizationWorker {
+    typealias Completion = (AVURLAsset, AVAsset?, Error?) -> Void
 
-    var sourceInput: AVAsset?
+    private enum State {
+        case active
+        case cancelled
+        case completed
+    }
 
-    var standardizedInput: AVAsset?
+    private struct LoadedAssetProperties {
+        let duration: CMTime
+        let naturalSize: CGSize
+        let preferredTransform: CGAffineTransform
+        let nominalFrameRate: Float
+        let formatDescriptions: [CMFormatDescription]
+    }
+
+    struct AudioProperties {
+        let sampleRate: Double
+        let channelCount: Int
+        let channelLayout: Data?
+        let sourceFormatDescription: CMAudioFormatDescription?
+
+        var isAAC: Bool {
+            sourceFormatDescription?.mediaSubType.rawValue == kAudioFormatMPEG4AAC
+        }
+    }
+
+    private final class UncheckedSendableBox<Value>: @unchecked Sendable {
+        let value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+
+    private let stateLock = NSLock()
+    private var state: State = .active
+    private var reader: AVAssetReader?
+    private var writer: AVAssetWriter?
+    private var outputURL: URL?
+    private var ownsOutputFile = false
 
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
         outputURL: URL,
-        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
+        completion: @escaping Completion
     ) {
-
-        let availableExportPresets = AVAssetExportSession.allExportPresets()
-
-        let exportPreset: String
-
-        switch rescalingDetails.maximumDesiredResolutionPreset {
-        case .default:
-            exportPreset = AVAssetExportPreset1920x1080
-        case .preset1280x720:
-            exportPreset = AVAssetExportPreset1280x720
-        case .preset1920x1080:
-            exportPreset = AVAssetExportPreset1920x1080
-        case .preset2560x1440:
-            // AVAssetExportSession has no 1440p preset. The
-            // reader/writer standardizer will implement this tier.
-            completion(sourceAsset, nil, StandardizationError.unsupportedResolutionTier)
-            return
-        case .preset3840x2160:
-            exportPreset = AVAssetExportPreset3840x2160
-        }
-
-        guard availableExportPresets.contains(where: {
-            $0 == exportPreset
-        }) else {
-            // TODO: Use VideoToolbox if export preset unavailable
-            completion(sourceAsset, nil, StandardizationError.missingExportPreset)
+        stateLock.lock()
+        guard state == .active else {
+            stateLock.unlock()
             return
         }
+        self.outputURL = outputURL
+        stateLock.unlock()
 
-        guard let exportSession = AVAssetExportSession(
-            asset: sourceAsset,
-            presetName: exportPreset
-        ) else {
-            // TODO: Use VideoToolbox if export session fails to initialize
-            completion(sourceAsset, nil, StandardizationError.exportSessionInitializationFailure)
-            return
-        }
+        sourceAsset.loadTracks(withMediaType: .video) { [weak self] videoTracks, error in
+            guard let self, self.isActive else { return }
+            guard error == nil, let videoTracks else {
+                self.complete(
+                    sourceAsset: sourceAsset,
+                    error: error ?? StandardizationError.missingVideoTrack,
+                    completion: completion
+                )
+                return
+            }
+            guard videoTracks.count == 1, let videoTrack = videoTracks.first else {
+                self.complete(
+                    sourceAsset: sourceAsset,
+                    error: videoTracks.isEmpty
+                        ? StandardizationError.missingVideoTrack
+                        : StandardizationError.multipleVideoTracks,
+                    completion: completion
+                )
+                return
+            }
 
-        exportSession.outputFileType = .mp4
-        exportSession.outputURL = outputURL
-
-        // TODO: Use Swift Concurrency
-        exportSession.exportAsynchronously {
-            if let exportError = exportSession.error {
-                completion(sourceAsset, nil, exportError)
-            } else if let standardizedAssetURL = exportSession.outputURL {
-                let standardizedAsset = AVAsset(url: standardizedAssetURL)
-                completion(sourceAsset, standardizedAsset, nil)
-            } else {
-                completion(sourceAsset, nil, StandardizationError.standardizedAssetExportFailure)
+            sourceAsset.loadTracks(withMediaType: .audio) { audioTracks, error in
+                guard self.isActive else { return }
+                guard error == nil, let audioTracks else {
+                    self.complete(
+                        sourceAsset: sourceAsset,
+                        error: error ?? StandardizationError.missingAudioFormat,
+                        completion: completion
+                    )
+                    return
+                }
+                let audioTrack = audioTracks.first
+                self.loadAudioProperties(for: audioTrack) { audioResult in
+                    guard self.isActive else { return }
+                    guard case .success(let audioProperties) = audioResult else {
+                        if case .failure(let error) = audioResult {
+                            self.complete(
+                                sourceAsset: sourceAsset,
+                                error: error,
+                                completion: completion
+                            )
+                        }
+                        return
+                    }
+                    self.loadProperties(
+                        sourceAsset: sourceAsset,
+                        videoTrack: videoTrack
+                    ) { result in
+                        guard self.isActive else { return }
+                        switch result {
+                        case .success(let properties):
+                            self.convert(
+                                sourceAsset: sourceAsset,
+                                videoTrack: videoTrack,
+                                audioTrack: audioTrack,
+                                audioProperties: audioProperties,
+                                properties: properties,
+                                rescalingDetails: rescalingDetails,
+                                outputURL: outputURL,
+                                completion: completion
+                            )
+                        case .failure(let error):
+                            self.complete(
+                                sourceAsset: sourceAsset,
+                                error: error,
+                                completion: completion
+                            )
+                        }
+                    }
+                }
             }
         }
     }
+
+    private func loadAudioProperties(
+        for track: AVAssetTrack?,
+        completion: @escaping (Result<AudioProperties?, Error>) -> Void
+    ) {
+        guard let track else {
+            completion(.success(nil))
+            return
+        }
+        track.loadValuesAsynchronously(forKeys: ["formatDescriptions"]) {
+            guard self.isActive else { return }
+            do {
+                completion(
+                    .success(
+                        try Self.audioProperties(
+                            formatDescriptions: track.formatDescriptions
+                                as? [CMAudioFormatDescription] ?? []
+                        )
+                    )
+                )
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func cancel() {
+        stateLock.lock()
+        guard state == .active else {
+            stateLock.unlock()
+            return
+        }
+        state = .cancelled
+        let reader = self.reader
+        let writer = self.writer
+        let outputURL = self.outputURL
+        let ownsOutputFile = self.ownsOutputFile
+        self.reader = nil
+        self.writer = nil
+        self.outputURL = nil
+        self.ownsOutputFile = false
+        stateLock.unlock()
+
+        reader?.cancelReading()
+        writer?.cancelWriting()
+        if ownsOutputFile {
+            removePartialOutput(at: outputURL)
+        }
+    }
+
+    private var isActive: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return state == .active
+    }
+
+    private func loadProperties(
+        sourceAsset: AVAsset,
+        videoTrack: AVAssetTrack,
+        completion: @escaping (Result<LoadedAssetProperties, Error>) -> Void
+    ) {
+        sourceAsset.loadValuesAsynchronously(forKeys: ["duration"]) {
+            guard self.isActive else { return }
+            videoTrack.loadValuesAsynchronously(
+                forKeys: [
+                    "naturalSize",
+                    "preferredTransform",
+                    "nominalFrameRate",
+                    "formatDescriptions"
+                ]
+            ) {
+                guard self.isActive else { return }
+                guard let formatDescriptions = videoTrack.formatDescriptions
+                    as? [CMFormatDescription],
+                      !formatDescriptions.isEmpty else {
+                    completion(.failure(StandardizationError.missingVideoFormat))
+                    return
+                }
+                completion(
+                    .success(
+                        LoadedAssetProperties(
+                            duration: sourceAsset.duration,
+                            naturalSize: videoTrack.naturalSize,
+                            preferredTransform: videoTrack.preferredTransform,
+                            nominalFrameRate: videoTrack.nominalFrameRate,
+                            formatDescriptions: formatDescriptions
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    private func convert(
+        sourceAsset: AVURLAsset,
+        videoTrack: AVAssetTrack,
+        audioTrack: AVAssetTrack?,
+        audioProperties: AudioProperties?,
+        properties: LoadedAssetProperties,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL,
+        completion: @escaping Completion
+    ) {
+        do {
+            let renderSize = try Self.renderSize(
+                naturalSize: properties.naturalSize,
+                preferredTransform: properties.preferredTransform,
+                boundingSize: Self.boundingSize(
+                    for: rescalingDetails.maximumDesiredResolutionPreset
+                )
+            )
+            let reader = try AVAssetReader(asset: sourceAsset)
+            guard !FileManager.default.fileExists(atPath: outputURL.path) else {
+                throw StandardizationError.outputFileAlreadyExists
+            }
+            let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+            writer.shouldOptimizeForNetworkUse = true
+            guard register(reader: reader, writer: writer) else { return }
+
+            let sourceFormatDescription = properties.formatDescriptions[0]
+            let decoderPixelFormat = Self.decoderPixelFormat(
+                for: sourceFormatDescription
+            )
+
+            let videoOutput = AVAssetReaderVideoCompositionOutput(
+                videoTracks: [videoTrack],
+                videoSettings: [
+                    kCVPixelBufferPixelFormatTypeKey as String:
+                        decoderPixelFormat,
+                    kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+                ]
+            )
+            videoOutput.alwaysCopiesSampleData = false
+            videoOutput.videoComposition = Self.videoComposition(
+                track: videoTrack,
+                duration: properties.duration,
+                naturalSize: properties.naturalSize,
+                preferredTransform: properties.preferredTransform,
+                nominalFrameRate: properties.nominalFrameRate,
+                renderSize: renderSize
+            )
+            guard reader.canAdd(videoOutput) else {
+                throw StandardizationError.cannotAddReaderOutput
+            }
+            reader.add(videoOutput)
+
+            let videoSettings = Self.videoWriterSettings(
+                codec: Self.outputCodec(
+                    for: sourceFormatDescription.mediaSubType
+                ),
+                renderSize: renderSize,
+                decoderPixelFormat: decoderPixelFormat
+            )
+            guard writer.canApply(
+                outputSettings: videoSettings,
+                forMediaType: .video
+            ) else {
+                throw StandardizationError.writerRejectedSettings
+            }
+            let videoInput = AVAssetWriterInput(
+                mediaType: .video,
+                outputSettings: videoSettings
+            )
+            videoInput.expectsMediaDataInRealTime = false
+            guard writer.canAdd(videoInput) else {
+                throw StandardizationError.cannotAddWriterInput
+            }
+            writer.add(videoInput)
+
+            let audioPair = try audioTrack.map {
+                guard let audioProperties else {
+                    throw StandardizationError.missingAudioFormat
+                }
+                return try Self.addAudioPipeline(
+                    track: $0,
+                    properties: audioProperties,
+                    reader: reader,
+                    writer: writer
+                )
+            }
+
+            guard writer.startWriting() else {
+                throw writer.error ?? StandardizationError.writerStartFailure
+            }
+            writer.startSession(atSourceTime: .zero)
+            guard reader.startReading() else {
+                writer.cancelWriting()
+                throw reader.error ?? StandardizationError.readerStartFailure
+            }
+
+            pump(
+                sourceAsset: sourceAsset,
+                reader: reader,
+                writer: writer,
+                videoOutput: videoOutput,
+                videoInput: videoInput,
+                audioOutput: audioPair?.output,
+                audioInput: audioPair?.input,
+                completion: completion
+            )
+        } catch {
+            complete(
+                sourceAsset: sourceAsset,
+                error: error,
+                completion: completion
+            )
+        }
+    }
+
+    private func register(reader: AVAssetReader, writer: AVAssetWriter) -> Bool {
+        stateLock.lock()
+        let shouldStart = state == .active
+        if shouldStart {
+            self.reader = reader
+            self.writer = writer
+            ownsOutputFile = true
+        }
+        stateLock.unlock()
+
+        if !shouldStart {
+            reader.cancelReading()
+            writer.cancelWriting()
+            removePartialOutput(at: writer.outputURL)
+        }
+        return shouldStart
+    }
+
+    private func pump(
+        sourceAsset: AVURLAsset,
+        reader: AVAssetReader,
+        writer: AVAssetWriter,
+        videoOutput: AVAssetReaderOutput,
+        videoInput: AVAssetWriterInput,
+        audioOutput: AVAssetReaderOutput?,
+        audioInput: AVAssetWriterInput?,
+        completion: @escaping Completion
+    ) {
+        let group = DispatchGroup()
+        let readerBox = UncheckedSendableBox(reader)
+
+        Self.transfer(
+            output: videoOutput,
+            input: videoInput,
+            reader: readerBox,
+            queue: DispatchQueue(
+                label: "com.mux.upload-sdk.standardization.video",
+                qos: .userInitiated
+            ),
+            group: group
+        )
+
+        if let audioOutput, let audioInput {
+            Self.transfer(
+                output: audioOutput,
+                input: audioInput,
+                reader: readerBox,
+                queue: DispatchQueue(
+                    label: "com.mux.upload-sdk.standardization.audio",
+                    qos: .userInitiated
+                ),
+                group: group
+            )
+        }
+
+        group.notify(queue: .global(qos: .userInitiated)) { [weak self] in
+            guard let self, self.isActive else { return }
+            guard reader.status == .completed else {
+                writer.cancelWriting()
+                self.complete(
+                    sourceAsset: sourceAsset,
+                    error: reader.error ?? StandardizationError.conversionFailure,
+                    completion: completion
+                )
+                return
+            }
+            writer.finishWriting {
+                guard self.isActive else { return }
+                guard writer.status == .completed else {
+                    self.complete(
+                        sourceAsset: sourceAsset,
+                        error: writer.error ?? StandardizationError.conversionFailure,
+                        completion: completion
+                    )
+                    return
+                }
+                self.complete(
+                    sourceAsset: sourceAsset,
+                    standardizedAsset: AVURLAsset(url: writer.outputURL),
+                    completion: completion
+                )
+            }
+        }
+    }
+
+    private static func transfer(
+        output: AVAssetReaderOutput,
+        input: AVAssetWriterInput,
+        reader: UncheckedSendableBox<AVAssetReader>,
+        queue: DispatchQueue,
+        group: DispatchGroup
+    ) {
+        let outputBox = UncheckedSendableBox(output)
+        let inputBox = UncheckedSendableBox(input)
+        group.enter()
+        input.requestMediaDataWhenReady(on: queue) {
+            let output = outputBox.value
+            let input = inputBox.value
+            while input.isReadyForMoreMediaData {
+                guard let sampleBuffer = output.copyNextSampleBuffer() else {
+                    input.markAsFinished()
+                    group.leave()
+                    return
+                }
+                guard input.append(sampleBuffer) else {
+                    reader.value.cancelReading()
+                    input.markAsFinished()
+                    group.leave()
+                    return
+                }
+            }
+        }
+    }
+
+    private func complete(
+        sourceAsset: AVURLAsset,
+        standardizedAsset: AVAsset? = nil,
+        error: Error? = nil,
+        completion: @escaping Completion
+    ) {
+        stateLock.lock()
+        guard state == .active else {
+            stateLock.unlock()
+            return
+        }
+        state = .completed
+        reader = nil
+        writer = nil
+        let outputURL = self.outputURL
+        let ownsOutputFile = self.ownsOutputFile
+        self.outputURL = nil
+        self.ownsOutputFile = false
+        stateLock.unlock()
+
+        if error != nil, ownsOutputFile {
+            removePartialOutput(at: outputURL)
+        }
+        completion(sourceAsset, standardizedAsset, error)
+    }
+
+    private func removePartialOutput(at url: URL?) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    static func outputCodec(
+        for mediaSubType: CMFormatDescription.MediaSubType
+    ) -> AVVideoCodecType {
+        switch mediaSubType.rawValue {
+        case CMFormatDescription.MediaSubType.hevc.rawValue,
+             0x68657631: // hev1
+            return .hevc
+        case CMFormatDescription.MediaSubType.h264.rawValue,
+             0x61766333: // avc3
+            return .h264
+        default:
+            return .h264
+        }
+    }
+
+    static func decoderPixelFormat(
+        for formatDescription: CMFormatDescription
+    ) -> OSType {
+        guard outputCodec(for: formatDescription.mediaSubType) == .hevc,
+              let extensions = CMFormatDescriptionGetExtensions(formatDescription)
+                as NSDictionary?,
+              AVFoundationUploadInputMetadataReader.codecConfiguration(
+                codec: .hevc,
+                extensions: extensions
+              ) == StandardInputPixelFormat(
+                bitDepth: 10,
+                chromaSubsampling: .yuv420
+              ) else {
+            return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        }
+        return kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+    }
+
+    static func boundingSize(
+        for preset: DirectUploadOptions.InputStandardization.MaximumResolution
+    ) -> CGSize {
+        switch preset {
+        case .preset1280x720:
+            return CGSize(width: 1280, height: 720)
+        case .default, .preset1920x1080:
+            return CGSize(width: 1920, height: 1080)
+        case .preset2560x1440:
+            return CGSize(width: 2560, height: 1440)
+        case .preset3840x2160:
+            return CGSize(width: 3840, height: 2160)
+        }
+    }
+
+    static func renderSize(
+        naturalSize: CGSize,
+        preferredTransform: CGAffineTransform,
+        boundingSize: CGSize
+    ) throws -> CGSize {
+        let displayRect = CGRect(origin: .zero, size: naturalSize)
+            .applying(preferredTransform)
+            .standardized
+        guard displayRect.width.isFinite,
+              displayRect.height.isFinite,
+              displayRect.width > 0,
+              displayRect.height > 0 else {
+            throw StandardizationError.invalidVideoDimensions
+        }
+        let scale = min(
+            1,
+            max(boundingSize.width, boundingSize.height)
+                / max(displayRect.width, displayRect.height),
+            min(boundingSize.width, boundingSize.height)
+                / min(displayRect.width, displayRect.height)
+        )
+        return CGSize(
+            width: even(displayRect.width * scale),
+            height: even(displayRect.height * scale)
+        )
+    }
+
+    private static func even(_ value: CGFloat) -> CGFloat {
+        CGFloat(max(2, Int((value / 2).rounded()) * 2))
+    }
+
+    private static func videoComposition(
+        track: AVAssetTrack,
+        duration: CMTime,
+        naturalSize: CGSize,
+        preferredTransform: CGAffineTransform,
+        nominalFrameRate: Float,
+        renderSize: CGSize
+    ) -> AVVideoComposition {
+        let transformedRect = CGRect(origin: .zero, size: naturalSize)
+            .applying(preferredTransform)
+            .standardized
+        let scale = min(
+            renderSize.width / transformedRect.width,
+            renderSize.height / transformedRect.height
+        )
+        let normalize = CGAffineTransform(
+            translationX: -transformedRect.minX,
+            y: -transformedRect.minY
+        )
+        let transform = preferredTransform
+            .concatenating(normalize)
+            .concatenating(CGAffineTransform(scaleX: scale, y: scale))
+
+        let layerInstruction = AVMutableVideoCompositionLayerInstruction(
+            assetTrack: track
+        )
+        layerInstruction.setTransform(transform, at: .zero)
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
+        instruction.layerInstructions = [layerInstruction]
+
+        let composition = AVMutableVideoComposition()
+        composition.instructions = [instruction]
+        composition.renderSize = renderSize
+        let frameRate = nominalFrameRate.isFinite && nominalFrameRate > 0
+            ? nominalFrameRate
+            : 30
+        composition.frameDuration = CMTime(
+            value: 1_000,
+            timescale: CMTimeScale((frameRate * 1_000).rounded())
+        )
+        return composition
+    }
+
+    private static func videoWriterSettings(
+        codec: AVVideoCodecType,
+        renderSize: CGSize,
+        decoderPixelFormat: OSType
+    ) -> [String: Any] {
+        var settings: [String: Any] = [
+            AVVideoCodecKey: codec,
+            AVVideoWidthKey: Int(renderSize.width),
+            AVVideoHeightKey: Int(renderSize.height)
+        ]
+        if codec == .hevc,
+           decoderPixelFormat == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange {
+            settings[AVVideoCompressionPropertiesKey] = [
+                AVVideoProfileLevelKey: kVTProfileLevel_HEVC_Main10_AutoLevel
+            ]
+        }
+        return settings
+    }
+
+    private static func addAudioPipeline(
+        track: AVAssetTrack,
+        properties: AudioProperties,
+        reader: AVAssetReader,
+        writer: AVAssetWriter
+    ) throws -> (output: AVAssetReaderOutput, input: AVAssetWriterInput) {
+        if properties.isAAC {
+            let output = AVAssetReaderTrackOutput(
+                track: track,
+                outputSettings: nil
+            )
+            output.alwaysCopiesSampleData = false
+            guard reader.canAdd(output) else {
+                throw StandardizationError.cannotAddReaderOutput
+            }
+            reader.add(output)
+
+            let input = AVAssetWriterInput(
+                mediaType: .audio,
+                outputSettings: nil,
+                sourceFormatHint: properties.sourceFormatDescription
+            )
+            input.expectsMediaDataInRealTime = false
+            guard writer.canAdd(input) else {
+                throw StandardizationError.cannotAddWriterInput
+            }
+            writer.add(input)
+            return (output, input)
+        }
+
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: [AVFormatIDKey: kAudioFormatLinearPCM]
+        )
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else {
+            throw StandardizationError.cannotAddReaderOutput
+        }
+        reader.add(output)
+
+        var settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: properties.sampleRate,
+            AVNumberOfChannelsKey: properties.channelCount,
+            AVEncoderBitRateKey: properties.channelCount > 2 ? 384_000 : 160_000
+        ]
+        if let channelLayout = properties.channelLayout {
+            settings[AVChannelLayoutKey] = channelLayout
+        }
+        guard writer.canApply(
+            outputSettings: settings,
+            forMediaType: .audio
+        ) else {
+            throw StandardizationError.writerRejectedSettings
+        }
+        let input = AVAssetWriterInput(
+            mediaType: .audio,
+            outputSettings: settings
+        )
+        input.expectsMediaDataInRealTime = false
+        guard writer.canAdd(input) else {
+            throw StandardizationError.cannotAddWriterInput
+        }
+        writer.add(input)
+        return (output, input)
+    }
+
+    static func audioProperties(
+        formatDescriptions: [CMAudioFormatDescription]
+    ) throws -> AudioProperties {
+        guard let formatDescription = formatDescriptions.first,
+              let streamDescription = CMAudioFormatDescriptionGetStreamBasicDescription(
+                formatDescription
+              )?.pointee,
+              streamDescription.mSampleRate.isFinite,
+              streamDescription.mSampleRate > 0,
+              streamDescription.mChannelsPerFrame > 0 else {
+            throw StandardizationError.missingAudioFormat
+        }
+
+        var layoutSize = 0
+        let layout = CMAudioFormatDescriptionGetChannelLayout(
+            formatDescription,
+            sizeOut: &layoutSize
+        )
+        let layoutData = layout.map { Data(bytes: $0, count: layoutSize) }
+            ?? defaultChannelLayout(channelCount: Int(streamDescription.mChannelsPerFrame))
+        return AudioProperties(
+            sampleRate: streamDescription.mSampleRate,
+            channelCount: Int(streamDescription.mChannelsPerFrame),
+            channelLayout: layoutData,
+            sourceFormatDescription: formatDescription
+        )
+    }
+
+    private static func defaultChannelLayout(channelCount: Int) -> Data? {
+        let tag: AudioChannelLayoutTag
+        switch channelCount {
+        case 1:
+            tag = kAudioChannelLayoutTag_Mono
+        case 2:
+            tag = kAudioChannelLayoutTag_Stereo
+        case 6:
+            tag = kAudioChannelLayoutTag_MPEG_5_1_D
+        default:
+            return nil
+        }
+        var layout = AudioChannelLayout(
+            mChannelLayoutTag: tag,
+            mChannelBitmap: AudioChannelBitmap(rawValue: 0),
+            mNumberChannelDescriptions: 0,
+            mChannelDescriptions: AudioChannelDescription()
+        )
+        return Data(
+            bytes: &layout,
+            count: MemoryLayout<AudioChannelLayout>.size
+        )
+    }
 }
+
+extension UploadInputStandardizationWorker: UploadInputStandardizationWorking {}

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -112,12 +112,143 @@ final class UploadInputStandardizationWorker {
         }
     }
 
+    final class TransferGroup {
+        private let lock = NSLock()
+        private let dispatchGroup = DispatchGroup()
+        private var unfinishedTrackIDs: Set<Int>
+        private var stopping = false
+        private var failed = false
+
+        init(trackCount: Int) {
+            unfinishedTrackIDs = Set(0..<trackCount)
+            for _ in 0..<trackCount {
+                dispatchGroup.enter()
+            }
+        }
+
+        var shouldContinue: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return !stopping
+        }
+
+        var didFail: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return failed
+        }
+
+        func stop(failed: Bool = false) -> [Int] {
+            lock.lock()
+            stopping = true
+            self.failed = self.failed || failed
+            let trackIDs = Array(unfinishedTrackIDs)
+            lock.unlock()
+            return trackIDs
+        }
+
+        func claimFinish(trackID: Int) -> Bool {
+            lock.lock()
+            let claimed = unfinishedTrackIDs.remove(trackID) != nil
+            lock.unlock()
+            return claimed
+        }
+
+        func leave() {
+            dispatchGroup.leave()
+        }
+
+        func notify(queue: DispatchQueue, completion: @escaping () -> Void) {
+            dispatchGroup.notify(queue: queue, execute: completion)
+        }
+    }
+
+    private final class TransferTrack {
+        let id: Int
+        let output: AVAssetReaderOutput
+        let input: AVAssetWriterInput
+        let queue: DispatchQueue
+
+        init(
+            id: Int,
+            output: AVAssetReaderOutput,
+            input: AVAssetWriterInput,
+            queue: DispatchQueue
+        ) {
+            self.id = id
+            self.output = output
+            self.input = input
+            self.queue = queue
+        }
+    }
+
+    private final class TransferCoordinator {
+        let group: TransferGroup
+        private let tracks: [TransferTrack]
+
+        init(tracks: [TransferTrack]) {
+            self.tracks = tracks
+            group = TransferGroup(trackCount: tracks.count)
+        }
+
+        func start() {
+            for track in tracks {
+                let trackBox = UncheckedSendableBox(track)
+                let coordinatorBox = UncheckedSendableBox(self)
+                track.input.requestMediaDataWhenReady(on: track.queue) {
+                    let track = trackBox.value
+                    let coordinator = coordinatorBox.value
+                    guard coordinator.group.shouldContinue else { return }
+
+                    while track.input.isReadyForMoreMediaData,
+                          coordinator.group.shouldContinue {
+                        guard let sampleBuffer = track.output.copyNextSampleBuffer() else {
+                            coordinator.finish(track: track)
+                            return
+                        }
+                        guard track.input.append(sampleBuffer) else {
+                            coordinator.stop(failed: true)
+                            return
+                        }
+                    }
+                }
+            }
+        }
+
+        func stop(failed: Bool = false) {
+            let unfinishedTrackIDs = group.stop(failed: failed)
+            for track in tracks where unfinishedTrackIDs.contains(track.id) {
+                let trackBox = UncheckedSendableBox(track)
+                let coordinatorBox = UncheckedSendableBox(self)
+                track.queue.async {
+                    coordinatorBox.value.finish(track: trackBox.value)
+                }
+            }
+        }
+
+        private func finish(track: TransferTrack) {
+            guard group.claimFinish(trackID: track.id) else { return }
+            track.input.markAsFinished()
+            group.leave()
+        }
+    }
+
     private let stateLock = NSLock()
+    private let lifecycleQueue = DispatchQueue(
+        label: "com.mux.upload-sdk.standardization.lifecycle",
+        qos: .userInitiated
+    )
     private var state: State = .active
     private var reader: AVAssetReader?
     private var writer: AVAssetWriter?
+    private var transferCoordinator: TransferCoordinator?
     private var outputURL: URL?
     private var ownsOutputFile = false
+    private let transferDidStart: (() -> Void)?
+
+    init(transferDidStart: (() -> Void)? = nil) {
+        self.transferDidStart = transferDidStart
+    }
 
     func standardize(
         sourceAsset: AVURLAsset,
@@ -239,6 +370,21 @@ final class UploadInputStandardizationWorker {
             return
         }
         state = .cancelled
+        stateLock.unlock()
+
+        let worker = UncheckedSendableBox(self)
+        lifecycleQueue.async {
+            worker.value.cancelOnLifecycleQueue()
+        }
+    }
+
+    private func cancelOnLifecycleQueue() {
+        stateLock.lock()
+        if let transferCoordinator {
+            stateLock.unlock()
+            transferCoordinator.stop()
+            return
+        }
         let reader = self.reader
         let writer = self.writer
         let outputURL = self.outputURL
@@ -300,6 +446,34 @@ final class UploadInputStandardizationWorker {
     }
 
     private func convert(
+        sourceAsset: AVURLAsset,
+        videoTrack: AVAssetTrack,
+        audioTrack: AVAssetTrack?,
+        audioProperties: AudioProperties?,
+        properties: LoadedAssetProperties,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL,
+        completion: @escaping Completion
+    ) {
+        let work = UncheckedSendableBox { [weak self] in
+            guard let self, self.isActive else { return }
+            self.convertOnLifecycleQueue(
+                sourceAsset: sourceAsset,
+                videoTrack: videoTrack,
+                audioTrack: audioTrack,
+                audioProperties: audioProperties,
+                properties: properties,
+                rescalingDetails: rescalingDetails,
+                outputURL: outputURL,
+                completion: completion
+            )
+        }
+        lifecycleQueue.async {
+            work.value()
+        }
+    }
+
+    private func convertOnLifecycleQueue(
         sourceAsset: AVURLAsset,
         videoTrack: AVAssetTrack,
         audioTrack: AVAssetTrack?,
@@ -443,90 +617,129 @@ final class UploadInputStandardizationWorker {
         audioInput: AVAssetWriterInput?,
         completion: @escaping Completion
     ) {
-        let group = DispatchGroup()
-        let readerBox = UncheckedSendableBox(reader)
-
-        Self.transfer(
-            output: videoOutput,
-            input: videoInput,
-            reader: readerBox,
-            queue: DispatchQueue(
-                label: "com.mux.upload-sdk.standardization.video",
-                qos: .userInitiated
-            ),
-            group: group
-        )
+        var tracks = [
+            TransferTrack(
+                id: 0,
+                output: videoOutput,
+                input: videoInput,
+                queue: DispatchQueue(
+                    label: "com.mux.upload-sdk.standardization.video",
+                    qos: .userInitiated
+                )
+            )
+        ]
 
         if let audioOutput, let audioInput {
-            Self.transfer(
-                output: audioOutput,
-                input: audioInput,
-                reader: readerBox,
-                queue: DispatchQueue(
-                    label: "com.mux.upload-sdk.standardization.audio",
-                    qos: .userInitiated
-                ),
-                group: group
+            tracks.append(
+                TransferTrack(
+                    id: tracks.count,
+                    output: audioOutput,
+                    input: audioInput,
+                    queue: DispatchQueue(
+                        label: "com.mux.upload-sdk.standardization.audio",
+                        qos: .userInitiated
+                    )
+                )
             )
         }
 
-        group.notify(queue: .global(qos: .userInitiated)) { [weak self] in
-            guard let self, self.isActive else { return }
-            guard reader.status == .completed else {
-                writer.cancelWriting()
-                self.complete(
-                    sourceAsset: sourceAsset,
-                    error: reader.error ?? StandardizationError.conversionFailure,
-                    completion: completion
-                )
-                return
+        let coordinator = TransferCoordinator(tracks: tracks)
+        stateLock.lock()
+        let shouldStart = state == .active
+        if shouldStart {
+            transferCoordinator = coordinator
+        }
+        stateLock.unlock()
+
+        guard shouldStart else {
+            cancelOnLifecycleQueue()
+            return
+        }
+
+        let worker = UncheckedSendableBox(self)
+        let coordinatorBox = UncheckedSendableBox(coordinator)
+        coordinator.group.notify(queue: lifecycleQueue) {
+            worker.value.transferDidFinish(
+                coordinator: coordinatorBox.value,
+                sourceAsset: sourceAsset,
+                reader: reader,
+                writer: writer,
+                completion: completion
+            )
+        }
+        coordinator.start()
+        transferDidStart?()
+    }
+
+    private func transferDidFinish(
+        coordinator: TransferCoordinator,
+        sourceAsset: AVURLAsset,
+        reader: AVAssetReader,
+        writer: AVAssetWriter,
+        completion: @escaping Completion
+    ) {
+        stateLock.lock()
+        if transferCoordinator === coordinator {
+            transferCoordinator = nil
+        }
+        let state = self.state
+        stateLock.unlock()
+
+        guard state == .active else {
+            if state == .cancelled {
+                cancelOnLifecycleQueue()
             }
-            writer.finishWriting {
-                guard self.isActive else { return }
-                guard writer.status == .completed else {
-                    self.complete(
-                        sourceAsset: sourceAsset,
-                        error: writer.error ?? StandardizationError.conversionFailure,
-                        completion: completion
-                    )
-                    return
-                }
-                self.complete(
-                    sourceAsset: sourceAsset,
-                    standardizedAsset: AVURLAsset(url: writer.outputURL),
-                    completion: completion
+            return
+        }
+
+        guard !coordinator.group.didFail,
+              reader.status == .completed else {
+            reader.cancelReading()
+            writer.cancelWriting()
+            complete(
+                sourceAsset: sourceAsset,
+                error: writer.error
+                    ?? reader.error
+                    ?? StandardizationError.conversionFailure,
+                completion: completion
+            )
+            return
+        }
+
+        let worker = UncheckedSendableBox(self)
+        let sourceAssetBox = UncheckedSendableBox(sourceAsset)
+        let writerBox = UncheckedSendableBox(writer)
+        let completionBox = UncheckedSendableBox(completion)
+        writer.finishWriting {
+            worker.value.lifecycleQueue.async {
+                worker.value.finishWritingDidComplete(
+                    sourceAsset: sourceAssetBox.value,
+                    writer: writerBox.value,
+                    completion: completionBox.value
                 )
             }
         }
     }
 
-    private static func transfer(
-        output: AVAssetReaderOutput,
-        input: AVAssetWriterInput,
-        reader: UncheckedSendableBox<AVAssetReader>,
-        queue: DispatchQueue,
-        group: DispatchGroup
+    private func finishWritingDidComplete(
+        sourceAsset: AVURLAsset,
+        writer: AVAssetWriter,
+        completion: @escaping Completion
     ) {
-        let outputBox = UncheckedSendableBox(output)
-        let inputBox = UncheckedSendableBox(input)
-        group.enter()
-        input.requestMediaDataWhenReady(on: queue) {
-            let output = outputBox.value
-            let input = inputBox.value
-            while input.isReadyForMoreMediaData {
-                guard let sampleBuffer = output.copyNextSampleBuffer() else {
-                    input.markAsFinished()
-                    group.leave()
-                    return
-                }
-                guard input.append(sampleBuffer) else {
-                    reader.value.cancelReading()
-                    input.markAsFinished()
-                    group.leave()
-                    return
-                }
-            }
+        guard isActive else { return }
+        guard writer.status == .completed else {
+            complete(
+                sourceAsset: sourceAsset,
+                error: writer.error ?? StandardizationError.conversionFailure,
+                completion: completion
+            )
+            return
         }
+        complete(
+            sourceAsset: sourceAsset,
+            standardizedAsset: AVURLAsset(url: writer.outputURL),
+            completion: completion
+        )
     }
 
     private func complete(

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -165,17 +165,21 @@ actor UploadInputStandardizationWorker {
         }
 
         private func pump() {
-            guard terminalResult == nil else { return }
+            guard terminalResult == nil,
+                  input.isReadyForMoreMediaData else { return }
+            guard let sampleBuffer = output.copyNextSampleBuffer() else {
+                finish(with: .success(()))
+                return
+            }
+            guard input.append(sampleBuffer) else {
+                finish(with: .failure(TransferError.appendFailed))
+                return
+            }
 
-            while input.isReadyForMoreMediaData, terminalResult == nil {
-                guard let sampleBuffer = output.copyNextSampleBuffer() else {
-                    finish(with: .success(()))
-                    return
-                }
-                guard input.append(sampleBuffer) else {
-                    finish(with: .failure(TransferError.appendFailed))
-                    return
-                }
+            // Yield between samples so cancellation queued on this serial
+            // adapter can run without racing AVAssetReader access.
+            queue.async { [self] in
+                pump()
             }
         }
 

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -14,11 +14,23 @@ protocol UploadInputStandardizing {
         completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
     )
 
+    func cancel(id: String)
+
     func acknowledgeCompletion(id: String)
 }
 
 class UploadInputStandardizer: UploadInputStandardizing {
-    var workers: [String: UploadInputStandardizationWorker] = [:]
+    private let lock = NSLock()
+    private let workerFactory: () -> UploadInputStandardizationWorking
+    private(set) var workers: [String: UploadInputStandardizationWorking] = [:]
+
+    init(
+        workerFactory: @escaping () -> UploadInputStandardizationWorking = {
+            UploadInputStandardizationWorker()
+        }
+    ) {
+        self.workerFactory = workerFactory
+    }
 
     func standardize(
         id: String,
@@ -27,8 +39,11 @@ class UploadInputStandardizer: UploadInputStandardizing {
         outputURL: URL,
         completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
     ) {
-        let worker = UploadInputStandardizationWorker()
-        workers[id] = worker
+        let worker = workerFactory()
+        lock.lock()
+        let previousWorker = workers.updateValue(worker, forKey: id)
+        lock.unlock()
+        previousWorker?.cancel()
 
         worker.standardize(
             sourceAsset: sourceAsset,
@@ -38,12 +53,18 @@ class UploadInputStandardizer: UploadInputStandardizing {
         )
     }
 
-    // Storing the worker might not be necessary if an
-    // alternative reference is in place outside the
-    // stack frame
+    func cancel(id: String) {
+        lock.lock()
+        let worker = workers.removeValue(forKey: id)
+        lock.unlock()
+        worker?.cancel()
+    }
+
     func acknowledgeCompletion(
         id: String
     ) {
+        lock.lock()
         workers[id] = nil
+        lock.unlock()
     }
 }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -5,28 +5,37 @@
 import AVFoundation
 import Foundation
 
+struct UploadInputStandardizationToken: Equatable, Sendable {
+    private let id = UUID()
+}
+
 protocol UploadInputStandardizing: Sendable {
     func standardize(
         id: String,
+        token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
         outputURL: URL
     ) async throws -> AVURLAsset
 
-    func cancel(id: String) async
+    func cancel(id: String, token: UploadInputStandardizationToken) async
 }
 
 actor UploadInputStandardizer: UploadInputStandardizing {
     private struct Entry {
-        let operationID: UUID
+        let token: UploadInputStandardizationToken
         let worker: UploadInputStandardizationWorking
     }
 
-    private let workerFactory: @Sendable () -> UploadInputStandardizationWorking
+    private let workerFactory: @Sendable (
+        UploadInputStandardizationToken
+    ) -> UploadInputStandardizationWorking
     private var entries: [String: Entry] = [:]
 
     init(
-        workerFactory: @escaping @Sendable () -> UploadInputStandardizationWorking = {
+        workerFactory: @escaping @Sendable (
+            UploadInputStandardizationToken
+        ) -> UploadInputStandardizationWorking = { _ in
             UploadInputStandardizationWorker()
         }
     ) {
@@ -35,14 +44,14 @@ actor UploadInputStandardizer: UploadInputStandardizing {
 
     func standardize(
         id: String,
+        token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
         outputURL: URL
     ) async throws -> AVURLAsset {
-        let worker = workerFactory()
-        let operationID = UUID()
+        let worker = workerFactory(token)
         let previousWorker = entries.updateValue(
-            Entry(operationID: operationID, worker: worker),
+            Entry(token: token, worker: worker),
             forKey: id
         )?.worker
         await previousWorker?.cancel()
@@ -53,15 +62,16 @@ actor UploadInputStandardizer: UploadInputStandardizing {
                 rescalingDetails: rescalingDetails,
                 outputURL: outputURL
             )
-            removeWorker(id: id, operationID: operationID)
+            removeWorker(id: id, token: token)
             return result
         } catch {
-            removeWorker(id: id, operationID: operationID)
+            removeWorker(id: id, token: token)
             throw error
         }
     }
 
-    func cancel(id: String) async {
+    func cancel(id: String, token: UploadInputStandardizationToken) async {
+        guard entries[id]?.token == token else { return }
         let worker = entries.removeValue(forKey: id)?.worker
         await worker?.cancel()
     }
@@ -70,8 +80,8 @@ actor UploadInputStandardizer: UploadInputStandardizing {
         entries[id] != nil
     }
 
-    private func removeWorker(id: String, operationID: UUID) {
-        guard entries[id]?.operationID == operationID else { return }
+    private func removeWorker(id: String, token: UploadInputStandardizationToken) {
+        guard entries[id]?.token == token else { return }
         entries[id] = nil
     }
 }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -5,27 +5,28 @@
 import AVFoundation
 import Foundation
 
-protocol UploadInputStandardizing {
+protocol UploadInputStandardizing: Sendable {
     func standardize(
         id: String,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
-    )
+        outputURL: URL
+    ) async throws -> AVURLAsset
 
-    func cancel(id: String)
-
-    func acknowledgeCompletion(id: String)
+    func cancel(id: String) async
 }
 
-class UploadInputStandardizer: UploadInputStandardizing {
-    private let lock = NSLock()
-    private let workerFactory: () -> UploadInputStandardizationWorking
-    private(set) var workers: [String: UploadInputStandardizationWorking] = [:]
+actor UploadInputStandardizer: UploadInputStandardizing {
+    private struct Entry {
+        let operationID: UUID
+        let worker: UploadInputStandardizationWorking
+    }
+
+    private let workerFactory: @Sendable () -> UploadInputStandardizationWorking
+    private var entries: [String: Entry] = [:]
 
     init(
-        workerFactory: @escaping () -> UploadInputStandardizationWorking = {
+        workerFactory: @escaping @Sendable () -> UploadInputStandardizationWorking = {
             UploadInputStandardizationWorker()
         }
     ) {
@@ -36,35 +37,41 @@ class UploadInputStandardizer: UploadInputStandardizing {
         id: String,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
-    ) {
+        outputURL: URL
+    ) async throws -> AVURLAsset {
         let worker = workerFactory()
-        lock.lock()
-        let previousWorker = workers.updateValue(worker, forKey: id)
-        lock.unlock()
-        previousWorker?.cancel()
+        let operationID = UUID()
+        let previousWorker = entries.updateValue(
+            Entry(operationID: operationID, worker: worker),
+            forKey: id
+        )?.worker
+        await previousWorker?.cancel()
 
-        worker.standardize(
-            sourceAsset: sourceAsset,
-            rescalingDetails: rescalingDetails,
-            outputURL: outputURL,
-            completion: completion
-        )
+        do {
+            let result = try await worker.standardize(
+                sourceAsset: sourceAsset,
+                rescalingDetails: rescalingDetails,
+                outputURL: outputURL
+            )
+            removeWorker(id: id, operationID: operationID)
+            return result
+        } catch {
+            removeWorker(id: id, operationID: operationID)
+            throw error
+        }
     }
 
-    func cancel(id: String) {
-        lock.lock()
-        let worker = workers.removeValue(forKey: id)
-        lock.unlock()
-        worker?.cancel()
+    func cancel(id: String) async {
+        let worker = entries.removeValue(forKey: id)?.worker
+        await worker?.cancel()
     }
 
-    func acknowledgeCompletion(
-        id: String
-    ) {
-        lock.lock()
-        workers[id] = nil
-        lock.unlock()
+    func hasWorker(id: String) -> Bool {
+        entries[id] != nil
+    }
+
+    private func removeWorker(id: String, operationID: UUID) {
+        guard entries[id]?.operationID == operationID else { return }
+        entries[id] = nil
     }
 }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -191,6 +191,7 @@ public final class DirectUpload {
     private let inputStandardizer: UploadInputStandardizing
     private let lifecycleLock = NSLock()
     private var activeAttempt: UploadAttempt?
+    private var inputStandardizationTask: Task<Void, Never>?
     private let fileWorkerFactory: FileWorkerFactory
 
     private struct UploadAttempt: Equatable {
@@ -304,6 +305,30 @@ public final class DirectUpload {
         lifecycleLock.lock()
         defer { lifecycleLock.unlock() }
         return activeAttempt == attempt
+    }
+
+    private func registerStandardizationTask(
+        _ task: Task<Void, Never>,
+        for attempt: UploadAttempt
+    ) {
+        lifecycleLock.lock()
+        let shouldKeep = activeAttempt == attempt
+        if shouldKeep {
+            inputStandardizationTask = task
+        }
+        lifecycleLock.unlock()
+
+        if !shouldKeep {
+            task.cancel()
+        }
+    }
+
+    private func clearStandardizationTask(for attempt: UploadAttempt) {
+        lifecycleLock.lock()
+        if activeAttempt == attempt {
+            inputStandardizationTask = nil
+        }
+        lifecycleLock.unlock()
     }
 
     /// Mutates input state while lifecycle ownership is locked, then returns
@@ -543,19 +568,29 @@ public final class DirectUpload {
                                 relativeTo: outputDirectory
                             )
 
-                            self.inputStandardizer.standardize(
-                                id: self.id,
-                                sourceAsset: sourceAsset,
-                                rescalingDetails: result.rescalingDetails,
-                                outputURL: outputURL
-                            ) { sourceAsset, standardizedAsset, error in
-
-                                guard self.isActive(attempt) else {
-                                    self.inputStandardizer.acknowledgeCompletion(id: self.id)
+                            let task = Task { [weak self] in
+                                guard let self else { return }
+                                do {
+                                    _ = try await self.inputStandardizer.standardize(
+                                        id: self.id,
+                                        sourceAsset: sourceAsset,
+                                        rescalingDetails: result.rescalingDetails,
+                                        outputURL: outputURL
+                                    )
+                                    guard !Task.isCancelled,
+                                          self.isActive(attempt) else { return }
+                                    self.clearStandardizationTask(for: attempt)
+                                    self.startNetworkTransport(
+                                        videoFile: outputURL,
+                                        duration: inputDuration,
+                                        attempt: attempt
+                                    )
+                                } catch is CancellationError {
                                     return
-                                }
-
-                                if let _ = error {
+                                } catch {
+                                    guard !Task.isCancelled,
+                                          self.isActive(attempt) else { return }
+                                    self.clearStandardizationTask(for: attempt)
                                     // Request upload confirmation
                                     // before proceeding. If handler unset,
                                     // by default do not cancel upload if
@@ -570,16 +605,9 @@ public final class DirectUpload {
                                     } else {
                                         self.cancelPreparation(for: attempt)
                                     }
-                                } else {
-                                    self.startNetworkTransport(
-                                        videoFile: outputURL,
-                                        duration: inputDuration,
-                                        attempt: attempt
-                                    )
                                 }
-
-                                self.inputStandardizer.acknowledgeCompletion(id: self.id)
                             }
+                            self.registerStandardizationTask(task, for: attempt)
 
                         } else {
                             self.startNetworkTransport(
@@ -606,19 +634,39 @@ public final class DirectUpload {
                             relativeTo: outputDirectory
                         )
 
-                        self.inputStandardizer.standardize(
-                            id: self.id,
-                            sourceAsset: sourceAsset,
-                            rescalingDetails: result.rescalingDetails,
-                            outputURL: outputURL
-                        ) { sourceAsset, standardizedAsset, error in
+                        let task = Task { [weak self] in
+                            guard let self else { return }
+                            do {
+                                _ = try await self.inputStandardizer.standardize(
+                                    id: self.id,
+                                    sourceAsset: sourceAsset,
+                                    rescalingDetails: result.rescalingDetails,
+                                    outputURL: outputURL
+                                )
+                                guard !Task.isCancelled,
+                                      self.isActive(attempt) else { return }
+                                self.clearStandardizationTask(for: attempt)
+                                reporter.reportUploadInputStandardizationSuccess(
+                                    inputDuration: inputDuration.seconds,
+                                    inputSize: inputSize,
+                                    options: self.uploadInfo.options,
+                                    nonStandardInputReasons: result.nonStandardInputReasons,
+                                    standardizationEndTime: Date(),
+                                    standardizationStartTime: inputStandardizationStartTime,
+                                    uploadURL: self.uploadURL
+                                )
 
-                            guard self.isActive(attempt) else {
-                                self.inputStandardizer.acknowledgeCompletion(id: self.id)
+                                self.startNetworkTransport(
+                                    videoFile: outputURL,
+                                    duration: inputDuration,
+                                    attempt: attempt
+                                )
+                            } catch is CancellationError {
                                 return
-                            }
-
-                            if let error {
+                            } catch {
+                                guard !Task.isCancelled,
+                                      self.isActive(attempt) else { return }
+                                self.clearStandardizationTask(for: attempt)
                                 // Request upload confirmation
                                 // before proceeding. If handler unset,
                                 // by default do not cancel upload if
@@ -645,26 +693,9 @@ public final class DirectUpload {
                                 } else {
                                     self.cancelPreparation(for: attempt)
                                 }
-                            } else {
-                                reporter.reportUploadInputStandardizationSuccess(
-                                    inputDuration: inputDuration.seconds,
-                                    inputSize: inputSize,
-                                    options: self.uploadInfo.options,
-                                    nonStandardInputReasons: result.nonStandardInputReasons,
-                                    standardizationEndTime: Date(),
-                                    standardizationStartTime: inputStandardizationStartTime,
-                                    uploadURL: self.uploadURL
-                                )
-
-                                self.startNetworkTransport(
-                                    videoFile: outputURL,
-                                    duration: inputDuration,
-                                    attempt: attempt
-                                )
                             }
-
-                            self.inputStandardizer.acknowledgeCompletion(id: self.id)
                         }
+                        self.registerStandardizationTask(task, for: attempt)
                     }
                 case (.some(_), .some(let error)):
                     self.handleInspectionFailure(
@@ -748,6 +779,8 @@ public final class DirectUpload {
         }
 
         activeAttempt = nil
+        let inputStandardizationTask = self.inputStandardizationTask
+        self.inputStandardizationTask = nil
         let fileWorker = self.fileWorker
         self.fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
@@ -756,6 +789,10 @@ public final class DirectUpload {
         }
         lifecycleLock.unlock()
 
+        inputStandardizationTask?.cancel()
+        Task {
+            await inputStandardizer.cancel(id: id)
+        }
         fileWorker?.cancel()
         cancellationNotification?()
     }
@@ -911,6 +948,8 @@ public final class DirectUpload {
 
         let cancelledAttempt = activeAttempt
         activeAttempt = nil
+        let inputStandardizationTask = self.inputStandardizationTask
+        self.inputStandardizationTask = nil
         let fileWorker = self.fileWorker
         self.fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
@@ -922,7 +961,10 @@ public final class DirectUpload {
         if let cancelledAttempt {
             inputInspectionOperations.cancel(for: cancelledAttempt.inspectionToken)
         }
-        inputStandardizer.cancel(id: id)
+        inputStandardizationTask?.cancel()
+        Task {
+            await inputStandardizer.cancel(id: id)
+        }
         fileWorker?.cancel()
         cancellationNotification?()
 

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -922,6 +922,7 @@ public final class DirectUpload {
         if let cancelledAttempt {
             inputInspectionOperations.cancel(for: cancelledAttempt.inspectionToken)
         }
+        inputStandardizer.cancel(id: id)
         fileWorker?.cancel()
         cancellationNotification?()
 

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -197,6 +197,7 @@ public final class DirectUpload {
     private struct UploadAttempt: Equatable {
         let id = UUID()
         let inspectionToken = UploadInputInspectionOperationRegistry.Token()
+        let standardizationToken = UploadInputStandardizationToken()
     }
 
     typealias FileWorkerFactory = (
@@ -573,6 +574,7 @@ public final class DirectUpload {
                                 do {
                                     _ = try await self.inputStandardizer.standardize(
                                         id: self.id,
+                                        token: attempt.standardizationToken,
                                         sourceAsset: sourceAsset,
                                         rescalingDetails: result.rescalingDetails,
                                         outputURL: outputURL
@@ -639,6 +641,7 @@ public final class DirectUpload {
                             do {
                                 _ = try await self.inputStandardizer.standardize(
                                     id: self.id,
+                                    token: attempt.standardizationToken,
                                     sourceAsset: sourceAsset,
                                     rescalingDetails: result.rescalingDetails,
                                     outputURL: outputURL
@@ -791,7 +794,10 @@ public final class DirectUpload {
 
         inputStandardizationTask?.cancel()
         Task {
-            await inputStandardizer.cancel(id: id)
+            await inputStandardizer.cancel(
+                id: id,
+                token: attempt.standardizationToken
+            )
         }
         fileWorker?.cancel()
         cancellationNotification?()
@@ -962,8 +968,13 @@ public final class DirectUpload {
             inputInspectionOperations.cancel(for: cancelledAttempt.inspectionToken)
         }
         inputStandardizationTask?.cancel()
-        Task {
-            await inputStandardizer.cancel(id: id)
+        if let cancelledAttempt {
+            Task {
+                await inputStandardizer.cancel(
+                    id: id,
+                    token: cancelledAttempt.standardizationToken
+                )
+            }
         }
         fileWorker?.cancel()
         cancellationNotification?()

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -10,10 +10,11 @@ import Foundation
 final class MockUploadInputStandardizer: UploadInputStandardizing {
     private(set) var standardizeCallCount = 0
     private(set) var acknowledgeCompletionCallCount = 0
+    private(set) var cancelCallCount = 0
 
     let error: Error
 
-    init(error: Error = StandardizationError.standardizedAssetExportFailure) {
+    init(error: Error = StandardizationError.conversionFailure) {
         self.error = error
     }
 
@@ -26,6 +27,10 @@ final class MockUploadInputStandardizer: UploadInputStandardizing {
     ) {
         standardizeCallCount += 1
         completion(sourceAsset, nil, error)
+    }
+
+    func cancel(id: String) {
+        cancelCallCount += 1
     }
 
     func acknowledgeCompletion(id: String) {

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -7,9 +7,13 @@ import Foundation
 
 @testable import MuxUploadSDK
 
-final class MockUploadInputStandardizer: UploadInputStandardizing {
+actor MockUploadInputStandardizer: UploadInputStandardizing {
+    struct Snapshot {
+        let standardizeCallCount: Int
+        let cancelCallCount: Int
+    }
+
     private(set) var standardizeCallCount = 0
-    private(set) var acknowledgeCompletionCallCount = 0
     private(set) var cancelCallCount = 0
 
     let error: Error
@@ -22,18 +26,20 @@ final class MockUploadInputStandardizer: UploadInputStandardizing {
         id: String,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL,
-        completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
-    ) {
+        outputURL: URL
+    ) async throws -> AVURLAsset {
         standardizeCallCount += 1
-        completion(sourceAsset, nil, error)
+        throw error
     }
 
     func cancel(id: String) {
         cancelCallCount += 1
     }
 
-    func acknowledgeCompletion(id: String) {
-        acknowledgeCompletionCallCount += 1
+    func snapshot() -> Snapshot {
+        Snapshot(
+            standardizeCallCount: standardizeCallCount,
+            cancelCallCount: cancelCallCount
+        )
     }
 }

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -24,6 +24,7 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
 
     func standardize(
         id: String,
+        token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
         outputURL: URL
@@ -32,7 +33,7 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
         throw error
     }
 
-    func cancel(id: String) {
+    func cancel(id: String, token: UploadInputStandardizationToken) {
         cancelCallCount += 1
     }
 

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/StandardInputPlannerTests.swift
@@ -599,6 +599,26 @@ final class StandardInputOutputValidatorTests: XCTestCase {
         XCTAssertEqual(validation.disposition, .accepted)
     }
 
+    func testGeneratedOutputAcceptsNearestEvenCinematicAspectRounding() throws {
+        var sourceFacts = compliantFacts(
+            dimensions: .init(width: 1920, height: 818)
+        )
+        sourceFacts.maximumKeyframeInterval = .known(21)
+        let conversion = try XCTUnwrap(makeConversion(facts: sourceFacts))
+        let outputFacts = compliantFacts(
+            dimensions: .init(width: 1280, height: 546)
+        )
+
+        let validation = validator.validateGeneratedOutput(
+            facts: outputFacts,
+            sourceTimeline: validTimeline(),
+            outputTimeline: validTimeline(),
+            for: conversion
+        )
+
+        XCTAssertEqual(validation.disposition, .accepted)
+    }
+
     func testGeneratedOutputAcceptsPortraitAlignmentWithinPixelBudget() throws {
         var sourceFacts = compliantFacts(
             dimensions: .init(width: 1080, height: 1920)

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -142,6 +142,40 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
     }
 
+    func testTransferFailureStopsAndDrainsEveryTrackExactlyOnce() {
+        let group = UploadInputStandardizationWorker.TransferGroup(trackCount: 2)
+        let completionExpectation = expectation(
+            description: "All failed transfers drain"
+        )
+        group.notify(queue: .main) {
+            completionExpectation.fulfill()
+        }
+
+        XCTAssertEqual(Set(group.stop(failed: true)), Set([0, 1]))
+        XCTAssertFalse(group.shouldContinue)
+        XCTAssertTrue(group.didFail)
+
+        for trackID in [0, 1] {
+            XCTAssertTrue(group.claimFinish(trackID: trackID))
+            XCTAssertFalse(group.claimFinish(trackID: trackID))
+            group.leave()
+        }
+
+        wait(for: [completionExpectation], timeout: 1)
+    }
+
+    func testTransferCancellationDrainsWithoutReportingFailure() {
+        let group = UploadInputStandardizationWorker.TransferGroup(trackCount: 2)
+
+        XCTAssertEqual(Set(group.stop()), Set([0, 1]))
+        XCTAssertFalse(group.shouldContinue)
+        XCTAssertFalse(group.didFail)
+
+        for trackID in [0, 1] where group.claimFinish(trackID: trackID) {
+            group.leave()
+        }
+    }
+
     func testCancelReleasesWorkerAndSuppressesCompletion() {
         let worker = ControllableWorker()
         let standardizer = UploadInputStandardizer { worker }
@@ -272,6 +306,38 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
     }
 
+    func testCatalogBackedCancellationDrainsActiveTransfers() throws {
+        let inputURL = try catalogFixtureURL(
+            id: "synthetic-standard-hevc-main10-sdr-2160p30-5-1"
+        )
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nat487-cancel-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        let transferStarted = expectation(description: "Transfer starts")
+        let completionExpectation = expectation(
+            description: "Cancelled transfer does not complete"
+        )
+        completionExpectation.isInverted = true
+
+        weak var cancellableWorker: UploadInputStandardizationWorker?
+        let worker = UploadInputStandardizationWorker {
+            transferStarted.fulfill()
+            cancellableWorker?.cancel()
+        }
+        cancellableWorker = worker
+        worker.standardize(
+            sourceAsset: AVURLAsset(url: inputURL),
+            rescalingDetails: .init(),
+            outputURL: outputURL
+        ) { _, _, _ in
+            completionExpectation.fulfill()
+        }
+
+        wait(for: [transferStarted], timeout: 2)
+        wait(for: [completionExpectation], timeout: 0.5)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+    }
+
     private func assertConversion(
         inputURL: URL,
         expectedCodec: AVVideoCodecType,
@@ -368,6 +434,21 @@ final class UploadInputStandardizerTests: XCTestCase {
             }
         }
         wait(for: [inspectionExpectation], timeout: 10)
+    }
+
+    private func catalogFixtureURL(id: String) throws -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        guard let fixtureDirectory = environment["MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY"],
+              let catalogPath = environment["MUX_UPLOAD_MEDIA_FIXTURE_CATALOG"] else {
+            throw XCTSkip("External media fixture environment is not configured")
+        }
+        let catalog = try JSONDecoder().decode(
+            FixtureCatalog.self,
+            from: Data(contentsOf: URL(fileURLWithPath: catalogPath))
+        )
+        let fixture = try XCTUnwrap(catalog.fixtures.first { $0.id == id })
+        return URL(fileURLWithPath: fixtureDirectory)
+            .appendingPathComponent(fixture.canonicalFilename)
     }
 
     private func makeHEVCFormatDescription(

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -175,10 +175,10 @@ final class UploadInputStandardizerTests: XCTestCase {
                 id: id,
                 token: token,
                 sourceAsset: AVURLAsset(
-                    url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+                    url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
                 ),
                 rescalingDetails: .init(),
-                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+                outputURL: URL(fileURLWithPath: "/tmp/missing-standardization-output.mp4")
             )
         }
         await worker.waitUntilStarted()
@@ -208,7 +208,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
         let id = UUID().uuidString
         let sourceAsset = AVURLAsset(
-            url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+            url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
         )
 
         let firstTask = Task {
@@ -217,7 +217,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                 token: firstToken,
                 sourceAsset: sourceAsset,
                 rescalingDetails: .init(),
-                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-first.mp4")
+                outputURL: URL(fileURLWithPath: "/tmp/missing-first-output.mp4")
             )
         }
         await firstWorker.waitUntilStarted()
@@ -228,7 +228,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                 token: replacementToken,
                 sourceAsset: sourceAsset,
                 rescalingDetails: .init(),
-                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-replacement.mp4")
+                outputURL: URL(fileURLWithPath: "/tmp/missing-replacement-output.mp4")
             )
         }
         await replacementWorker.waitUntilStarted()
@@ -251,10 +251,10 @@ final class UploadInputStandardizerTests: XCTestCase {
         do {
             _ = try await worker.standardize(
                 sourceAsset: AVURLAsset(
-                    url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+                    url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
                 ),
                 rescalingDetails: .init(),
-                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+                outputURL: URL(fileURLWithPath: "/tmp/missing-standardization-output.mp4")
             )
             XCTFail("Cancelled worker should throw")
         } catch is CancellationError {
@@ -266,7 +266,7 @@ final class UploadInputStandardizerTests: XCTestCase {
 
     func testCancelDoesNotDeleteAnOutputFileTheWorkerDoesNotOwn() async throws {
         let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("nat487-existing-\(UUID().uuidString).mp4")
+            .appendingPathComponent("standardization-existing-\(UUID().uuidString).mp4")
         let existingData = Data("existing".utf8)
         try existingData.write(to: outputURL)
         defer { try? FileManager.default.removeItem(at: outputURL) }
@@ -275,7 +275,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         await worker.cancel()
         _ = try? await worker.standardize(
             sourceAsset: AVURLAsset(
-                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+                url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
             ),
             rescalingDetails: .init(),
             outputURL: outputURL
@@ -352,7 +352,7 @@ final class UploadInputStandardizerTests: XCTestCase {
             id: "synthetic-standard-hevc-main10-sdr-2160p30-5-1"
         )
         let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("nat487-cancel-\(UUID().uuidString).mp4")
+            .appendingPathComponent("standardization-cancel-\(UUID().uuidString).mp4")
         defer { try? FileManager.default.removeItem(at: outputURL) }
         let transferStarted = expectation(description: "Transfer starts")
         let worker = UploadInputStandardizationWorker { worker in
@@ -384,7 +384,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         expectedAudioChannels: UInt32
     ) async throws {
         let outputURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("nat487-\(UUID().uuidString).mp4")
+            .appendingPathComponent("standardized-\(UUID().uuidString).mp4")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         let worker = UploadInputStandardizationWorker()

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -8,18 +8,41 @@ import XCTest
 @testable import MuxUploadSDK
 
 final class UploadInputStandardizerTests: XCTestCase {
-    private final class ControllableWorker: UploadInputStandardizationWorking {
+    private actor ControllableWorker: UploadInputStandardizationWorking {
         private(set) var cancellationCount = 0
+        private var isCancelled = false
+        private var continuation: CheckedContinuation<AVURLAsset, Error>?
+        private var didStart = false
+        private var startWaiters: [CheckedContinuation<Void, Never>] = []
 
         func standardize(
             sourceAsset: AVURLAsset,
             rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-            outputURL: URL,
-            completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
-        ) {}
+            outputURL: URL
+        ) async throws -> AVURLAsset {
+            if isCancelled {
+                throw CancellationError()
+            }
+            didStart = true
+            startWaiters.forEach { $0.resume() }
+            startWaiters = []
+            return try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
+
+        func waitUntilStarted() async {
+            guard !didStart else { return }
+            await withCheckedContinuation { continuation in
+                startWaiters.append(continuation)
+            }
+        }
 
         func cancel() {
             cancellationCount += 1
+            isCancelled = true
+            continuation?.resume(throwing: CancellationError())
+            continuation = nil
         }
     }
 
@@ -142,88 +165,57 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
     }
 
-    func testTransferFailureStopsAndDrainsEveryTrackExactlyOnce() {
-        let group = UploadInputStandardizationWorker.TransferGroup(trackCount: 2)
-        let completionExpectation = expectation(
-            description: "All failed transfers drain"
-        )
-        group.notify(queue: .main) {
-            completionExpectation.fulfill()
-        }
-
-        XCTAssertEqual(Set(group.stop(failed: true)), Set([0, 1]))
-        XCTAssertFalse(group.shouldContinue)
-        XCTAssertTrue(group.didFail)
-
-        for trackID in [0, 1] {
-            XCTAssertTrue(group.claimFinish(trackID: trackID))
-            XCTAssertFalse(group.claimFinish(trackID: trackID))
-            group.leave()
-        }
-
-        wait(for: [completionExpectation], timeout: 1)
-    }
-
-    func testTransferCancellationDrainsWithoutReportingFailure() {
-        let group = UploadInputStandardizationWorker.TransferGroup(trackCount: 2)
-
-        XCTAssertEqual(Set(group.stop()), Set([0, 1]))
-        XCTAssertFalse(group.shouldContinue)
-        XCTAssertFalse(group.didFail)
-
-        for trackID in [0, 1] where group.claimFinish(trackID: trackID) {
-            group.leave()
-        }
-    }
-
-    func testCancelReleasesWorkerAndSuppressesCompletion() {
+    func testCancelReleasesWorkerAndSuppressesCompletion() async {
         let worker = ControllableWorker()
         let standardizer = UploadInputStandardizer { worker }
         let id = UUID().uuidString
-        let completionExpectation = expectation(
-            description: "Cancelled conversion does not complete"
-        )
-        completionExpectation.isInverted = true
-
-        standardizer.standardize(
-            id: id,
-            sourceAsset: AVURLAsset(
-                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
-            ),
-            rescalingDetails: .init(),
-            outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
-        ) { _, _, _ in
-            completionExpectation.fulfill()
+        let task = Task {
+            try await standardizer.standardize(
+                id: id,
+                sourceAsset: AVURLAsset(
+                    url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+                ),
+                rescalingDetails: .init(),
+                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+            )
         }
-        standardizer.cancel(id: id)
+        await worker.waitUntilStarted()
+        await standardizer.cancel(id: id)
 
-        wait(for: [completionExpectation], timeout: 0.25)
-        XCTAssertEqual(worker.cancellationCount, 1)
-        XCTAssertNil(standardizer.workers[id])
+        do {
+            _ = try await task.value
+            XCTFail("Cancelled standardization should throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        let cancellationCount = await worker.cancellationCount
+        let hasActiveWorker = await standardizer.hasWorker(id: id)
+        XCTAssertEqual(cancellationCount, 1)
+        XCTAssertFalse(hasActiveWorker)
     }
 
-    func testCancelledWorkerSuppressesCompletion() {
+    func testCancelledWorkerSuppressesCompletion() async {
         let worker = UploadInputStandardizationWorker()
-        let completionExpectation = expectation(
-            description: "Cancelled worker does not complete"
-        )
-        completionExpectation.isInverted = true
-
-        worker.cancel()
-        worker.standardize(
-            sourceAsset: AVURLAsset(
-                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
-            ),
-            rescalingDetails: .init(),
-            outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
-        ) { _, _, _ in
-            completionExpectation.fulfill()
+        await worker.cancel()
+        do {
+            _ = try await worker.standardize(
+                sourceAsset: AVURLAsset(
+                    url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+                ),
+                rescalingDetails: .init(),
+                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+            )
+            XCTFail("Cancelled worker should throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
-
-        wait(for: [completionExpectation], timeout: 0.25)
     }
 
-    func testCancelDoesNotDeleteAnOutputFileTheWorkerDoesNotOwn() throws {
+    func testCancelDoesNotDeleteAnOutputFileTheWorkerDoesNotOwn() async throws {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("nat487-existing-\(UUID().uuidString).mp4")
         let existingData = Data("existing".utf8)
@@ -231,19 +223,19 @@ final class UploadInputStandardizerTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
         let worker = UploadInputStandardizationWorker()
-        worker.standardize(
+        await worker.cancel()
+        _ = try? await worker.standardize(
             sourceAsset: AVURLAsset(
                 url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
             ),
             rescalingDetails: .init(),
             outputURL: outputURL
-        ) { _, _, _ in }
-        worker.cancel()
+        )
 
         XCTAssertEqual(try Data(contentsOf: outputURL), existingData)
     }
 
-    func testCatalogBackedCodecPreservingMP4AACConversion() throws {
+    func testCatalogBackedCodecPreservingMP4AACConversion() async throws {
         let environment = ProcessInfo.processInfo.environment
         guard let fixtureDirectory = environment["MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY"],
               let catalogPath = environment["MUX_UPLOAD_MEDIA_FIXTURE_CATALOG"] else {
@@ -295,7 +287,7 @@ final class UploadInputStandardizerTests: XCTestCase {
             let fixture = try XCTUnwrap(
                 catalog.fixtures.first { $0.id == testCase.id }
             )
-            try assertConversion(
+            try await assertConversion(
                 inputURL: URL(fileURLWithPath: fixtureDirectory)
                     .appendingPathComponent(fixture.canonicalFilename),
                 expectedCodec: testCase.codec,
@@ -306,7 +298,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
     }
 
-    func testCatalogBackedCancellationDrainsActiveTransfers() throws {
+    func testCatalogBackedCancellationDrainsActiveTransfers() async throws {
         let inputURL = try catalogFixtureURL(
             id: "synthetic-standard-hevc-main10-sdr-2160p30-5-1"
         )
@@ -314,27 +306,24 @@ final class UploadInputStandardizerTests: XCTestCase {
             .appendingPathComponent("nat487-cancel-\(UUID().uuidString).mp4")
         defer { try? FileManager.default.removeItem(at: outputURL) }
         let transferStarted = expectation(description: "Transfer starts")
-        let completionExpectation = expectation(
-            description: "Cancelled transfer does not complete"
-        )
-        completionExpectation.isInverted = true
-
-        weak var cancellableWorker: UploadInputStandardizationWorker?
-        let worker = UploadInputStandardizationWorker {
+        let worker = UploadInputStandardizationWorker { worker in
             transferStarted.fulfill()
-            cancellableWorker?.cancel()
+            await worker.cancel()
         }
-        cancellableWorker = worker
-        worker.standardize(
-            sourceAsset: AVURLAsset(url: inputURL),
-            rescalingDetails: .init(),
-            outputURL: outputURL
-        ) { _, _, _ in
-            completionExpectation.fulfill()
+        do {
+            _ = try await worker.standardize(
+                sourceAsset: AVURLAsset(url: inputURL),
+                rescalingDetails: .init(),
+                outputURL: outputURL
+            )
+            XCTFail("Cancelled transfer should throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
         }
 
-        wait(for: [transferStarted], timeout: 2)
-        wait(for: [completionExpectation], timeout: 0.5)
+        await fulfillment(of: [transferStarted], timeout: 2)
         XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
     }
 
@@ -344,96 +333,65 @@ final class UploadInputStandardizerTests: XCTestCase {
         expectedBitDepth: Int,
         expectedDimensions: CGSize,
         expectedAudioChannels: UInt32
-    ) throws {
+    ) async throws {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("nat487-\(UUID().uuidString).mp4")
         defer { try? FileManager.default.removeItem(at: outputURL) }
 
-        let completionExpectation = expectation(
-            description: "Conversion completes for \(inputURL.lastPathComponent)"
-        )
-        var conversionError: Error?
         let worker = UploadInputStandardizationWorker()
-        worker.standardize(
+        let standardizedAsset = try await worker.standardize(
             sourceAsset: AVURLAsset(url: inputURL),
             rescalingDetails: .init(
                 maximumDesiredResolutionPreset: .default,
                 recordedResolution: .init(width: 0, height: 0)
             ),
             outputURL: outputURL
-        ) { _, standardizedAsset, error in
-            conversionError = error
-            XCTAssertNotNil(standardizedAsset)
-            completionExpectation.fulfill()
-        }
-        wait(for: [completionExpectation], timeout: 60)
-        XCTAssertNil(conversionError)
+        )
+        XCTAssertEqual(standardizedAsset.url, outputURL)
 
         let outputAsset = AVURLAsset(url: outputURL)
-        let inspectionExpectation = expectation(
-            description: "Converted tracks can be read"
+        let videoTracks = try await outputAsset.loadTracks(withMediaType: .video)
+        let videoTrack = try XCTUnwrap(videoTracks.first)
+        let (videoFormats, naturalSize) = try await videoTrack.load(
+            .formatDescriptions,
+            .naturalSize
         )
-        outputAsset.loadTracks(withMediaType: .video) { videoTracks, videoError in
-            XCTAssertNil(videoError)
-            guard let videoTrack = videoTracks?.first else {
-                XCTFail("Missing converted video track")
-                inspectionExpectation.fulfill()
-                return
-            }
-            videoTrack.loadValuesAsynchronously(
-                forKeys: ["formatDescriptions", "naturalSize"]
-            ) {
-                let formatDescription = (videoTrack.formatDescriptions
-                    as? [CMFormatDescription])?.first
-                XCTAssertEqual(
-                    formatDescription?.mediaSubType,
-                    expectedCodec == .hevc ? .hevc : .h264
-                )
-                if let formatDescription,
-                   let extensions = CMFormatDescriptionGetExtensions(formatDescription)
-                    as NSDictionary? {
-                    XCTAssertEqual(
-                        AVFoundationUploadInputMetadataReader.codecConfiguration(
-                            codec: expectedCodec == .hevc ? .hevc : .h264,
-                            extensions: extensions
-                        )?.bitDepth,
-                        expectedBitDepth
-                    )
-                } else {
-                    XCTFail("Missing converted video format description")
-                }
-                XCTAssertEqual(videoTrack.naturalSize, expectedDimensions)
-                outputAsset.loadTracks(withMediaType: .audio) { audioTracks, audioError in
-                    XCTAssertNil(audioError)
-                    guard let audioTrack = audioTracks?.first else {
-                        XCTFail("Missing converted audio track")
-                        inspectionExpectation.fulfill()
-                        return
-                    }
-                    audioTrack.loadValuesAsynchronously(
-                        forKeys: ["formatDescriptions"]
-                    ) {
-                        let audioFormat = (audioTrack.formatDescriptions
-                            as? [CMAudioFormatDescription])?.first
-                        XCTAssertEqual(
-                            audioFormat?.mediaSubType,
-                            CMFormatDescription.MediaSubType(
-                                rawValue: kAudioFormatMPEG4AAC
-                            )
-                        )
-                        XCTAssertEqual(
-                            audioFormat.flatMap {
-                                CMAudioFormatDescriptionGetStreamBasicDescription($0)?
-                                    .pointee.mChannelsPerFrame
-                            },
-                            expectedAudioChannels
-                        )
-                        inspectionExpectation.fulfill()
-                    }
-                }
-            }
+        let formatDescription = videoFormats.first
+        XCTAssertEqual(
+            formatDescription?.mediaSubType,
+            expectedCodec == .hevc ? .hevc : .h264
+        )
+        if let formatDescription,
+           let extensions = CMFormatDescriptionGetExtensions(formatDescription)
+            as NSDictionary? {
+            XCTAssertEqual(
+                AVFoundationUploadInputMetadataReader.codecConfiguration(
+                    codec: expectedCodec == .hevc ? .hevc : .h264,
+                    extensions: extensions
+                )?.bitDepth,
+                expectedBitDepth
+            )
+        } else {
+            XCTFail("Missing converted video format description")
         }
-        wait(for: [inspectionExpectation], timeout: 10)
+        XCTAssertEqual(naturalSize, expectedDimensions)
+
+        let audioTracks = try await outputAsset.loadTracks(withMediaType: .audio)
+        let audioTrack = try XCTUnwrap(audioTracks.first)
+        let audioFormat = try await audioTrack.load(.formatDescriptions).first
+        XCTAssertEqual(
+            audioFormat?.mediaSubType,
+            CMFormatDescription.MediaSubType(
+                rawValue: kAudioFormatMPEG4AAC
+            )
+        )
+        XCTAssertEqual(
+            audioFormat.flatMap {
+                CMAudioFormatDescriptionGetStreamBasicDescription($0)?
+                    .pointee.mChannelsPerFrame
+            },
+            expectedAudioChannels
+        )
     }
 
     private func catalogFixtureURL(id: String) throws -> URL {

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -265,23 +265,61 @@ final class UploadInputStandardizerTests: XCTestCase {
     }
 
     func testCancelDoesNotDeleteAnOutputFileTheWorkerDoesNotOwn() async throws {
+        let inputURL = try await makeGeneratedH264Asset()
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("standardization-existing-\(UUID().uuidString).mp4")
         let existingData = Data("existing".utf8)
         try existingData.write(to: outputURL)
-        defer { try? FileManager.default.removeItem(at: outputURL) }
+        defer {
+            try? FileManager.default.removeItem(at: inputURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
 
         let worker = UploadInputStandardizationWorker()
-        await worker.cancel()
-        _ = try? await worker.standardize(
-            sourceAsset: AVURLAsset(
-                url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
-            ),
+        do {
+            _ = try await worker.standardize(
+                sourceAsset: AVURLAsset(url: inputURL),
+                rescalingDetails: .init(),
+                outputURL: outputURL
+            )
+            XCTFail("Standardization should reject an existing output file")
+        } catch {
+            XCTAssertEqual(
+                error.localizedDescription,
+                StandardizationError.outputFileAlreadyExists.localizedDescription
+            )
+        }
+
+        XCTAssertEqual(try Data(contentsOf: outputURL), existingData)
+    }
+
+    func testGeneratedH264ConversionRunsWithoutExternalFixtures() async throws {
+        let inputURL = try await makeGeneratedH264Asset()
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("standardized-generated-\(UUID().uuidString).mp4")
+        defer {
+            try? FileManager.default.removeItem(at: inputURL)
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+
+        let worker = UploadInputStandardizationWorker()
+        let standardizedAsset = try await worker.standardize(
+            sourceAsset: AVURLAsset(url: inputURL),
             rescalingDetails: .init(),
             outputURL: outputURL
         )
 
-        XCTAssertEqual(try Data(contentsOf: outputURL), existingData)
+        XCTAssertEqual(standardizedAsset.url, outputURL)
+        let videoTracks = try await standardizedAsset.loadTracks(withMediaType: .video)
+        let videoTrack = try XCTUnwrap(videoTracks.first)
+        let (formatDescriptions, naturalSize) = try await videoTrack.load(
+            .formatDescriptions,
+            .naturalSize
+        )
+        XCTAssertEqual(formatDescriptions.first?.mediaSubType, .h264)
+        XCTAssertEqual(naturalSize, CGSize(width: 64, height: 64))
+        let audioTracks = try await standardizedAsset.loadTracks(withMediaType: .audio)
+        XCTAssertTrue(audioTracks.isEmpty)
     }
 
     func testCatalogBackedCodecPreservingMP4AACConversion() async throws {
@@ -456,6 +494,96 @@ final class UploadInputStandardizerTests: XCTestCase {
         let fixture = try XCTUnwrap(catalog.fixtures.first { $0.id == id })
         return URL(fileURLWithPath: fixtureDirectory)
             .appendingPathComponent(fixture.canonicalFilename)
+    }
+
+    private func makeGeneratedH264Asset() async throws -> URL {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("generated-h264-\(UUID().uuidString).mp4")
+        var didFinish = false
+        defer {
+            if !didFinish {
+                try? FileManager.default.removeItem(at: outputURL)
+            }
+        }
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let input = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: 64,
+                AVVideoHeightKey: 64
+            ]
+        )
+        input.expectsMediaDataInRealTime = false
+        guard writer.canAdd(input) else {
+            throw StandardizationError.cannotAddWriterInput
+        }
+        writer.add(input)
+
+        let pixelBufferAttributes: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String:
+                kCVPixelFormatType_32BGRA,
+            kCVPixelBufferWidthKey as String: 64,
+            kCVPixelBufferHeightKey as String: 64,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+        ]
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: pixelBufferAttributes
+        )
+
+        guard writer.startWriting() else {
+            throw writer.error ?? StandardizationError.writerStartFailure
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        for frameIndex in 0..<3 {
+            for _ in 0..<1_000 {
+                if input.isReadyForMoreMediaData { break }
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+            guard input.isReadyForMoreMediaData else {
+                throw StandardizationError.conversionFailure
+            }
+
+            var pixelBuffer: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault,
+                64,
+                64,
+                kCVPixelFormatType_32BGRA,
+                pixelBufferAttributes as CFDictionary,
+                &pixelBuffer
+            )
+            guard status == kCVReturnSuccess, let pixelBuffer else {
+                throw StandardizationError.conversionFailure
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) {
+                baseAddress.assumingMemoryBound(to: UInt8.self).initialize(
+                    repeating: UInt8(48 + frameIndex * 24),
+                    count: CVPixelBufferGetBytesPerRow(pixelBuffer)
+                        * CVPixelBufferGetHeight(pixelBuffer)
+                )
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+
+            guard adaptor.append(
+                pixelBuffer,
+                withPresentationTime: CMTime(value: CMTimeValue(frameIndex), timescale: 30)
+            ) else {
+                throw writer.error ?? StandardizationError.conversionFailure
+            }
+        }
+
+        input.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? StandardizationError.conversionFailure
+        }
+        didFinish = true
+        return outputURL
     }
 
     private func makeHEVCFormatDescription(

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -167,11 +167,13 @@ final class UploadInputStandardizerTests: XCTestCase {
 
     func testCancelReleasesWorkerAndSuppressesCompletion() async {
         let worker = ControllableWorker()
-        let standardizer = UploadInputStandardizer { worker }
+        let standardizer = UploadInputStandardizer { _ in worker }
         let id = UUID().uuidString
+        let token = UploadInputStandardizationToken()
         let task = Task {
             try await standardizer.standardize(
                 id: id,
+                token: token,
                 sourceAsset: AVURLAsset(
                     url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
                 ),
@@ -180,7 +182,7 @@ final class UploadInputStandardizerTests: XCTestCase {
             )
         }
         await worker.waitUntilStarted()
-        await standardizer.cancel(id: id)
+        await standardizer.cancel(id: id, token: token)
 
         do {
             _ = try await task.value
@@ -194,6 +196,53 @@ final class UploadInputStandardizerTests: XCTestCase {
         let hasActiveWorker = await standardizer.hasWorker(id: id)
         XCTAssertEqual(cancellationCount, 1)
         XCTAssertFalse(hasActiveWorker)
+    }
+
+    func testStaleCancelDoesNotCancelReplacementWorker() async {
+        let firstToken = UploadInputStandardizationToken()
+        let replacementToken = UploadInputStandardizationToken()
+        let firstWorker = ControllableWorker()
+        let replacementWorker = ControllableWorker()
+        let standardizer = UploadInputStandardizer { token in
+            token == firstToken ? firstWorker : replacementWorker
+        }
+        let id = UUID().uuidString
+        let sourceAsset = AVURLAsset(
+            url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+        )
+
+        let firstTask = Task {
+            try await standardizer.standardize(
+                id: id,
+                token: firstToken,
+                sourceAsset: sourceAsset,
+                rescalingDetails: .init(),
+                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-first.mp4")
+            )
+        }
+        await firstWorker.waitUntilStarted()
+
+        let replacementTask = Task {
+            try await standardizer.standardize(
+                id: id,
+                token: replacementToken,
+                sourceAsset: sourceAsset,
+                rescalingDetails: .init(),
+                outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-replacement.mp4")
+            )
+        }
+        await replacementWorker.waitUntilStarted()
+
+        await standardizer.cancel(id: id, token: firstToken)
+
+        let replacementCancellationCount = await replacementWorker.cancellationCount
+        let hasReplacementWorker = await standardizer.hasWorker(id: id)
+        XCTAssertEqual(replacementCancellationCount, 0)
+        XCTAssertTrue(hasReplacementWorker)
+
+        await standardizer.cancel(id: id, token: replacementToken)
+        _ = await firstTask.result
+        _ = await replacementTask.result
     }
 
     func testCancelledWorkerSuppressesCompletion() async {

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -8,36 +8,390 @@ import XCTest
 @testable import MuxUploadSDK
 
 final class UploadInputStandardizerTests: XCTestCase {
+    private final class ControllableWorker: UploadInputStandardizationWorking {
+        private(set) var cancellationCount = 0
 
-    func testSynchronousFailureAcknowledgementDoesNotRetainWorker() {
-        let standardizer = UploadInputStandardizer()
+        func standardize(
+            sourceAsset: AVURLAsset,
+            rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+            outputURL: URL,
+            completion: @escaping (AVURLAsset, AVAsset?, Error?) -> ()
+        ) {}
+
+        func cancel() {
+            cancellationCount += 1
+        }
+    }
+
+    private struct FixtureCatalog: Decodable {
+        struct Fixture: Decodable {
+            let id: String
+            let canonicalFilename: String
+        }
+
+        let fixtures: [Fixture]
+    }
+
+    func testOutputCodecPreservesH264AndHEVC() {
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(for: .h264),
+            .h264
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(for: .hevc),
+            .hevc
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(
+                for: .init(rawValue: 0x61766333)
+            ),
+            .h264
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(
+                for: .init(rawValue: 0x68657631)
+            ),
+            .hevc
+        )
+    }
+
+    func testOutputCodecUsesH264ForOtherDecodableFormats() {
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(for: .proRes422),
+            .h264
+        )
+    }
+
+    func testDecoderPixelFormatPreservesSupportedHEVCBitDepth() throws {
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.decoderPixelFormat(
+                for: try makeHEVCFormatDescription(bitDepth: 8)
+            ),
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.decoderPixelFormat(
+                for: try makeHEVCFormatDescription(bitDepth: 10)
+            ),
+            kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+        )
+    }
+
+    func testRenderSizeDoesNotUpscale() throws {
+        XCTAssertEqual(
+            try UploadInputStandardizationWorker.renderSize(
+                naturalSize: CGSize(width: 1280, height: 720),
+                preferredTransform: .identity,
+                boundingSize: CGSize(width: 1920, height: 1080)
+            ),
+            CGSize(width: 1280, height: 720)
+        )
+    }
+
+    func testRenderSizeScalesAndAppliesOrientation() throws {
+        let portraitTransform = CGAffineTransform(
+            a: 0,
+            b: 1,
+            c: -1,
+            d: 0,
+            tx: 2160,
+            ty: 0
+        )
+        XCTAssertEqual(
+            try UploadInputStandardizationWorker.renderSize(
+                naturalSize: CGSize(width: 3840, height: 2160),
+                preferredTransform: portraitTransform,
+                boundingSize: CGSize(width: 1920, height: 1080)
+            ),
+            CGSize(width: 1080, height: 1920)
+        )
+    }
+
+    func testRenderSizeFitsBothOutputAxes() throws {
+        XCTAssertEqual(
+            try UploadInputStandardizationWorker.renderSize(
+                naturalSize: CGSize(width: 4000, height: 3000),
+                preferredTransform: .identity,
+                boundingSize: CGSize(width: 1920, height: 1080)
+            ),
+            CGSize(width: 1440, height: 1080)
+        )
+    }
+
+    func testRenderSizeRoundsToNearestEvenDimensions() throws {
+        XCTAssertEqual(
+            try UploadInputStandardizationWorker.renderSize(
+                naturalSize: CGSize(width: 1920, height: 818),
+                preferredTransform: .identity,
+                boundingSize: CGSize(width: 1280, height: 720)
+            ),
+            CGSize(width: 1280, height: 546)
+        )
+    }
+
+    func testUnreadableAudioFormatFailsInsteadOfGuessing() {
+        XCTAssertThrowsError(
+            try UploadInputStandardizationWorker.audioProperties(
+                formatDescriptions: []
+            )
+        ) { error in
+            XCTAssertEqual(
+                error.localizedDescription,
+                StandardizationError.missingAudioFormat.localizedDescription
+            )
+        }
+    }
+
+    func testCancelReleasesWorkerAndSuppressesCompletion() {
+        let worker = ControllableWorker()
+        let standardizer = UploadInputStandardizer { worker }
         let id = UUID().uuidString
-        let sourceAsset = AVURLAsset(
-            url: URL(fileURLWithPath: "/tmp/input.mp4")
-        )
         let completionExpectation = expectation(
-            description: "Expected unsupported tier to fail synchronously"
+            description: "Cancelled conversion does not complete"
         )
+        completionExpectation.isInverted = true
 
         standardizer.standardize(
             id: id,
-            sourceAsset: sourceAsset,
-            rescalingDetails: .init(
-                maximumDesiredResolutionPreset: .preset2560x1440,
-                recordedResolution: .init(width: 3840, height: 2160)
+            sourceAsset: AVURLAsset(
+                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
             ),
-            outputURL: URL(fileURLWithPath: "/tmp/output.mp4")
-        ) { _, standardizedAsset, error in
-            XCTAssertNil(standardizedAsset)
-            XCTAssertEqual(
-                error?.localizedDescription,
-                StandardizationError.unsupportedResolutionTier.localizedDescription
-            )
-            standardizer.acknowledgeCompletion(id: id)
+            rescalingDetails: .init(),
+            outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+        ) { _, _, _ in
+            completionExpectation.fulfill()
+        }
+        standardizer.cancel(id: id)
+
+        wait(for: [completionExpectation], timeout: 0.25)
+        XCTAssertEqual(worker.cancellationCount, 1)
+        XCTAssertNil(standardizer.workers[id])
+    }
+
+    func testCancelledWorkerSuppressesCompletion() {
+        let worker = UploadInputStandardizationWorker()
+        let completionExpectation = expectation(
+            description: "Cancelled worker does not complete"
+        )
+        completionExpectation.isInverted = true
+
+        worker.cancel()
+        worker.standardize(
+            sourceAsset: AVURLAsset(
+                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+            ),
+            rescalingDetails: .init(),
+            outputURL: URL(fileURLWithPath: "/tmp/missing-nat487-output.mp4")
+        ) { _, _, _ in
             completionExpectation.fulfill()
         }
 
-        wait(for: [completionExpectation], timeout: 1.0)
-        XCTAssertNil(standardizer.workers[id])
+        wait(for: [completionExpectation], timeout: 0.25)
+    }
+
+    func testCancelDoesNotDeleteAnOutputFileTheWorkerDoesNotOwn() throws {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nat487-existing-\(UUID().uuidString).mp4")
+        let existingData = Data("existing".utf8)
+        try existingData.write(to: outputURL)
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let worker = UploadInputStandardizationWorker()
+        worker.standardize(
+            sourceAsset: AVURLAsset(
+                url: URL(fileURLWithPath: "/tmp/missing-nat487-input.mp4")
+            ),
+            rescalingDetails: .init(),
+            outputURL: outputURL
+        ) { _, _, _ in }
+        worker.cancel()
+
+        XCTAssertEqual(try Data(contentsOf: outputURL), existingData)
+    }
+
+    func testCatalogBackedCodecPreservingMP4AACConversion() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let fixtureDirectory = environment["MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY"],
+              let catalogPath = environment["MUX_UPLOAD_MEDIA_FIXTURE_CATALOG"] else {
+            throw XCTSkip("External media fixture environment is not configured")
+        }
+
+        let catalog = try JSONDecoder().decode(
+            FixtureCatalog.self,
+            from: Data(contentsOf: URL(fileURLWithPath: catalogPath))
+        )
+        let cases: [(
+            id: String,
+            codec: AVVideoCodecType,
+            bitDepth: Int,
+            dimensions: CGSize,
+            audioChannels: UInt32
+        )] = [
+            (
+                "synthetic-standard-h264-sdr-2160p30-stereo",
+                .h264,
+                8,
+                CGSize(width: 1920, height: 1080),
+                2
+            ),
+            (
+                "synthetic-standard-hevc-main-sdr-1440p30-stereo",
+                .hevc,
+                8,
+                CGSize(width: 1920, height: 1080),
+                2
+            ),
+            (
+                "synthetic-standard-hevc-main10-sdr-2160p30-5-1",
+                .hevc,
+                10,
+                CGSize(width: 1920, height: 1080),
+                6
+            ),
+            (
+                "synthetic-unsupported-prores-sdr-720p30-stereo",
+                .h264,
+                8,
+                CGSize(width: 1280, height: 720),
+                2
+            )
+        ]
+
+        for testCase in cases {
+            let fixture = try XCTUnwrap(
+                catalog.fixtures.first { $0.id == testCase.id }
+            )
+            try assertConversion(
+                inputURL: URL(fileURLWithPath: fixtureDirectory)
+                    .appendingPathComponent(fixture.canonicalFilename),
+                expectedCodec: testCase.codec,
+                expectedBitDepth: testCase.bitDepth,
+                expectedDimensions: testCase.dimensions,
+                expectedAudioChannels: testCase.audioChannels
+            )
+        }
+    }
+
+    private func assertConversion(
+        inputURL: URL,
+        expectedCodec: AVVideoCodecType,
+        expectedBitDepth: Int,
+        expectedDimensions: CGSize,
+        expectedAudioChannels: UInt32
+    ) throws {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("nat487-\(UUID().uuidString).mp4")
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+
+        let completionExpectation = expectation(
+            description: "Conversion completes for \(inputURL.lastPathComponent)"
+        )
+        var conversionError: Error?
+        let worker = UploadInputStandardizationWorker()
+        worker.standardize(
+            sourceAsset: AVURLAsset(url: inputURL),
+            rescalingDetails: .init(
+                maximumDesiredResolutionPreset: .default,
+                recordedResolution: .init(width: 0, height: 0)
+            ),
+            outputURL: outputURL
+        ) { _, standardizedAsset, error in
+            conversionError = error
+            XCTAssertNotNil(standardizedAsset)
+            completionExpectation.fulfill()
+        }
+        wait(for: [completionExpectation], timeout: 60)
+        XCTAssertNil(conversionError)
+
+        let outputAsset = AVURLAsset(url: outputURL)
+        let inspectionExpectation = expectation(
+            description: "Converted tracks can be read"
+        )
+        outputAsset.loadTracks(withMediaType: .video) { videoTracks, videoError in
+            XCTAssertNil(videoError)
+            guard let videoTrack = videoTracks?.first else {
+                XCTFail("Missing converted video track")
+                inspectionExpectation.fulfill()
+                return
+            }
+            videoTrack.loadValuesAsynchronously(
+                forKeys: ["formatDescriptions", "naturalSize"]
+            ) {
+                let formatDescription = (videoTrack.formatDescriptions
+                    as? [CMFormatDescription])?.first
+                XCTAssertEqual(
+                    formatDescription?.mediaSubType,
+                    expectedCodec == .hevc ? .hevc : .h264
+                )
+                if let formatDescription,
+                   let extensions = CMFormatDescriptionGetExtensions(formatDescription)
+                    as NSDictionary? {
+                    XCTAssertEqual(
+                        AVFoundationUploadInputMetadataReader.codecConfiguration(
+                            codec: expectedCodec == .hevc ? .hevc : .h264,
+                            extensions: extensions
+                        )?.bitDepth,
+                        expectedBitDepth
+                    )
+                } else {
+                    XCTFail("Missing converted video format description")
+                }
+                XCTAssertEqual(videoTrack.naturalSize, expectedDimensions)
+                outputAsset.loadTracks(withMediaType: .audio) { audioTracks, audioError in
+                    XCTAssertNil(audioError)
+                    guard let audioTrack = audioTracks?.first else {
+                        XCTFail("Missing converted audio track")
+                        inspectionExpectation.fulfill()
+                        return
+                    }
+                    audioTrack.loadValuesAsynchronously(
+                        forKeys: ["formatDescriptions"]
+                    ) {
+                        let audioFormat = (audioTrack.formatDescriptions
+                            as? [CMAudioFormatDescription])?.first
+                        XCTAssertEqual(
+                            audioFormat?.mediaSubType,
+                            CMFormatDescription.MediaSubType(
+                                rawValue: kAudioFormatMPEG4AAC
+                            )
+                        )
+                        XCTAssertEqual(
+                            audioFormat.flatMap {
+                                CMAudioFormatDescriptionGetStreamBasicDescription($0)?
+                                    .pointee.mChannelsPerFrame
+                            },
+                            expectedAudioChannels
+                        )
+                        inspectionExpectation.fulfill()
+                    }
+                }
+            }
+        }
+        wait(for: [inspectionExpectation], timeout: 10)
+    }
+
+    private func makeHEVCFormatDescription(
+        bitDepth: Int
+    ) throws -> CMVideoFormatDescription {
+        var configuration = Data(repeating: 0, count: 19)
+        configuration[0] = 1
+        configuration[16] = 1
+        configuration[17] = UInt8(bitDepth - 8)
+        configuration[18] = UInt8(bitDepth - 8)
+
+        var formatDescription: CMVideoFormatDescription?
+        let status = CMVideoFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            codecType: kCMVideoCodecType_HEVC,
+            width: 1920,
+            height: 1080,
+            extensions: [
+                kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms:
+                    ["hvcC": configuration]
+            ] as CFDictionary,
+            formatDescriptionOut: &formatDescription
+        )
+        XCTAssertEqual(status, noErr)
+        return try XCTUnwrap(formatDescription)
     }
 }

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -81,7 +81,7 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() throws {
+    func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() async throws {
         let input = try UploadInput.mockReadyInput()
         let inspector = MockUploadInputInspector()
         let standardizer = MockUploadInputStandardizer()
@@ -122,13 +122,17 @@ class DirectUploadTests: XCTestCase {
         inspector.completeDeferredInspection()
 
         XCTAssertTrue(operation.isCancelled)
-        XCTAssertEqual(standardizer.cancelCallCount, 1)
+        let standardizerSnapshot = await waitForStandardizer(
+            standardizer,
+            cancelCallCount: 1
+        )
+        XCTAssertEqual(standardizerSnapshot.cancelCallCount, 1)
         XCTAssertNil(upload.fileWorker)
         guard case .ready = upload.inputStatus else {
             return XCTFail("Expected cancellation to reset the upload to ready")
         }
-        wait(
-            for: [cancellationExpectation, transportExpectation],
+        await fulfillment(
+            of: [cancellationExpectation, transportExpectation],
             timeout: 0.1
         )
     }
@@ -344,8 +348,8 @@ class DirectUploadTests: XCTestCase {
         upload.cancel()
     }
 
-    func testHandlerReturningTrueCancelsAfterRescalingFailure() throws {
-        try assertStandardizationFailureBehavior(
+    func testHandlerReturningTrueCancelsAfterRescalingFailure() async throws {
+        try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [],
                 rescalingDetails: .init(
@@ -357,8 +361,8 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testHandlerReturningFalseUploadsOriginalAfterRescalingFailure() throws {
-        try assertStandardizationFailureBehavior(
+    func testHandlerReturningFalseUploadsOriginalAfterRescalingFailure() async throws {
+        try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [],
                 rescalingDetails: .init(
@@ -370,8 +374,8 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testHandlerReturningTrueCancelsAfterNonstandardInputFailure() throws {
-        try assertStandardizationFailureBehavior(
+    func testHandlerReturningTrueCancelsAfterNonstandardInputFailure() async throws {
+        try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [.videoCodec],
                 rescalingDetails: .init()
@@ -380,8 +384,8 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testHandlerReturningFalseUploadsOriginalAfterNonstandardInputFailure() throws {
-        try assertStandardizationFailureBehavior(
+    func testHandlerReturningFalseUploadsOriginalAfterNonstandardInputFailure() async throws {
+        try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [.videoCodec],
                 rescalingDetails: .init()
@@ -393,7 +397,7 @@ class DirectUploadTests: XCTestCase {
     private func assertStandardizationFailureBehavior(
         inspectionResult: UploadInputFormatInspectionResult,
         shouldCancel: Bool
-    ) throws {
+    ) async throws {
         let input = try UploadInput.mockReadyInput()
         let standardizer = MockUploadInputStandardizer()
         let upload = DirectUpload(
@@ -405,17 +409,36 @@ class DirectUploadTests: XCTestCase {
             inputStandardizer: standardizer
         )
         var handlerCallCount = 0
+        let handlerExpectation = expectation(
+            description: "Standardization failure handler runs"
+        )
+        let finalStatusExpectation = expectation(
+            description: "Standardization failure reaches its final status"
+        )
 
         upload.nonStandardInputHandler = {
             handlerCallCount += 1
+            handlerExpectation.fulfill()
             return shouldCancel
+        }
+        upload.inputStatusHandler = { status in
+            if shouldCancel, case .ready = status {
+                finalStatusExpectation.fulfill()
+            } else if !shouldCancel, case .transportInProgress = status {
+                finalStatusExpectation.fulfill()
+            }
         }
 
         upload.start()
+        await fulfillment(
+            of: [handlerExpectation, finalStatusExpectation],
+            timeout: 2,
+            enforceOrder: true
+        )
 
         XCTAssertEqual(handlerCallCount, 1)
-        XCTAssertEqual(standardizer.standardizeCallCount, 1)
-        XCTAssertEqual(standardizer.acknowledgeCompletionCallCount, 1)
+        let standardizerSnapshot = await standardizer.snapshot()
+        XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 1)
 
         if shouldCancel {
             guard case .ready = upload.inputStatus else {
@@ -428,6 +451,20 @@ class DirectUploadTests: XCTestCase {
             XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
             upload.cancel()
         }
+    }
+
+    private func waitForStandardizer(
+        _ standardizer: MockUploadInputStandardizer,
+        cancelCallCount: Int
+    ) async -> MockUploadInputStandardizer.Snapshot {
+        for _ in 0..<100 {
+            let snapshot = await standardizer.snapshot()
+            if snapshot.cancelCallCount == cancelCallCount {
+                return snapshot
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return await standardizer.snapshot()
     }
 
 }

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -84,11 +84,13 @@ class DirectUploadTests: XCTestCase {
     func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() throws {
         let input = try UploadInput.mockReadyInput()
         let inspector = MockUploadInputInspector()
+        let standardizer = MockUploadInputStandardizer()
         inspector.shouldDeferCompletion = true
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
-            inputInspector: inspector
+            inputInspector: inspector,
+            inputStandardizer: standardizer
         )
         let cancellationExpectation = expectation(
             description: "Expected cancellation result during inspection"
@@ -120,6 +122,7 @@ class DirectUploadTests: XCTestCase {
         inspector.completeDeferredInspection()
 
         XCTAssertTrue(operation.isCancelled)
+        XCTAssertEqual(standardizer.cancelCallCount, 1)
         XCTAssertNil(upload.fileWorker)
         guard case .ready = upload.inputStatus else {
             return XCTFail("Expected cancellation to reset the upload to ready")


### PR DESCRIPTION
## Summary

- replace the export-session standardizer with a cancellable `AVAssetReader`/`AVAssetWriter` MP4 pipeline
- preserve H.264 and HEVC codec families, including supported HEVC Main 10 SDR, while converting other decodable codecs to H.264
- apply orientation-aware, nearest-even resizing without upscaling
- preserve existing AAC samples and channel layouts; encode supported non-AAC audio to AAC and fail conservatively when audio metadata is unreadable
- connect conversion cancellation to `DirectUpload.cancel()`, suppress late completion, and clean up only worker-owned partial files
- add always-on and opt-in catalog-backed coverage for codec selection, bit depth, geometry, audio, cancellation, and cleanup

## Why

This provides the reusable codec-preserving reader/writer conversion mechanism required by the Standard Input pipeline. It replaces `AVAssetExportSession`, which cannot support the full resolution and codec matrix needed by the HEVC/4K work.

## Impact

The conversion worker can now produce MP4/AAC output while retaining H.264 or HEVC as planned. Existing AAC is passed through without re-encoding, supported HEVC Main 10 SDR remains 10-bit, and cancellation cannot start late transport or delete files the worker does not own.

## Scope and dependencies

This PR intentionally focuses on the reusable conversion mechanism. Final encoder policy controls—including bitrate, frame-rate, keyframe, and GOP configuration—remain separate, as do production HDR preservation and tone mapping and final planner/output-validator orchestration.

Until those controls are integrated, default encoder settings may produce output that fails final bitrate or frame-rate validation. Callers must retain original-upload fallback and avoid enabling the complete success path prematurely.

The external media catalog is used only as local development evidence and is not added as a product dependency or release artifact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large change to core upload media conversion and cancellation paths; incorrect behavior could affect output quality, partial file cleanup, or when transport starts after cancel.
> 
> **Overview**
> Replaces **`AVAssetExportSession`**-based input standardization with a cancellable **`AVAssetReader` / `AVAssetWriter`** MP4 pipeline, including **2560×1440** and full resolution presets that export could not cover.
> 
> The new **`UploadInputStandardizationWorker`** preserves **H.264/HEVC** (including supported **HEVC Main 10**), transcodes other decodable video to H.264, applies **orientation-aware downscale** with **nearest-even** dimensions, **passes through AAC** or encodes non-AAC audio, and **rejects** pre-existing output paths while **deleting only worker-owned partial files** on failure or cancel.
> 
> **`UploadInputStandardizer`** and **`DirectUpload`** move to **async/await** with **`UploadInputStandardizationToken`**-scoped **cancel** so late work cannot start transport; tests and planner validation add coverage for geometry rounding and the conversion matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f8199c7e5437cb7c5e2d11ac5bb4047bee1d4be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->