### PR TITLE
NAT-488: Add Standard Input encoder controls

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -262,39 +262,51 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         operation: UploadInputInspectionOperation
     ) {
-        sourceInput.loadValuesAsynchronously(forKeys: ["duration"]) {
-            guard !operation.isCancelled else { return }
-            let sourceInputDuration = sourceInput.duration
-            videoTrack.loadValuesAsynchronously(
-                forKeys: [
-                    "formatDescriptions",
-                    "preferredTransform",
-                    "nominalFrameRate",
-                    "estimatedDataRate"
-                ]
-            ) {
+        Task {
+            let sourceInputDuration: CMTime
+            do {
+                sourceInputDuration = try await sourceInput.load(.duration)
+            } catch {
                 guard !operation.isCancelled else { return }
-                guard let formatDescriptions = videoTrack.formatDescriptions
-                    as? [CMFormatDescription],
-                      let formatDescription = formatDescriptions.first else {
-                    operation.complete(
-                        self.makeVideoInspectionFailureResult(
-                            videoTrackCount: 1,
-                            audioMetadata: audioMetadata
-                        ),
-                        duration: sourceInputDuration,
-                        error: UploadInputInspectionError.inspectionFailure
-                    )
-                    return
+                operation.complete(
+                    nil,
+                    duration: .zero,
+                    error: UploadInputInspectionError.inspectionFailure
+                )
+                return
+            }
+
+            do {
+                async let formatDescriptions = videoTrack.load(.formatDescriptions)
+                async let preferredTransform = videoTrack.load(.preferredTransform)
+                async let nominalFrameRate = videoTrack.load(.nominalFrameRate)
+                async let estimatedDataRate = videoTrack.load(.estimatedDataRate)
+                async let segments = videoTrack.load(.segments)
+                let loadedMetadata = try await (
+                    formatDescriptions,
+                    preferredTransform,
+                    nominalFrameRate,
+                    estimatedDataRate,
+                    segments
+                )
+                guard !operation.isCancelled else { return }
+                guard let formatDescription = loadedMetadata.0.first else {
+                    throw UploadInputInspectionError.inspectionFailure
                 }
 
                 let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
                     videoTracks: [
                         AVFoundationVideoTrackMetadata(
-                            formatDescriptions: formatDescriptions,
-                            preferredTransform: videoTrack.preferredTransform,
-                            nominalFrameRate: videoTrack.nominalFrameRate,
-                            estimatedDataRate: videoTrack.estimatedDataRate
+                            formatDescriptions: loadedMetadata.0,
+                            preferredTransform: loadedMetadata.1,
+                            nominalFrameRate: loadedMetadata.2,
+                            estimatedDataRate: loadedMetadata.3,
+                            segments: loadedMetadata.4.map {
+                                AVFoundationVideoTrackSegmentMetadata(
+                                    timeMapping: $0.timeMapping,
+                                    isEmpty: $0.isEmpty
+                                )
+                            }
                         )
                     ],
                     audioTracks: audioMetadata
@@ -315,8 +327,8 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                 let nonStandardReasons = self.legacyNonStandardReasons(
                     formatDescription: formatDescription,
                     videoDimensions: videoDimensions,
-                    frameRate: videoTrack.nominalFrameRate,
-                    estimatedBitrate: videoTrack.estimatedDataRate
+                    frameRate: loadedMetadata.2,
+                    estimatedBitrate: loadedMetadata.3
                 )
 
                 operation.complete(
@@ -331,6 +343,16 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     ),
                     duration: sourceInputDuration,
                     error: nil
+                )
+            } catch {
+                guard !operation.isCancelled else { return }
+                operation.complete(
+                    self.makeVideoInspectionFailureResult(
+                        videoTrackCount: 1,
+                        audioMetadata: audioMetadata
+                    ),
+                    duration: sourceInputDuration,
+                    error: UploadInputInspectionError.inspectionFailure
                 )
             }
         }

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
@@ -122,13 +122,17 @@ enum AVFoundationUploadInputMetadataReader {
 
         for segment in segments {
             let mapping = segment.timeMapping
+            guard mapping.target.start.isNumeric,
+                  mapping.target.duration.isNumeric,
+                  CMTimeCompare(mapping.target.duration, .zero) > 0 else {
+                return .unknown
+            }
+            if segment.isEmpty {
+                continue
+            }
             guard mapping.source.start.isNumeric,
                   mapping.source.duration.isNumeric,
-                  mapping.target.start.isNumeric,
-                  mapping.target.duration.isNumeric,
-                  CMTimeCompare(mapping.target.duration, .zero) > 0,
-                  segment.isEmpty
-                    || CMTimeCompare(mapping.source.duration, .zero) > 0 else {
+                  CMTimeCompare(mapping.source.duration, .zero) > 0 else {
                 return .unknown
             }
         }

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
@@ -41,6 +41,12 @@ struct AVFoundationVideoTrackMetadata {
     let preferredTransform: CGAffineTransform
     let nominalFrameRate: Float
     let estimatedDataRate: Float
+    var segments: [AVFoundationVideoTrackSegmentMetadata]? = nil
+}
+
+struct AVFoundationVideoTrackSegmentMetadata {
+    let timeMapping: CMTimeMapping
+    let isEmpty: Bool
 }
 
 struct AVFoundationAudioTrackMetadata {
@@ -90,6 +96,7 @@ enum AVFoundationUploadInputMetadataReader {
         metadata.videoTransform = inspectVideoTransform(videoTrack.preferredTransform)
         facts.frameRate = positiveFinite(Double(videoTrack.nominalFrameRate))
         facts.averageBitrate = positiveFiniteInteger(Double(videoTrack.estimatedDataRate))
+        facts.editList = inspectEditList(videoTrack.segments)
 
         let extensions = (CMFormatDescriptionGetExtensions(formatDescription)
             as NSDictionary?) ?? NSDictionary()
@@ -104,6 +111,41 @@ enum AVFoundationUploadInputMetadataReader {
         )
 
         return Result(mediaFacts: facts, metadata: metadata)
+    }
+
+    static func inspectEditList(
+        _ segments: [AVFoundationVideoTrackSegmentMetadata]?
+    ) -> StandardInputFact<StandardInputEditList> {
+        guard let segments, !segments.isEmpty else {
+            return .unknown
+        }
+
+        for segment in segments {
+            let mapping = segment.timeMapping
+            guard mapping.source.start.isNumeric,
+                  mapping.source.duration.isNumeric,
+                  mapping.target.start.isNumeric,
+                  mapping.target.duration.isNumeric,
+                  CMTimeCompare(mapping.target.duration, .zero) > 0,
+                  segment.isEmpty
+                    || CMTimeCompare(mapping.source.duration, .zero) > 0 else {
+                return .unknown
+            }
+        }
+
+        guard segments.count == 1, let segment = segments.first else {
+            return .known(.complex)
+        }
+        let mapping = segment.timeMapping
+        guard !segment.isEmpty,
+              CMTimeCompare(mapping.source.duration, mapping.target.duration) == 0,
+              CMTimeCompare(mapping.target.start, .zero) == 0 else {
+            return .known(.complex)
+        }
+
+        return CMTimeCompare(mapping.source.start, .zero) == 0
+            ? .known(.none)
+            : .known(.simple)
     }
 
     private static func inspectVideoCodec(

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -101,6 +101,14 @@ actor UploadInputStandardizationWorker {
         }
     }
 
+    struct EncoderConfiguration: Equatable {
+        let outputFrameRate: Double
+        let averageBitRate: Int
+        let maximumBitRate: Int
+        let maximumKeyFrameInterval: TimeInterval
+        let profileLevel: String
+    }
+
     private enum TransferError: Error {
         case appendFailed
         case startedMoreThanOnce
@@ -346,6 +354,15 @@ actor UploadInputStandardizationWorker {
         let decoderPixelFormat = Self.decoderPixelFormat(
             for: sourceFormatDescription
         )
+        let codec = Self.outputCodec(
+            for: sourceFormatDescription.mediaSubType
+        )
+        let encoderConfiguration = Self.encoderConfiguration(
+            codec: codec,
+            renderSize: renderSize,
+            sourceFrameRate: Double(properties.nominalFrameRate),
+            decoderPixelFormat: decoderPixelFormat
+        )
 
         let videoOutput = AVAssetReaderVideoCompositionOutput(
             videoTracks: [videoTrack],
@@ -361,7 +378,7 @@ actor UploadInputStandardizationWorker {
             duration: properties.duration,
             naturalSize: properties.naturalSize,
             preferredTransform: properties.preferredTransform,
-            nominalFrameRate: properties.nominalFrameRate,
+            outputFrameRate: encoderConfiguration.outputFrameRate,
             renderSize: renderSize
         )
         guard reader.canAdd(videoOutput) else {
@@ -370,11 +387,9 @@ actor UploadInputStandardizationWorker {
         reader.add(videoOutput)
 
         let videoSettings = Self.videoWriterSettings(
-            codec: Self.outputCodec(
-                for: sourceFormatDescription.mediaSubType
-            ),
+            codec: codec,
             renderSize: renderSize,
-            decoderPixelFormat: decoderPixelFormat
+            encoderConfiguration: encoderConfiguration
         )
         guard writer.canApply(
             outputSettings: videoSettings,
@@ -586,7 +601,7 @@ actor UploadInputStandardizationWorker {
         duration: CMTime,
         naturalSize: CGSize,
         preferredTransform: CGAffineTransform,
-        nominalFrameRate: Float,
+        outputFrameRate: Double,
         renderSize: CGSize
     ) -> AVVideoComposition {
         let transformedRect = CGRect(origin: .zero, size: naturalSize)
@@ -615,33 +630,99 @@ actor UploadInputStandardizationWorker {
         let composition = AVMutableVideoComposition()
         composition.instructions = [instruction]
         composition.renderSize = renderSize
-        let frameRate = nominalFrameRate.isFinite && nominalFrameRate > 0
-            ? nominalFrameRate
-            : 30
         composition.frameDuration = CMTime(
             value: 1_000,
-            timescale: CMTimeScale((frameRate * 1_000).rounded())
+            timescale: CMTimeScale((outputFrameRate * 1_000).rounded())
         )
         return composition
+    }
+
+    static func encoderConfiguration(
+        codec: AVVideoCodecType,
+        renderSize: CGSize,
+        sourceFrameRate: Double,
+        decoderPixelFormat: OSType
+    ) -> EncoderConfiguration {
+        let maximumDimension = max(renderSize.width, renderSize.height)
+        let standardDimension = StandardInputPolicyProfile.publishedMux.limits(
+            for: .upTo1080p
+        ).maximumSourceDimension
+        // The policy's effective tier follows the completed output dimensions.
+        // A small output under a high-resolution customer selection must still
+        // meet the stricter up-to-1080p limits.
+        let acceptanceTier: StandardInputAcceptanceTier = maximumDimension
+                <= CGFloat(standardDimension)
+            ? .upTo1080p
+            : .highResolution
+        let limits = StandardInputPolicyProfile.publishedMux.limits(
+            for: acceptanceTier
+        )
+        let outputFrameRate = sourceFrameRate.isFinite
+                && limits.frameRateRange.contains(sourceFrameRate)
+            ? sourceFrameRate
+            : 30
+
+        let averageBitRate: Int
+        // Leave deliberate headroom below the published ceiling for each
+        // generated size. The data-rate limit below is the hard guardrail;
+        // VideoToolbox documents average bitrate as a soft target.
+        switch maximumDimension {
+        case ...1280:
+            averageBitRate = 5_000_000
+        case ...2048:
+            averageBitRate = 7_000_000
+        case ...2560:
+            averageBitRate = 16_000_000
+        default:
+            averageBitRate = 18_000_000
+        }
+
+        let profileLevel: String
+        switch codec {
+        case .hevc:
+            profileLevel = decoderPixelFormat
+                    == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+                ? kVTProfileLevel_HEVC_Main10_AutoLevel as String
+                : kVTProfileLevel_HEVC_Main_AutoLevel as String
+        default:
+            profileLevel = AVVideoProfileLevelH264HighAutoLevel
+        }
+
+        return EncoderConfiguration(
+            outputFrameRate: outputFrameRate,
+            averageBitRate: averageBitRate,
+            maximumBitRate: Int(limits.maximumAverageBitrate),
+            maximumKeyFrameInterval: 0.9 * (limits.maximumKeyframeIntervals[
+                codec == .hevc ? .hevc : .h264
+            ] ?? 10),
+            profileLevel: profileLevel
+        )
     }
 
     private static func videoWriterSettings(
         codec: AVVideoCodecType,
         renderSize: CGSize,
-        decoderPixelFormat: OSType
+        encoderConfiguration: EncoderConfiguration
     ) -> [String: Any] {
-        var settings: [String: Any] = [
+        [
             AVVideoCodecKey: codec,
             AVVideoWidthKey: Int(renderSize.width),
-            AVVideoHeightKey: Int(renderSize.height)
-        ]
-        if codec == .hevc,
-           decoderPixelFormat == kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange {
-            settings[AVVideoCompressionPropertiesKey] = [
-                AVVideoProfileLevelKey: kVTProfileLevel_HEVC_Main10_AutoLevel
+            AVVideoHeightKey: Int(renderSize.height),
+            AVVideoCompressionPropertiesKey: [
+                kVTCompressionPropertyKey_AverageBitRate as String:
+                    encoderConfiguration.averageBitRate,
+                kVTCompressionPropertyKey_DataRateLimits as String: [
+                    encoderConfiguration.maximumBitRate / 8,
+                    1
+                ],
+                kVTCompressionPropertyKey_ExpectedFrameRate as String:
+                    encoderConfiguration.outputFrameRate,
+                kVTCompressionPropertyKey_MaxKeyFrameIntervalDuration as String:
+                    encoderConfiguration.maximumKeyFrameInterval,
+                kVTCompressionPropertyKey_AllowOpenGOP as String: false,
+                AVVideoProfileLevelKey: encoderConfiguration.profileLevel
             ]
-        }
-        return settings
+        ]
     }
 
     private static func addAudioPipeline(

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -386,11 +386,23 @@ actor UploadInputStandardizationWorker {
         }
         reader.add(videoOutput)
 
-        let videoSettings = Self.videoWriterSettings(
+        var videoSettings = Self.videoWriterSettings(
             codec: codec,
             renderSize: renderSize,
             encoderConfiguration: encoderConfiguration
         )
+        let compressionPropertiesKey = AVVideoCompressionPropertiesKey
+        if !writer.canApply(outputSettings: videoSettings, forMediaType: .video),
+           var compressionProperties = videoSettings[compressionPropertiesKey]
+                as? [String: Any] {
+            // Apple documents AllowOpenGOP as applicable only to certain
+            // encoders. If unavailable, omit only that hint; output validation
+            // remains the final gate for GOP structure compliance.
+            compressionProperties.removeValue(
+                forKey: kVTCompressionPropertyKey_AllowOpenGOP as String
+            )
+            videoSettings[compressionPropertiesKey] = compressionProperties
+        }
         guard writer.canApply(
             outputSettings: videoSettings,
             forMediaType: .video
@@ -500,7 +512,9 @@ actor UploadInputStandardizationWorker {
         transfers.forEach { $0.cancel() }
         transfers = []
         reader?.cancelReading()
-        writer?.cancelWriting()
+        if let writer, writer.status != .unknown {
+            writer.cancelWriting()
+        }
         reader = nil
         writer = nil
         let outputURL = self.outputURL

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
@@ -10,6 +10,70 @@ import XCTest
 
 final class UploadInputMetadataInspectionTests: XCTestCase {
 
+    func testClassifiesIdentityTrimAndComplexEditMappings() {
+        let identity = AVFoundationVideoTrackSegmentMetadata(
+            timeMapping: CMTimeMapping(
+                source: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 3, preferredTimescale: 600)
+                ),
+                target: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 3, preferredTimescale: 600)
+                )
+            ),
+            isEmpty: false
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList([identity]),
+            .known(.none)
+        )
+
+        let trim = AVFoundationVideoTrackSegmentMetadata(
+            timeMapping: CMTimeMapping(
+                source: CMTimeRange(
+                    start: CMTime(seconds: 0.5, preferredTimescale: 600),
+                    duration: CMTime(seconds: 3, preferredTimescale: 600)
+                ),
+                target: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 3, preferredTimescale: 600)
+                )
+            ),
+            isEmpty: false
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList([trim]),
+            .known(.simple)
+        )
+
+        let scaled = AVFoundationVideoTrackSegmentMetadata(
+            timeMapping: CMTimeMapping(
+                source: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 3, preferredTimescale: 600)
+                ),
+                target: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 4, preferredTimescale: 600)
+                )
+            ),
+            isEmpty: false
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList([scaled]),
+            .known(.complex)
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList([identity, trim]),
+            .known(.complex)
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList(nil),
+            .unknown
+        )
+    }
+
     func testReadsH264SDRMetadataIntoPolicyFacts() throws {
         let formatDescription = try makeVideoFormatDescription(
             codecType: fourCharacterCode("avc1"),

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputMetadataInspectionTests.swift
@@ -64,6 +64,21 @@ final class UploadInputMetadataInspectionTests: XCTestCase {
             AVFoundationUploadInputMetadataReader.inspectEditList([scaled]),
             .known(.complex)
         )
+
+        let empty = AVFoundationVideoTrackSegmentMetadata(
+            timeMapping: CMTimeMapping(
+                source: .invalid,
+                target: CMTimeRange(
+                    start: .zero,
+                    duration: CMTime(seconds: 1, preferredTimescale: 600)
+                )
+            ),
+            isEmpty: true
+        )
+        XCTAssertEqual(
+            AVFoundationUploadInputMetadataReader.inspectEditList([empty]),
+            .known(.complex)
+        )
         XCTAssertEqual(
             AVFoundationUploadInputMetadataReader.inspectEditList([identity, trim]),
             .known(.complex)

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -3,6 +3,7 @@
 //
 
 import AVFoundation
+import VideoToolbox
 import XCTest
 
 @testable import MuxUploadSDK
@@ -98,6 +99,154 @@ final class UploadInputStandardizerTests: XCTestCase {
             ),
             kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
         )
+    }
+
+    func testEncoderConfigurationNormalizesOnlyUnsupportedFrameRates() {
+        let lowResolution = CGSize(width: 1920, height: 1080)
+        let highResolution = CGSize(width: 2560, height: 1440)
+
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .h264,
+                renderSize: lowResolution,
+                sourceFrameRate: 5,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            5
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .h264,
+                renderSize: lowResolution,
+                sourceFrameRate: 4.999,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            30
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .h264,
+                renderSize: lowResolution,
+                sourceFrameRate: 120,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            120
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .h264,
+                renderSize: lowResolution,
+                sourceFrameRate: 121,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            30
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .hevc,
+                renderSize: highResolution,
+                sourceFrameRate: 60,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            60
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .hevc,
+                renderSize: highResolution,
+                sourceFrameRate: 60.001,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            30
+        )
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.encoderConfiguration(
+                codec: .hevc,
+                renderSize: highResolution,
+                sourceFrameRate: .nan,
+                decoderPixelFormat: kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+            ).outputFrameRate,
+            30
+        )
+    }
+
+    func testEncoderConfigurationKeepsTargetsBelowPublishedLimits() {
+        let cases: [(
+            codec: AVVideoCodecType,
+            renderSize: CGSize,
+            pixelFormat: OSType,
+            averageBitRate: Int,
+            maximumBitRate: Int,
+            keyFrameInterval: TimeInterval,
+            profileLevel: String
+        )] = [
+            (
+                .h264,
+                CGSize(width: 1280, height: 720),
+                kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                5_000_000,
+                8_000_000,
+                18,
+                AVVideoProfileLevelH264HighAutoLevel
+            ),
+            (
+                .h264,
+                CGSize(width: 1920, height: 1080),
+                kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                7_000_000,
+                8_000_000,
+                18,
+                AVVideoProfileLevelH264HighAutoLevel
+            ),
+            (
+                .hevc,
+                CGSize(width: 2560, height: 1440),
+                kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange,
+                16_000_000,
+                20_000_000,
+                5.4,
+                kVTProfileLevel_HEVC_Main_AutoLevel as String
+            ),
+            (
+                .hevc,
+                CGSize(width: 3840, height: 2160),
+                kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange,
+                18_000_000,
+                20_000_000,
+                5.4,
+                kVTProfileLevel_HEVC_Main10_AutoLevel as String
+            )
+        ]
+
+        for testCase in cases {
+            let configuration = UploadInputStandardizationWorker
+                .encoderConfiguration(
+                    codec: testCase.codec,
+                    renderSize: testCase.renderSize,
+                    sourceFrameRate: 30,
+                    decoderPixelFormat: testCase.pixelFormat
+                )
+            XCTAssertEqual(
+                configuration.averageBitRate,
+                testCase.averageBitRate
+            )
+            XCTAssertEqual(
+                configuration.maximumBitRate,
+                testCase.maximumBitRate
+            )
+            XCTAssertLessThan(
+                configuration.averageBitRate,
+                configuration.maximumBitRate
+            )
+            XCTAssertEqual(
+                configuration.maximumKeyFrameInterval,
+                testCase.keyFrameInterval
+            )
+            XCTAssertEqual(
+                configuration.profileLevel,
+                testCase.profileLevel
+            )
+        }
     }
 
     func testRenderSizeDoesNotUpscale() throws {
@@ -337,35 +486,72 @@ final class UploadInputStandardizerTests: XCTestCase {
             id: String,
             codec: AVVideoCodecType,
             bitDepth: Int,
+            maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
             dimensions: CGSize,
+            constantFrameRate: Double?,
             audioChannels: UInt32
         )] = [
             (
                 "synthetic-standard-h264-sdr-2160p30-stereo",
                 .h264,
                 8,
-                CGSize(width: 1920, height: 1080),
+                .preset1280x720,
+                CGSize(width: 1280, height: 720),
+                30,
                 2
             ),
             (
                 "synthetic-standard-hevc-main-sdr-1440p30-stereo",
                 .hevc,
                 8,
-                CGSize(width: 1920, height: 1080),
+                .preset2560x1440,
+                CGSize(width: 2560, height: 1440),
+                30,
                 2
             ),
             (
                 "synthetic-standard-hevc-main10-sdr-2160p30-5-1",
                 .hevc,
                 10,
-                CGSize(width: 1920, height: 1080),
+                .preset3840x2160,
+                CGSize(width: 3840, height: 2160),
+                30,
                 6
             ),
             (
                 "synthetic-unsupported-prores-sdr-720p30-stereo",
                 .h264,
                 8,
+                .default,
                 CGSize(width: 1280, height: 720),
+                30,
+                2
+            ),
+            (
+                "synthetic-nonstandard-h264-sdr-1080p121-stereo",
+                .h264,
+                8,
+                .default,
+                CGSize(width: 1920, height: 1080),
+                30,
+                2
+            ),
+            (
+                "synthetic-nonstandard-h264-sdr-1080p-open-gop-stereo",
+                .h264,
+                8,
+                .default,
+                CGSize(width: 1920, height: 1080),
+                30,
+                2
+            ),
+            (
+                "nat480-hevc-sdr-4k-edit-list",
+                .hevc,
+                8,
+                .preset3840x2160,
+                CGSize(width: 2160, height: 3840),
+                nil,
                 2
             )
         ]
@@ -379,7 +565,9 @@ final class UploadInputStandardizerTests: XCTestCase {
                     .appendingPathComponent(fixture.canonicalFilename),
                 expectedCodec: testCase.codec,
                 expectedBitDepth: testCase.bitDepth,
+                maximumResolution: testCase.maximumResolution,
                 expectedDimensions: testCase.dimensions,
+                expectedConstantFrameRate: testCase.constantFrameRate,
                 expectedAudioChannels: testCase.audioChannels
             )
         }
@@ -418,7 +606,9 @@ final class UploadInputStandardizerTests: XCTestCase {
         inputURL: URL,
         expectedCodec: AVVideoCodecType,
         expectedBitDepth: Int,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         expectedDimensions: CGSize,
+        expectedConstantFrameRate: Double?,
         expectedAudioChannels: UInt32
     ) async throws {
         let outputURL = FileManager.default.temporaryDirectory
@@ -429,7 +619,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         let standardizedAsset = try await worker.standardize(
             sourceAsset: AVURLAsset(url: inputURL),
             rescalingDetails: .init(
-                maximumDesiredResolutionPreset: .default,
+                maximumDesiredResolutionPreset: maximumResolution,
                 recordedResolution: .init(width: 0, height: 0)
             ),
             outputURL: outputURL
@@ -463,6 +653,18 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
         XCTAssertEqual(naturalSize, expectedDimensions)
 
+        if let expectedConstantFrameRate {
+            let frameDurations = try await videoSampleDurations(asset: outputAsset)
+            XCTAssertGreaterThan(frameDurations.count, 1)
+            for frameDuration in frameDurations {
+                XCTAssertEqual(
+                    frameDuration,
+                    1 / expectedConstantFrameRate,
+                    accuracy: 0.001
+                )
+            }
+        }
+
         let audioTracks = try await outputAsset.loadTracks(withMediaType: .audio)
         let audioTrack = try XCTUnwrap(audioTracks.first)
         let audioFormat = try await audioTrack.load(.formatDescriptions).first
@@ -479,6 +681,84 @@ final class UploadInputStandardizerTests: XCTestCase {
             },
             expectedAudioChannels
         )
+
+        let inspectionResult = try await inspect(
+            asset: outputAsset,
+            maximumResolution: maximumResolution
+        )
+        if let expectedConstantFrameRate {
+            XCTAssertEqual(
+                inspectionResult.mediaFacts.frameRate.value ?? 0,
+                expectedConstantFrameRate,
+                accuracy: 0.001
+            )
+        }
+        let evaluation = StandardInputPolicyEvaluator().evaluate(
+            inspectionResult.mediaFacts,
+            selection: StandardInputPolicySelection(
+                maximumResolution: maximumResolution
+            ),
+            role: .generatedOutput
+        )
+        XCTAssertTrue(
+            evaluation.nonCompliantRequirements.isEmpty,
+            "Generated output is non-compliant: \(evaluation.nonCompliantRequirements)"
+        )
+        XCTAssertTrue(
+            evaluation.unknownRequirements.isEmpty,
+            "Generated output lacks policy evidence: \(evaluation.unknownRequirements)"
+        )
+        XCTAssertTrue(
+            StandardInputOutputValidator().validatePolicyCompliance(
+                facts: inspectionResult.mediaFacts,
+                maximumResolution: maximumResolution
+            ).isAccepted,
+            "The validator must accept a policy-compliant generated output"
+        )
+    }
+
+    private func inspect(
+        asset: AVAsset,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution
+    ) async throws -> UploadInputFormatInspectionResult {
+        try await withCheckedThrowingContinuation { continuation in
+            AVFoundationUploadInputInspector().performInspection(
+                sourceInput: asset,
+                maximumResolution: maximumResolution
+            ) { result, _, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let result {
+                    continuation.resume(returning: result)
+                } else {
+                    continuation.resume(
+                        throwing: UploadInputInspectionError.inspectionFailure
+                    )
+                }
+            }
+        }
+    }
+
+    private func videoSampleDurations(asset: AVAsset) async throws -> [Double] {
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        let track = try XCTUnwrap(tracks.first)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(
+            track: track,
+            outputSettings: nil
+        )
+        reader.add(output)
+        XCTAssertTrue(reader.startReading())
+
+        var durations: [Double] = []
+        while let sampleBuffer = output.copyNextSampleBuffer() {
+            let duration = CMSampleBufferGetDuration(sampleBuffer).seconds
+            if duration.isFinite, duration > 0 {
+                durations.append(duration)
+            }
+        }
+        XCTAssertEqual(reader.status, .completed)
+        return durations
     }
 
     private func catalogFixtureURL(id: String) throws -> URL {


### PR DESCRIPTION
## Summary

- configure codec-preserving H.264/HEVC output with policy-tier frame-rate, bitrate, keyframe, GOP, profile, and pixel-format controls
- keep encoder targets below published limits, including a 10% keyframe-interval margin and hard data-rate guardrails
- derive edit-list facts from AVFoundation track-segment mappings so completed conversions can pass conservative output validation
- validate converted 720p, 1080p, 1440p, and 2160p outputs across H.264, HEVC Main/Main10, ProRes input, high-frame-rate input, open-GOP input, and the external 4K edit-list fixture

## Rationale

The reader/writer conversion pipeline previously relied on platform encoder defaults. Those defaults are not reliable enough to guarantee Standard Input compliance: bitrate may exceed the selected tier, keyframe and GOP behavior may vary, and completed outputs cannot pass conservative validation when edit-list evidence remains unknown.

This change makes encoding behavior explicit and policy-driven while preserving supported codec families, bit depth, orientation, aspect ratio, and audio behavior.

## Design choices

- derive the effective policy tier from the rendered output dimensions rather than the customer's maximum-resolution selection
- preserve source frame rates already allowed by the selected tier and normalize unsupported rates to 30 fps
- use resolution-specific average-bitrate targets with policy-tier hard data-rate ceilings
- target keyframe intervals at 90% of the published maximum to leave room for encoder timing variance
- disable open GOPs and select H.264 High, HEVC Main, or HEVC Main10 according to the preserved codec and pixel format
- classify identity track mappings as no edit list, a single unscaled trim as a simple edit list, and empty, multiple, scaled, or discontinuous mappings as complex; unavailable or malformed evidence remains unknown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core transcode/encode path and output validation semantics; behavior changes for bitrate, GOP, and frame rate could affect upload acceptance, though tests and policy ceilings mitigate regressions.
> 
> **Overview**
> Replaces implicit VideoToolbox defaults during upload standardization with an explicit **`EncoderConfiguration`** derived from published Standard Input policy tiers (based on **rendered output size**, not only the customer’s max-resolution preset). Writer settings now set average bitrate, hard data-rate limits, expected frame rate (source rate when in-tier, otherwise 30 fps), max keyframe interval at 90% of policy, **closed GOP** (`AllowOpenGOP: false`, with fallback if the writer rejects that key), and H.264 High / HEVC Main or Main10 profiles. Video composition timing uses the chosen output frame rate instead of the source nominal rate.
> 
> **Input inspection** moves single-video-track loading to **async `load`** (including **track segments**) and feeds segment time mappings into new **`inspectEditList`** logic so `editList` facts can be **none**, **simple**, **complex**, or **unknown** for policy validation on converted outputs.
> 
> Catalog-backed conversion tests cover more resolutions and edge fixtures (high frame rate, open GOP, ProRes input, 4K edit-list) and assert policy compliance on generated outputs. Cleanup only calls **`cancelWriting`** when the writer has left `.unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c438efffdae8a05ad9435fcff1d0ec8bacd005b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->