### PR TITLE
NAT-489: Add HDR tone mapping

### DIFF
--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
@@ -27,7 +27,7 @@ struct StandardInputPlanningCapabilities: Equatable {
     }
 }
 
-struct StandardInputConversion: Equatable {
+struct StandardInputConversion: Equatable, Sendable {
     let sourceCodec: StandardInputVideoCodec
     let outputCodec: StandardInputVideoCodec
     let sourceDynamicRange: StandardInputDynamicRange

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
@@ -18,14 +18,15 @@ enum StandardInputFact<Value> {
 }
 
 extension StandardInputFact: Equatable where Value: Equatable { }
+extension StandardInputFact: Sendable where Value: Sendable { }
 
-enum StandardInputVideoCodec: Hashable {
+enum StandardInputVideoCodec: Hashable, Sendable {
     case h264
     case hevc
     case other
 }
 
-struct StandardInputDisplayDimensions: Equatable {
+struct StandardInputDisplayDimensions: Equatable, Sendable {
     let width: Int
     let height: Int
 
@@ -53,7 +54,7 @@ struct StandardInputPixelFormat: Hashable {
     let chromaSubsampling: ChromaSubsampling
 }
 
-enum StandardInputDynamicRange: Hashable {
+enum StandardInputDynamicRange: Hashable, Sendable {
     case sdr
     case hlg
     case pq
@@ -100,12 +101,12 @@ struct StandardInputMediaFacts: Equatable {
     var editList: StandardInputFact<StandardInputEditList> = .unknown
 }
 
-enum StandardInputAcceptanceTier: Hashable {
+enum StandardInputAcceptanceTier: Hashable, Sendable {
     case upTo1080p
     case highResolution
 }
 
-struct StandardInputPolicySelection: Equatable {
+struct StandardInputPolicySelection: Equatable, Sendable {
     let acceptanceTier: StandardInputAcceptanceTier
     let generatedOutputDimensions: StandardInputDisplayDimensions
 
@@ -239,7 +240,7 @@ extension StandardInputPolicyProfile {
 }
 
 struct StandardInputPolicyEvaluation: Equatable {
-    enum Requirement: CaseIterable, Hashable {
+    enum Requirement: CaseIterable, Hashable, Sendable {
         case videoCodec
         case videoResolution
         case frameRate

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -13,10 +13,26 @@ protocol UploadInputStandardizationWorking: AnyObject, Sendable {
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset
 
     func cancel() async
+}
+
+extension UploadInputStandardizationWorking {
+    func standardize(
+        sourceAsset: AVURLAsset,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL
+    ) async throws -> AVURLAsset {
+        try await standardize(
+            sourceAsset: sourceAsset,
+            rescalingDetails: rescalingDetails,
+            conversion: nil,
+            outputURL: outputURL
+        )
+    }
 }
 
 struct StandardizationError: LocalizedError {
@@ -221,6 +237,7 @@ actor UploadInputStandardizationWorker {
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset {
         try ensureActive()
@@ -249,6 +266,7 @@ actor UploadInputStandardizationWorker {
                 audioProperties: audioProperties,
                 properties: properties,
                 rescalingDetails: rescalingDetails,
+                conversion: conversion,
                 outputURL: outputURL
             )
             try ensureActive()
@@ -331,6 +349,7 @@ actor UploadInputStandardizationWorker {
         audioProperties: AudioProperties?,
         properties: LoadedAssetProperties,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset {
         let renderSize = try Self.renderSize(
@@ -352,11 +371,11 @@ actor UploadInputStandardizationWorker {
 
         let sourceFormatDescription = properties.formatDescriptions[0]
         let decoderPixelFormat = Self.decoderPixelFormat(
-            for: sourceFormatDescription
+            for: sourceFormatDescription,
+            toneMapsToSDR: conversion?.toneMapsToSDR == true
         )
-        let codec = Self.outputCodec(
-            for: sourceFormatDescription.mediaSubType
-        )
+        let codec = conversion.map(Self.outputCodec(for:))
+            ?? Self.outputCodec(for: sourceFormatDescription.mediaSubType)
         let encoderConfiguration = Self.encoderConfiguration(
             codec: codec,
             renderSize: renderSize,
@@ -366,11 +385,10 @@ actor UploadInputStandardizationWorker {
 
         let videoOutput = AVAssetReaderVideoCompositionOutput(
             videoTracks: [videoTrack],
-            videoSettings: [
-                kCVPixelBufferPixelFormatTypeKey as String:
-                    decoderPixelFormat,
-                kCVPixelBufferIOSurfacePropertiesKey as String: [:]
-            ]
+            videoSettings: Self.readerVideoSettings(
+                decoderPixelFormat: decoderPixelFormat,
+                toneMapsToSDR: conversion?.toneMapsToSDR == true
+            )
         )
         videoOutput.alwaysCopiesSampleData = false
         videoOutput.videoComposition = Self.videoComposition(
@@ -379,7 +397,8 @@ actor UploadInputStandardizationWorker {
             naturalSize: properties.naturalSize,
             preferredTransform: properties.preferredTransform,
             outputFrameRate: encoderConfiguration.outputFrameRate,
-            renderSize: renderSize
+            renderSize: renderSize,
+            toneMapsToSDR: conversion?.toneMapsToSDR == true
         )
         guard reader.canAdd(videoOutput) else {
             throw StandardizationError.cannotAddReaderOutput
@@ -389,7 +408,8 @@ actor UploadInputStandardizationWorker {
         var videoSettings = Self.videoWriterSettings(
             codec: codec,
             renderSize: renderSize,
-            encoderConfiguration: encoderConfiguration
+            encoderConfiguration: encoderConfiguration,
+            toneMapsToSDR: conversion?.toneMapsToSDR == true
         )
         let compressionPropertiesKey = AVVideoCompressionPropertiesKey
         if !writer.canApply(outputSettings: videoSettings, forMediaType: .video),
@@ -546,9 +566,24 @@ actor UploadInputStandardizationWorker {
         }
     }
 
+    static func outputCodec(
+        for conversion: StandardInputConversion
+    ) -> AVVideoCodecType {
+        switch conversion.outputCodec {
+        case .hevc:
+            return .hevc
+        case .h264, .other:
+            return .h264
+        }
+    }
+
     static func decoderPixelFormat(
-        for formatDescription: CMFormatDescription
+        for formatDescription: CMFormatDescription,
+        toneMapsToSDR: Bool = false
     ) -> OSType {
+        guard !toneMapsToSDR else {
+            return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        }
         guard outputCodec(for: formatDescription.mediaSubType) == .hevc,
               let extensions = CMFormatDescriptionGetExtensions(formatDescription)
                 as NSDictionary?,
@@ -562,6 +597,20 @@ actor UploadInputStandardizationWorker {
             return kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
         }
         return kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+    }
+
+    static func readerVideoSettings(
+        decoderPixelFormat: OSType,
+        toneMapsToSDR: Bool
+    ) -> [String: Any] {
+        var settings: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: decoderPixelFormat,
+            kCVPixelBufferIOSurfacePropertiesKey as String: [:]
+        ]
+        if toneMapsToSDR {
+            settings[AVVideoColorPropertiesKey] = rec709ColorProperties
+        }
+        return settings
     }
 
     static func boundingSize(
@@ -610,13 +659,14 @@ actor UploadInputStandardizationWorker {
         CGFloat(max(2, Int((value / 2).rounded()) * 2))
     }
 
-    private static func videoComposition(
+    static func videoComposition(
         track: AVAssetTrack,
         duration: CMTime,
         naturalSize: CGSize,
         preferredTransform: CGAffineTransform,
         outputFrameRate: Double,
-        renderSize: CGSize
+        renderSize: CGSize,
+        toneMapsToSDR: Bool
     ) -> AVVideoComposition {
         let transformedRect = CGRect(origin: .zero, size: naturalSize)
             .applying(preferredTransform)
@@ -648,6 +698,11 @@ actor UploadInputStandardizationWorker {
             value: 1_000,
             timescale: CMTimeScale((outputFrameRate * 1_000).rounded())
         )
+        if toneMapsToSDR {
+            composition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+            composition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+            composition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        }
         return composition
     }
 
@@ -713,12 +768,13 @@ actor UploadInputStandardizationWorker {
         )
     }
 
-    private static func videoWriterSettings(
+    static func videoWriterSettings(
         codec: AVVideoCodecType,
         renderSize: CGSize,
-        encoderConfiguration: EncoderConfiguration
+        encoderConfiguration: EncoderConfiguration,
+        toneMapsToSDR: Bool
     ) -> [String: Any] {
-        [
+        var settings: [String: Any] = [
             AVVideoCodecKey: codec,
             AVVideoWidthKey: Int(renderSize.width),
             AVVideoHeightKey: Int(renderSize.height),
@@ -736,6 +792,18 @@ actor UploadInputStandardizationWorker {
                 kVTCompressionPropertyKey_AllowOpenGOP as String: false,
                 AVVideoProfileLevelKey: encoderConfiguration.profileLevel
             ]
+        ]
+        if toneMapsToSDR {
+            settings[AVVideoColorPropertiesKey] = rec709ColorProperties
+        }
+        return settings
+    }
+
+    static var rec709ColorProperties: [String: Any] {
+        [
+            AVVideoColorPrimariesKey: AVVideoColorPrimaries_ITU_R_709_2,
+            AVVideoTransferFunctionKey: AVVideoTransferFunction_ITU_R_709_2,
+            AVVideoYCbCrMatrixKey: AVVideoYCbCrMatrix_ITU_R_709_2
         ]
     }
 

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -15,10 +15,30 @@ protocol UploadInputStandardizing: Sendable {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset
 
     func cancel(id: String, token: UploadInputStandardizationToken) async
+}
+
+extension UploadInputStandardizing {
+    func standardize(
+        id: String,
+        token: UploadInputStandardizationToken,
+        sourceAsset: AVURLAsset,
+        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        outputURL: URL
+    ) async throws -> AVURLAsset {
+        try await standardize(
+            id: id,
+            token: token,
+            sourceAsset: sourceAsset,
+            rescalingDetails: rescalingDetails,
+            conversion: nil,
+            outputURL: outputURL
+        )
+    }
 }
 
 actor UploadInputStandardizer: UploadInputStandardizing {
@@ -47,6 +67,7 @@ actor UploadInputStandardizer: UploadInputStandardizing {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset {
         let worker = workerFactory(token)
@@ -60,6 +81,7 @@ actor UploadInputStandardizer: UploadInputStandardizing {
             let result = try await worker.standardize(
                 sourceAsset: sourceAsset,
                 rescalingDetails: rescalingDetails,
+                conversion: conversion,
                 outputURL: outputURL
             )
             removeWorker(id: id, token: token)

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -27,6 +27,7 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+        conversion: StandardInputConversion?,
         outputURL: URL
     ) async throws -> AVURLAsset {
         standardizeCallCount += 1

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -9,6 +9,22 @@ import XCTest
 @testable import MuxUploadSDK
 
 final class UploadInputStandardizerTests: XCTestCase {
+    private actor ImmediateWorker: UploadInputStandardizationWorking {
+        private(set) var receivedConversion: StandardInputConversion?
+
+        func standardize(
+            sourceAsset: AVURLAsset,
+            rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+            conversion: StandardInputConversion?,
+            outputURL: URL
+        ) async throws -> AVURLAsset {
+            receivedConversion = conversion
+            return AVURLAsset(url: outputURL)
+        }
+
+        func cancel() { }
+    }
+
     private actor ControllableWorker: UploadInputStandardizationWorking {
         private(set) var cancellationCount = 0
         private var isCancelled = false
@@ -19,6 +35,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         func standardize(
             sourceAsset: AVURLAsset,
             rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
+            conversion: StandardInputConversion?,
             outputURL: URL
         ) async throws -> AVURLAsset {
             if isCancelled {
@@ -99,6 +116,97 @@ final class UploadInputStandardizerTests: XCTestCase {
             ),
             kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
         )
+    }
+
+    func testToneMappingUsesPlannedCodecAndRec709EightBitOutput() throws {
+        let conversion = toneMappingConversion(dynamicRange: .hlg)
+        XCTAssertEqual(
+            UploadInputStandardizationWorker.outputCodec(for: conversion),
+            .hevc
+        )
+
+        let decoderPixelFormat = UploadInputStandardizationWorker.decoderPixelFormat(
+            for: try makeHEVCFormatDescription(bitDepth: 10),
+            toneMapsToSDR: true
+        )
+        XCTAssertEqual(
+            decoderPixelFormat,
+            kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
+        )
+
+        let readerSettings = UploadInputStandardizationWorker.readerVideoSettings(
+            decoderPixelFormat: decoderPixelFormat,
+            toneMapsToSDR: true
+        )
+        assertRec709ColorProperties(
+            readerSettings[AVVideoColorPropertiesKey]
+        )
+
+        let configuration = UploadInputStandardizationWorker.encoderConfiguration(
+            codec: .hevc,
+            renderSize: CGSize(width: 1920, height: 1080),
+            sourceFrameRate: 30,
+            decoderPixelFormat: decoderPixelFormat
+        )
+        XCTAssertEqual(
+            configuration.profileLevel,
+            kVTProfileLevel_HEVC_Main_AutoLevel as String
+        )
+        let writerSettings = UploadInputStandardizationWorker.videoWriterSettings(
+            codec: .hevc,
+            renderSize: CGSize(width: 1920, height: 1080),
+            encoderConfiguration: configuration,
+            toneMapsToSDR: true
+        )
+        assertRec709ColorProperties(
+            writerSettings[AVVideoColorPropertiesKey]
+        )
+    }
+
+    func testNonToneMappedConversionDoesNotOverrideColorProperties() throws {
+        let decoderPixelFormat = UploadInputStandardizationWorker.decoderPixelFormat(
+            for: try makeHEVCFormatDescription(bitDepth: 10)
+        )
+        let readerSettings = UploadInputStandardizationWorker.readerVideoSettings(
+            decoderPixelFormat: decoderPixelFormat,
+            toneMapsToSDR: false
+        )
+        XCTAssertNil(readerSettings[AVVideoColorPropertiesKey])
+
+        let configuration = UploadInputStandardizationWorker.encoderConfiguration(
+            codec: .hevc,
+            renderSize: CGSize(width: 1920, height: 1080),
+            sourceFrameRate: 30,
+            decoderPixelFormat: decoderPixelFormat
+        )
+        let writerSettings = UploadInputStandardizationWorker.videoWriterSettings(
+            codec: .hevc,
+            renderSize: CGSize(width: 1920, height: 1080),
+            encoderConfiguration: configuration,
+            toneMapsToSDR: false
+        )
+        XCTAssertNil(writerSettings[AVVideoColorPropertiesKey])
+    }
+
+    func testStandardizerForwardsPlannedConversionToWorker() async throws {
+        let worker = ImmediateWorker()
+        let standardizer = UploadInputStandardizer { _ in worker }
+        let conversion = toneMappingConversion(dynamicRange: .pq)
+        let outputURL = URL(fileURLWithPath: "/tmp/planned-tone-map.mp4")
+
+        _ = try await standardizer.standardize(
+            id: UUID().uuidString,
+            token: UploadInputStandardizationToken(),
+            sourceAsset: AVURLAsset(
+                url: URL(fileURLWithPath: "/tmp/planned-tone-map-source.mp4")
+            ),
+            rescalingDetails: .init(),
+            conversion: conversion,
+            outputURL: outputURL
+        )
+
+        let receivedConversion = await worker.receivedConversion
+        XCTAssertEqual(receivedConversion, conversion)
     }
 
     func testEncoderConfigurationNormalizesOnlyUnsupportedFrameRates() {
@@ -573,6 +681,67 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
     }
 
+    func testCatalogBackedHLGAndPQToneMappingProducesRec709SDR() async throws {
+        let cases: [(
+            id: String,
+            dynamicRange: StandardInputDynamicRange,
+            sourceDimensions: StandardInputDisplayDimensions,
+            dimensions: CGSize,
+            audioChannels: UInt32?,
+            validatesTimeline: Bool
+        )] = [
+            (
+                "synthetic-standard-hevc-main10-hlg-1080p30-stereo",
+                .hlg,
+                StandardInputDisplayDimensions(width: 1920, height: 1080),
+                CGSize(width: 1920, height: 1080),
+                2,
+                false
+            ),
+            (
+                "synthetic-standard-hevc-main10-pq-1080p30-stereo",
+                .pq,
+                StandardInputDisplayDimensions(width: 1920, height: 1080),
+                CGSize(width: 1920, height: 1080),
+                2,
+                false
+            ),
+            (
+                "nat480-iphone-dolby-vision-84-hlg-4k-vfr",
+                .hlg,
+                StandardInputDisplayDimensions(width: 2160, height: 3840),
+                CGSize(width: 1080, height: 1920),
+                2,
+                true
+            ),
+            (
+                "nat480-clean-hdr10-pq-hevc-1080p5994",
+                .pq,
+                StandardInputDisplayDimensions(width: 1920, height: 1080),
+                CGSize(width: 1920, height: 1080),
+                nil,
+                true
+            )
+        ]
+
+        for testCase in cases {
+            try await assertConversion(
+                inputURL: try catalogFixtureURL(id: testCase.id),
+                expectedCodec: .hevc,
+                expectedBitDepth: 8,
+                maximumResolution: .preset1920x1080,
+                expectedDimensions: testCase.dimensions,
+                expectedConstantFrameRate: nil,
+                expectedAudioChannels: testCase.audioChannels,
+                conversion: toneMappingConversion(
+                    dynamicRange: testCase.dynamicRange,
+                    sourceDimensions: testCase.sourceDimensions
+                ),
+                validatesTimeline: testCase.validatesTimeline
+            )
+        }
+    }
+
     func testCatalogBackedCancellationDrainsActiveTransfers() async throws {
         let inputURL = try catalogFixtureURL(
             id: "synthetic-standard-hevc-main10-sdr-2160p30-5-1"
@@ -609,7 +778,9 @@ final class UploadInputStandardizerTests: XCTestCase {
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         expectedDimensions: CGSize,
         expectedConstantFrameRate: Double?,
-        expectedAudioChannels: UInt32
+        expectedAudioChannels: UInt32?,
+        conversion: StandardInputConversion? = nil,
+        validatesTimeline: Bool = false
     ) async throws {
         let outputURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("standardized-\(UUID().uuidString).mp4")
@@ -622,6 +793,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                 maximumDesiredResolutionPreset: maximumResolution,
                 recordedResolution: .init(width: 0, height: 0)
             ),
+            conversion: conversion,
             outputURL: outputURL
         )
         XCTAssertEqual(standardizedAsset.url, outputURL)
@@ -666,26 +838,31 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
 
         let audioTracks = try await outputAsset.loadTracks(withMediaType: .audio)
-        let audioTrack = try XCTUnwrap(audioTracks.first)
-        let audioFormat = try await audioTrack.load(.formatDescriptions).first
-        XCTAssertEqual(
-            audioFormat?.mediaSubType,
-            CMFormatDescription.MediaSubType(
-                rawValue: kAudioFormatMPEG4AAC
+        if let expectedAudioChannels {
+            let audioTrack = try XCTUnwrap(audioTracks.first)
+            let audioFormat = try await audioTrack.load(.formatDescriptions).first
+            XCTAssertEqual(
+                audioFormat?.mediaSubType,
+                CMFormatDescription.MediaSubType(
+                    rawValue: kAudioFormatMPEG4AAC
+                )
             )
-        )
-        XCTAssertEqual(
-            audioFormat.flatMap {
-                CMAudioFormatDescriptionGetStreamBasicDescription($0)?
-                    .pointee.mChannelsPerFrame
-            },
-            expectedAudioChannels
-        )
+            XCTAssertEqual(
+                audioFormat.flatMap {
+                    CMAudioFormatDescriptionGetStreamBasicDescription($0)?
+                        .pointee.mChannelsPerFrame
+                },
+                expectedAudioChannels
+            )
+        } else {
+            XCTAssertTrue(audioTracks.isEmpty)
+        }
 
         let inspectionResult = try await inspect(
             asset: outputAsset,
             maximumResolution: maximumResolution
         )
+        XCTAssertEqual(inspectionResult.mediaFacts.dynamicRange, .known(.sdr))
         if let expectedConstantFrameRate {
             XCTAssertEqual(
                 inspectionResult.mediaFacts.frameRate.value ?? 0,
@@ -715,6 +892,38 @@ final class UploadInputStandardizerTests: XCTestCase {
             ).isAccepted,
             "The validator must accept a policy-compliant generated output"
         )
+        if let conversion {
+            let sourceTimeline = try await timelineFacts(
+                asset: AVURLAsset(url: inputURL)
+            )
+            let outputTimeline = try await timelineFacts(asset: outputAsset)
+            if case .known(let sourceDuration) = sourceTimeline.duration,
+               case .known(let outputDuration) = outputTimeline.duration {
+                XCTAssertLessThanOrEqual(
+                    abs(sourceDuration - outputDuration),
+                    max(
+                        StandardInputOutputValidator.minimumDurationDelta,
+                        1 / (inspectionResult.mediaFacts.frameRate.value ?? 30)
+                    )
+                )
+            }
+            guard validatesTimeline else { return }
+            let generatedValidation = StandardInputOutputValidator()
+                .validateGeneratedOutput(
+                    facts: inspectionResult.mediaFacts,
+                    sourceTimeline: sourceTimeline,
+                    outputTimeline: outputTimeline,
+                    for: conversion
+                )
+            XCTAssertTrue(
+                generatedValidation.isAccepted,
+                """
+                Generated output must match the HDR plan for \
+                \(inputURL.lastPathComponent): \(generatedValidation); \
+                source timeline: \(sourceTimeline); output timeline: \(outputTimeline)
+                """
+            )
+        }
     }
 
     private func inspect(
@@ -759,6 +968,58 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
         XCTAssertEqual(reader.status, .completed)
         return durations
+    }
+
+    private func timelineFacts(
+        asset: AVAsset
+    ) async throws -> StandardInputTimelineFacts {
+        let duration = try await asset.load(.duration).seconds
+        let videoStart = try await minimumSamplePresentationTime(
+            asset: asset,
+            mediaType: .video
+        )
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        let audioVideoStartOffset: StandardInputTimelineFacts.AudioVideoStartOffset
+        if audioTracks.isEmpty {
+            audioVideoStartOffset = .notApplicable
+        } else {
+            let audioStart = try await minimumSamplePresentationTime(
+                asset: asset,
+                mediaType: .audio
+            )
+            audioVideoStartOffset = .seconds(audioStart - videoStart)
+        }
+        return StandardInputTimelineFacts(
+            duration: .known(duration),
+            audioVideoStartOffset: .known(audioVideoStartOffset)
+        )
+    }
+
+    private func minimumSamplePresentationTime(
+        asset: AVAsset,
+        mediaType: AVMediaType
+    ) async throws -> TimeInterval {
+        let tracks = try await asset.loadTracks(withMediaType: mediaType)
+        let track = try XCTUnwrap(tracks.first)
+        let reader = try AVAssetReader(asset: asset)
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+        reader.add(output)
+        XCTAssertTrue(reader.startReading())
+        var minimumTime: CMTime?
+        while let sample = output.copyNextSampleBuffer() {
+            let presentationTime = CMSampleBufferGetPresentationTimeStamp(sample)
+            guard presentationTime.isValid, presentationTime.isNumeric else {
+                continue
+            }
+            if let currentMinimum = minimumTime {
+                if CMTimeCompare(presentationTime, currentMinimum) < 0 {
+                    minimumTime = presentationTime
+                }
+            } else {
+                minimumTime = presentationTime
+            }
+        }
+        return try XCTUnwrap(minimumTime).seconds
     }
 
     private func catalogFixtureURL(id: String) throws -> URL {
@@ -864,6 +1125,53 @@ final class UploadInputStandardizerTests: XCTestCase {
         }
         didFinish = true
         return outputURL
+    }
+
+    private func toneMappingConversion(
+        dynamicRange: StandardInputDynamicRange,
+        sourceDimensions: StandardInputDisplayDimensions =
+            StandardInputDisplayDimensions(width: 1920, height: 1080)
+    ) -> StandardInputConversion {
+        StandardInputConversion(
+            sourceCodec: .hevc,
+            outputCodec: .hevc,
+            sourceDynamicRange: dynamicRange,
+            sourceDisplayDimensions: .known(sourceDimensions),
+            toneMapsToSDR: true,
+            selection: StandardInputPolicySelection(
+                maximumResolution: .preset1920x1080
+            ),
+            requirementsToRemediate: []
+        )
+    }
+
+    private func assertRec709ColorProperties(
+        _ value: Any?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let properties = value as? [String: Any] else {
+            XCTFail("Missing color properties", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(
+            properties[AVVideoColorPrimariesKey] as? String,
+            AVVideoColorPrimaries_ITU_R_709_2,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            properties[AVVideoTransferFunctionKey] as? String,
+            AVVideoTransferFunction_ITU_R_709_2,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            properties[AVVideoYCbCrMatrixKey] as? String,
+            AVVideoYCbCrMatrix_ITU_R_709_2,
+            file: file,
+            line: line
+        )
     }
 
     private func makeHEVCFormatDescription(


### PR DESCRIPTION
## Summary

- forward the planner's HDR conversion decision through the standardizer to the conversion worker
- use Apple's video-composition path to produce 8-bit BT.709 SDR for supported HLG and PQ inputs
- preserve the planned H.264 or HEVC codec family and leave non-tone-mapped color properties unchanged
- add concurrency-safe value conformances and focused coverage for conversion forwarding, Rec.709 settings, real-media output, timing, and audio

## Scope

This PR implements the conversion-worker path only. Final `DirectUpload` planner/validator orchestration, preserve/original-upload fallback wiring, storage preflight, and broader device/OS acceptance validation remain follow-up work.

[NAT-489](https://mux1.atlassian.net/browse/NAT-489)

[NAT-489]: https://mux1.atlassian.net/browse/NAT-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AVFoundation encode/decode color and pixel-format behavior for HDR uploads; mistakes could affect visual quality or compatibility, though scope is limited to the conversion worker and is heavily tested.
> 
> **Overview**
> Adds **HDR tone mapping** in the upload input standardization worker by threading an optional `StandardInputConversion` from the standardizer through to `UploadInputStandardizationWorker`, with protocol extensions defaulting `conversion` to `nil` so existing call sites stay unchanged.
> 
> When `conversion.toneMapsToSDR` is true, the worker forces **8-bit Rec.709 SDR**: planned output codec, 8-bit decoder pixel format, Rec.709 on the reader, video composition, and writer; non-tone-mapped paths still omit explicit color overrides. Related planner/policy types gain **`Sendable`** conformances for concurrency-safe passing of conversion plans.
> 
> Tests cover Rec.709 settings, conversion forwarding, catalog HLG/PQ outputs (SDR inspection, optional timeline validation), and optional audio expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b34492531967f4cb6c3ea68ffd4228f1c77edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->