### PR TITLE
Releases/v1.1.2

### DIFF
--- a/Mux-Upload-SDK.podspec
+++ b/Mux-Upload-SDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'Mux-Upload-SDK'
   s.module_name      = 'MuxUploadSDK'
-  s.version          = '1.1.1'
+  s.version          = '1.1.2'
   s.summary          = 'Upload video to Mux.'
   s.description      = 'A library for uploading video to Mux. Similar to UpChunk, but for iOS.'
 

--- a/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SemanticVersion.swift
@@ -14,7 +14,7 @@ public struct SemanticVersion {
     /// Minor version component.
     public static let minor = 1
     /// Patch version component.
-    public static let patch = 1
+    public static let patch = 2
 
     /// String form of the version number in the format X.Y.Z
     /// where X, Y, and Z are the major, minor, and patch


### PR DESCRIPTION
## Summary
- bump SDK version from 1.1.1 to 1.1.2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata updates with no logic, API surface, or security-sensitive changes.
> 
> **Overview**
> **Release 1.1.2** — bumps the published SDK version from **1.1.1** to **1.1.2** in the CocoaPods spec (`Mux-Upload-SDK.podspec`) and in the public `SemanticVersion` API (`patch` and derived `versionString`).
> 
> No runtime or upload behavior changes in this diff; it aligns packaging and in-app version reporting for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02b1df3e162c8e49dd8f9b6015fb169bbfa5c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Improvements

* Version Bump