### PR TITLE
NAT-490: Integrate DirectUpload standardization

### DIFF
--- a/Sources/MuxUploadSDK/InputInspection/StandardInputTimelineInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/StandardInputTimelineInspector.swift
@@ -1,0 +1,78 @@
+//
+//  StandardInputTimelineInspector.swift
+//
+
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+
+enum StandardInputTimelineInspector {
+    static func inspect(
+        asset: AVAsset,
+        videoTrack: AVAssetTrack,
+        audioTrack: AVAssetTrack?,
+        duration: CMTime,
+        operation: UploadInputInspectionOperation
+    ) async -> StandardInputTimelineFacts {
+        let durationSeconds = duration.seconds
+        let durationFact: StandardInputFact<TimeInterval> = durationSeconds.isFinite
+                && durationSeconds > 0
+            ? .known(durationSeconds)
+            : .unknown
+
+        guard let videoStart = await firstPresentationTime(
+            asset: asset,
+            track: videoTrack,
+            operation: operation
+        ) else {
+            return StandardInputTimelineFacts(duration: durationFact)
+        }
+
+        guard let audioTrack else {
+            return StandardInputTimelineFacts(
+                duration: durationFact,
+                audioVideoStartOffset: .known(.notApplicable)
+            )
+        }
+        guard let audioStart = await firstPresentationTime(
+            asset: asset,
+            track: audioTrack,
+            operation: operation
+        ) else {
+            return StandardInputTimelineFacts(duration: durationFact)
+        }
+
+        return StandardInputTimelineFacts(
+            duration: durationFact,
+            audioVideoStartOffset: .known(.seconds(audioStart - videoStart))
+        )
+    }
+
+    private static func firstPresentationTime(
+        asset: AVAsset,
+        track: AVAssetTrack,
+        operation: UploadInputInspectionOperation
+    ) async -> TimeInterval? {
+        guard !(await operation.isCancelled) else { return nil }
+        guard let reader = try? AVAssetReader(asset: asset) else { return nil }
+        let output = AVAssetReaderTrackOutput(track: track, outputSettings: nil)
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else { return nil }
+        reader.add(output)
+        guard reader.startReading(),
+              await operation.register(assetReader: reader) else {
+            return nil
+        }
+        while let sample = output.copyNextSampleBuffer() {
+            guard !(await operation.isCancelled) else {
+                reader.cancelReading()
+                return nil
+            }
+            guard CMSampleBufferGetNumSamples(sample) > 0 else { continue }
+            let seconds = CMSampleBufferGetPresentationTimeStamp(sample).seconds
+            reader.cancelReading()
+            return seconds.isFinite ? seconds : nil
+        }
+        return nil
+    }
+}

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputFormatInspectionResult.swift
@@ -5,8 +5,8 @@
 import AVFoundation
 import Foundation
 
-struct UploadInputFormatInspectionResult {
-    enum NonstandardInputReason {
+struct UploadInputFormatInspectionResult: Sendable {
+    enum NonstandardInputReason: Sendable {
         case videoCodec
         case audioCodec
         case videoGOPSize
@@ -26,11 +26,13 @@ struct UploadInputFormatInspectionResult {
 
     var metadata: UploadInputMetadataInspection = UploadInputMetadataInspection()
 
+    var timelineFacts: StandardInputTimelineFacts = StandardInputTimelineFacts()
+
     var isStandardInput: Bool {
         nonStandardInputReasons.isEmpty
     }
 
-    struct RescalingDetails {
+    struct RescalingDetails: Sendable {
         var maximumDesiredResolutionPreset: DirectUploadOptions.InputStandardization.MaximumResolution = .default
 
         var recordedResolution: CMVideoDimensions = CMVideoDimensions(width: 0, height: 0)

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputInspector.swift
@@ -2,81 +2,66 @@
 //  UploadInputInspector.swift
 //  
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import CoreMedia
 import Foundation
 
-typealias UploadInputInspectionCompletionHandler = (UploadInputFormatInspectionResult?, CMTime, Error?) -> ()
+struct UploadInputInspectionOutcome: Sendable {
+    let result: UploadInputFormatInspectionResult?
+    let duration: CMTime
+    let error: Error?
+}
 
-final class UploadInputInspectionOperation {
+typealias UploadInputInspectionCompletionHandler = (
+    UploadInputFormatInspectionResult?,
+    CMTime,
+    Error?
+) -> Void
+
+actor UploadInputInspectionOperation {
     private enum State {
         case active
         case cancelled
         case completed
     }
 
-    private let lock = NSLock()
-    private let completionHandler: UploadInputInspectionCompletionHandler
     private var state: State = .active
-    private var assetReader: AVAssetReader?
-
-    init(completionHandler: @escaping UploadInputInspectionCompletionHandler) {
-        self.completionHandler = completionHandler
-    }
+    private var hasRegisteredReader = false
 
     var isCancelled: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return state == .cancelled
+        state == .cancelled
+    }
+
+    var hasRegisteredAssetReader: Bool {
+        hasRegisteredReader
     }
 
     func register(assetReader: AVAssetReader) -> Bool {
-        lock.lock()
-        let isActive = state == .active
-        if isActive {
-            self.assetReader = assetReader
-        }
-        lock.unlock()
-
-        if !isActive {
+        guard state == .active else {
             assetReader.cancelReading()
+            return false
         }
-        return isActive
+        hasRegisteredReader = true
+        return true
     }
 
     func cancel() {
-        lock.lock()
-        guard state == .active else {
-            lock.unlock()
-            return
-        }
+        guard state == .active else { return }
+        // AVAssetReader forbids calling cancelReading() concurrently with
+        // copyNextSampleBuffer(). Record cancellation here; the task consuming
+        // samples observes this state and cancels its reader on that same task.
         state = .cancelled
-        let assetReader = self.assetReader
-        self.assetReader = nil
-        lock.unlock()
-
-        assetReader?.cancelReading()
     }
 
-    func complete(
-        _ result: UploadInputFormatInspectionResult?,
-        duration: CMTime,
-        error: Error?
-    ) {
-        lock.lock()
-        guard state == .active else {
-            lock.unlock()
-            return
-        }
+    func complete() -> Bool {
+        guard state == .active else { return false }
         state = .completed
-        assetReader = nil
-        lock.unlock()
-
-        completionHandler(result, duration, error)
+        hasRegisteredReader = false
+        return true
     }
 }
 
-final class UploadInputInspectionOperationRegistry: @unchecked Sendable {
+actor UploadInputInspectionOperationRegistry {
     struct Token: Equatable, Sendable {
         private let id: UUID
 
@@ -90,58 +75,44 @@ final class UploadInputInspectionOperationRegistry: @unchecked Sendable {
         let operation: UploadInputInspectionOperation
     }
 
-    private let lock = NSLock()
     private var registration: Registration?
 
     func register(
         _ operation: UploadInputInspectionOperation,
         for token: Token
-    ) {
-        lock.lock()
+    ) async {
         let previousOperation = registration?.operation
         registration = Registration(
             token: token,
             operation: operation
         )
-        lock.unlock()
-
-        previousOperation?.cancel()
+        await previousOperation?.cancel()
     }
 
     @discardableResult
-    func claimCompletion(for token: Token) -> Bool {
-        lock.lock()
-        guard registration?.token == token else {
-            lock.unlock()
-            return false
-        }
-        registration = nil
-        lock.unlock()
-        return true
-    }
-
-    @discardableResult
-    func cancel(for token: Token) -> Bool {
-        lock.lock()
-        guard registration?.token == token else {
-            lock.unlock()
-            return false
-        }
+    func claimCompletion(for token: Token) async -> Bool {
+        guard registration?.token == token else { return false }
         let operation = registration?.operation
         registration = nil
-        lock.unlock()
+        return await operation?.complete() ?? false
+    }
 
-        operation?.cancel()
+    @discardableResult
+    func cancel(for token: Token) async -> Bool {
+        guard registration?.token == token else { return false }
+        let operation = registration?.operation
+        registration = nil
+        await operation?.cancel()
         return operation != nil
     }
 }
 
-protocol UploadInputInspector {
-    func performInspection(
+protocol UploadInputInspector: Sendable {
+    func inspect(
         sourceInput: AVAsset,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         operation: UploadInputInspectionOperation
-    )
+    ) async -> UploadInputInspectionOutcome
 }
 
 extension UploadInputInspector {
@@ -151,14 +122,16 @@ extension UploadInputInspector {
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         completionHandler: @escaping UploadInputInspectionCompletionHandler
     ) -> UploadInputInspectionOperation {
-        let operation = UploadInputInspectionOperation(
-            completionHandler: completionHandler
-        )
-        performInspection(
-            sourceInput: sourceInput,
-            maximumResolution: maximumResolution,
-            operation: operation
-        )
+        let operation = UploadInputInspectionOperation()
+        Task {
+            let outcome = await inspect(
+                sourceInput: sourceInput,
+                maximumResolution: maximumResolution,
+                operation: operation
+            )
+            guard await operation.complete() else { return }
+            completionHandler(outcome.result, outcome.duration, outcome.error)
+        }
         return operation
     }
 }
@@ -169,114 +142,109 @@ struct UploadInputInspectionError: Error {
 
 }
 
-class AVFoundationUploadInputInspector: UploadInputInspector {
+final class AVFoundationUploadInputInspector: UploadInputInspector {
 
     static let shared = AVFoundationUploadInputInspector()
 
-    // FIXME: Trying to avoid the callback pyramid of doom
-    // here, newer AVAsset APIs use Concurrency
-    // but Concurrency itself has very primitive
-    // task sequencing. Replace with async AVAsset
-    // methods.
-    func performInspection(
+    func inspect(
         sourceInput: AVAsset,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         operation: UploadInputInspectionOperation
-    ) {
-        sourceInput.loadTracks(
-            withMediaType: .video
-        ) { videoTracks, videoError in
-            guard !operation.isCancelled else { return }
-            guard videoError == nil, let videoTracks else {
-                operation.complete(
-                    nil,
-                    duration: CMTime.zero,
-                    error: UploadInputInspectionError.inspectionFailure
-                )
-                return
+    ) async -> UploadInputInspectionOutcome {
+        do {
+            let videoTracks = try await sourceInput.loadTracks(withMediaType: .video)
+            guard !(await operation.isCancelled) else {
+                return cancelledOutcome()
             }
-
-            sourceInput.loadTracks(
-                withMediaType: .audio
-            ) { audioTracks, audioError in
-                guard !operation.isCancelled else { return }
-                self.inspect(
-                    sourceInput: sourceInput,
-                    videoTracks: videoTracks,
-                    audioTracks: audioError == nil ? audioTracks : nil,
-                    maximumResolution: maximumResolution,
-                    operation: operation
-                )
+            let audioTracks = try? await sourceInput.loadTracks(withMediaType: .audio)
+            guard !(await operation.isCancelled) else {
+                return cancelledOutcome()
             }
+            return await inspect(
+                sourceInput: sourceInput,
+                videoTracks: videoTracks,
+                audioTracks: audioTracks,
+                maximumResolution: maximumResolution,
+                operation: operation
+            )
+        } catch {
+            return UploadInputInspectionOutcome(
+                result: nil,
+                duration: .zero,
+                error: UploadInputInspectionError.inspectionFailure
+            )
         }
     }
 
-    func inspect(
+    private func inspect(
         sourceInput: AVAsset,
         videoTracks: [AVAssetTrack],
         audioTracks: [AVAssetTrack]?,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         operation: UploadInputInspectionOperation
-    ) {
-        loadAudioMetadata(audioTracks, operation: operation) { audioMetadata in
-            guard !operation.isCancelled else { return }
-            switch videoTracks.count {
-            case 0:
-                let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
-                    videoTracks: [],
-                    audioTracks: audioMetadata
-                )
-                operation.complete(
-                    UploadInputFormatInspectionResult(
-                        mediaFacts: metadataResult.mediaFacts,
-                        metadata: metadataResult.metadata
-                    ),
-                    duration: CMTime.zero,
-                    error: nil
-                )
-            case 1:
-                self.inspectSingleVideoTrack(
-                    sourceInput: sourceInput,
-                    videoTrack: videoTracks[0],
-                    audioMetadata: audioMetadata,
-                    maximumResolution: maximumResolution,
-                    operation: operation
-                )
-            default:
-                operation.complete(
-                    self.makeVideoInspectionFailureResult(
-                        videoTrackCount: videoTracks.count,
-                        audioMetadata: audioMetadata
-                    ),
-                    duration: CMTime.zero,
-                    error: UploadInputInspectionError.inspectionFailure
-                )
-            }
+    ) async -> UploadInputInspectionOutcome {
+        let audioMetadata = await loadAudioMetadata(
+            audioTracks,
+            operation: operation
+        )
+        guard !(await operation.isCancelled) else {
+            return cancelledOutcome()
+        }
+        switch videoTracks.count {
+        case 0:
+            let metadataResult = AVFoundationUploadInputMetadataReader.inspect(
+                videoTracks: [],
+                audioTracks: audioMetadata
+            )
+            return UploadInputInspectionOutcome(
+                result: UploadInputFormatInspectionResult(
+                    mediaFacts: metadataResult.mediaFacts,
+                    metadata: metadataResult.metadata
+                ),
+                duration: .zero,
+                error: nil
+            )
+        case 1:
+            return await inspectSingleVideoTrack(
+                sourceInput: sourceInput,
+                videoTrack: videoTracks[0],
+                audioTracks: audioTracks,
+                audioMetadata: audioMetadata,
+                maximumResolution: maximumResolution,
+                operation: operation
+            )
+        default:
+            return UploadInputInspectionOutcome(
+                result: makeVideoInspectionFailureResult(
+                    videoTrackCount: videoTracks.count,
+                    audioMetadata: audioMetadata
+                ),
+                duration: .zero,
+                error: UploadInputInspectionError.inspectionFailure
+            )
         }
     }
 
     private func inspectSingleVideoTrack(
         sourceInput: AVAsset,
         videoTrack: AVAssetTrack,
+        audioTracks: [AVAssetTrack]?,
         audioMetadata: [AVFoundationAudioTrackMetadata]?,
         maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
         operation: UploadInputInspectionOperation
-    ) {
-        Task {
-            let sourceInputDuration: CMTime
-            do {
-                sourceInputDuration = try await sourceInput.load(.duration)
-            } catch {
-                guard !operation.isCancelled else { return }
-                operation.complete(
-                    nil,
-                    duration: .zero,
-                    error: UploadInputInspectionError.inspectionFailure
-                )
-                return
-            }
+    ) async -> UploadInputInspectionOutcome {
+        let sourceInputDuration: CMTime
+        do {
+            sourceInputDuration = try await sourceInput.load(.duration)
+        } catch {
+            return UploadInputInspectionOutcome(
+                result: nil,
+                duration: .zero,
+                error: UploadInputInspectionError.inspectionFailure
+            )
+        }
 
-            do {
+        do {
                 async let formatDescriptions = videoTrack.load(.formatDescriptions)
                 async let preferredTransform = videoTrack.load(.preferredTransform)
                 async let nominalFrameRate = videoTrack.load(.nominalFrameRate)
@@ -289,7 +257,9 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     estimatedDataRate,
                     segments
                 )
-                guard !operation.isCancelled else { return }
+                guard !(await operation.isCancelled) else {
+                    return cancelledOutcome(duration: sourceInputDuration)
+                }
                 guard let formatDescription = loadedMetadata.0.first else {
                     throw UploadInputInspectionError.inspectionFailure
                 }
@@ -312,14 +282,27 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     audioTracks: audioMetadata
                 )
                 var mediaFacts = metadataResult.mediaFacts
-                let sampleFacts = AVFoundationUploadInputSampleReader.inspect(
+                let sampleFacts = await AVFoundationUploadInputSampleReader.inspect(
                     asset: sourceInput,
                     videoTrack: videoTrack,
                     codec: mediaFacts.videoCodec,
                     operation: operation
                 )
-                guard !operation.isCancelled else { return }
+                guard !(await operation.isCancelled) else {
+                    return cancelledOutcome(duration: sourceInputDuration)
+                }
                 mediaFacts.mergeGOPFacts(from: sampleFacts)
+
+                let timelineFacts = await StandardInputTimelineInspector.inspect(
+                    asset: sourceInput,
+                    videoTrack: videoTrack,
+                    audioTrack: audioTracks?.first,
+                    duration: sourceInputDuration,
+                    operation: operation
+                )
+                guard !(await operation.isCancelled) else {
+                    return cancelledOutcome(duration: sourceInputDuration)
+                }
 
                 let videoDimensions = CMVideoFormatDescriptionGetDimensions(
                     formatDescription
@@ -331,11 +314,12 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     estimatedBitrate: loadedMetadata.3
                 )
 
-                operation.complete(
-                    UploadInputFormatInspectionResult(
+                return UploadInputInspectionOutcome(
+                    result: UploadInputFormatInspectionResult(
                         nonStandardInputReasons: nonStandardReasons,
                         mediaFacts: mediaFacts,
                         metadata: metadataResult.metadata,
+                        timelineFacts: timelineFacts,
                         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails(
                             maximumDesiredResolutionPreset: maximumResolution,
                             recordedResolution: videoDimensions
@@ -344,17 +328,18 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
                     duration: sourceInputDuration,
                     error: nil
                 )
-            } catch {
-                guard !operation.isCancelled else { return }
-                operation.complete(
-                    self.makeVideoInspectionFailureResult(
+        } catch {
+            guard !(await operation.isCancelled) else {
+                return cancelledOutcome(duration: sourceInputDuration)
+            }
+            return UploadInputInspectionOutcome(
+                result: makeVideoInspectionFailureResult(
                         videoTrackCount: 1,
                         audioMetadata: audioMetadata
                     ),
-                    duration: sourceInputDuration,
-                    error: UploadInputInspectionError.inspectionFailure
-                )
-            }
+                duration: sourceInputDuration,
+                error: UploadInputInspectionError.inspectionFailure
+            )
         }
     }
 
@@ -376,38 +361,30 @@ class AVFoundationUploadInputInspector: UploadInputInspector {
 
     private func loadAudioMetadata(
         _ tracks: [AVAssetTrack]?,
-        operation: UploadInputInspectionOperation,
-        index: Int = 0,
-        accumulated: [AVFoundationAudioTrackMetadata] = [],
-        completionHandler: @escaping ([AVFoundationAudioTrackMetadata]?) -> Void
-    ) {
+        operation: UploadInputInspectionOperation
+    ) async -> [AVFoundationAudioTrackMetadata]? {
         guard let tracks else {
-            completionHandler(nil)
-            return
+            return nil
         }
-
-        guard index < tracks.count else {
-            completionHandler(accumulated)
-            return
-        }
-
-        let track = tracks[index]
-        track.loadValuesAsynchronously(forKeys: ["formatDescriptions"]) {
-            guard !operation.isCancelled else { return }
-            let formatDescriptions = track.formatDescriptions as? [CMFormatDescription]
-                ?? []
-            self.loadAudioMetadata(
-                tracks,
-                operation: operation,
-                index: index + 1,
-                accumulated: accumulated + [
-                    AVFoundationAudioTrackMetadata(
-                        formatDescriptions: formatDescriptions
-                    )
-                ],
-                completionHandler: completionHandler
+        var metadata: [AVFoundationAudioTrackMetadata] = []
+        for track in tracks {
+            guard !(await operation.isCancelled) else { return nil }
+            guard let descriptions = try? await track.load(.formatDescriptions) else {
+                return nil
+            }
+            metadata.append(
+                AVFoundationAudioTrackMetadata(formatDescriptions: descriptions)
             )
         }
+        return metadata
+    }
+
+    private func cancelledOutcome(duration: CMTime = .zero) -> UploadInputInspectionOutcome {
+        UploadInputInspectionOutcome(
+            result: nil,
+            duration: duration,
+            error: CancellationError()
+        )
     }
 
     private func legacyNonStandardReasons(

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputMetadataInspection.swift
@@ -7,11 +7,11 @@ import CoreGraphics
 import CoreMedia
 import Foundation
 
-struct UploadInputMetadataInspection: Equatable {
-    struct VideoTransform: Equatable {
+struct UploadInputMetadataInspection: Equatable, Sendable {
+    struct VideoTransform: Equatable, Sendable {
         /// The source metadata orientation normalized to the range 0...270.
         /// For example, a signed -90-degree rotation is represented as 270 degrees.
-        enum Rotation: Int, Equatable {
+        enum Rotation: Int, Equatable, Sendable {
             case degrees0 = 0
             case degrees90 = 90
             case degrees180 = 180
@@ -22,7 +22,7 @@ struct UploadInputMetadataInspection: Equatable {
         let isMirrored: Bool
     }
 
-    struct ColorProperties: Equatable {
+    struct ColorProperties: Equatable, Sendable {
         var primaries: StandardInputFact<String> = .unknown
         var transferFunction: StandardInputFact<String> = .unknown
         var yCbCrMatrix: StandardInputFact<String> = .unknown

--- a/Sources/MuxUploadSDK/InputInspection/UploadInputSampleInspection.swift
+++ b/Sources/MuxUploadSDK/InputInspection/UploadInputSampleInspection.swift
@@ -2,7 +2,7 @@
 //  UploadInputSampleInspection.swift
 //
 
-import AVFoundation
+@preconcurrency import AVFoundation
 import CoreMedia
 import Foundation
 
@@ -170,8 +170,8 @@ enum AVFoundationUploadInputSampleReader {
         videoTrack: AVAssetTrack,
         codec: StandardInputFact<StandardInputVideoCodec>,
         operation: UploadInputInspectionOperation? = nil
-    ) -> StandardInputMediaFacts {
-        guard operation?.isCancelled != true else { return StandardInputMediaFacts() }
+    ) async -> StandardInputMediaFacts {
+        guard (await operation?.isCancelled) != true else { return StandardInputMediaFacts() }
         guard let codec = codec.value,
               codec == .h264 || codec == .hevc else {
             return StandardInputMediaFacts()
@@ -191,12 +191,12 @@ enum AVFoundationUploadInputSampleReader {
         guard reader.startReading() else {
             return StandardInputMediaFacts()
         }
-        guard operation?.register(assetReader: reader) ?? true else {
+        guard await operation?.register(assetReader: reader) ?? true else {
             return StandardInputMediaFacts()
         }
 
         var accumulator = UploadInputCompressedSampleAggregator.Accumulator()
-        while operation?.isCancelled != true,
+        while (await operation?.isCancelled) != true,
               let sampleBuffer = output.copyNextSampleBuffer() {
             // Readers may vend zero-sample marker buffers before media samples.
             if CMSampleBufferGetNumSamples(sampleBuffer) == 0 {
@@ -217,7 +217,7 @@ enum AVFoundationUploadInputSampleReader {
             }
         }
 
-        guard operation?.isCancelled != true else {
+        guard (await operation?.isCancelled) != true else {
             reader.cancelReading()
             return StandardInputMediaFacts()
         }

--- a/Sources/MuxUploadSDK/InputStandardization/DirectUploadPreparation.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/DirectUploadPreparation.swift
@@ -1,0 +1,217 @@
+//
+//  DirectUploadPreparation.swift
+//
+
+import AVFoundation
+import Foundation
+import VideoToolbox
+
+protocol StandardInputPlanningCapabilityProviding: Sendable {
+    func capabilities(
+        for inspection: UploadInputFormatInspectionResult,
+        sourceAsset: AVAsset
+    ) async -> StandardInputPlanningCapabilities
+}
+
+struct AVFoundationStandardInputPlanningCapabilityProvider:
+    StandardInputPlanningCapabilityProviding {
+    func capabilities(
+        for inspection: UploadInputFormatInspectionResult,
+        sourceAsset: AVAsset
+    ) async -> StandardInputPlanningCapabilities {
+        var codecs: Set<StandardInputVideoCodec> = []
+        if canCreateCompressionSession(codec: kCMVideoCodecType_H264) {
+            codecs.insert(.h264)
+        }
+        if canCreateCompressionSession(codec: kCMVideoCodecType_HEVC) {
+            codecs.insert(.hevc)
+        }
+        return StandardInputPlanningCapabilities(
+            sourceIsDecodable: await canDecodeVideoSample(
+                from: sourceAsset,
+                expectedTrackCount: inspection.metadata.videoTrackCount
+            ),
+            encodableVideoCodecs: codecs,
+            remediableRequirements: Set(StandardInputPolicyEvaluation.Requirement.allCases),
+            toneMappableDynamicRanges: [.hlg, .pq],
+            preservableHDRDynamicRanges: [.hlg, .pq]
+        )
+    }
+
+    /// Starts a bounded decode and requests one decompressed pixel buffer. A
+    /// track count alone only proves that compressed samples are present.
+    private func canDecodeVideoSample(
+        from asset: AVAsset,
+        expectedTrackCount: Int
+    ) async -> Bool {
+        guard expectedTrackCount == 1,
+              let videoTrack = try? await asset.loadTracks(withMediaType: .video).first,
+              let reader = try? AVAssetReader(asset: asset) else {
+            return false
+        }
+        let output = AVAssetReaderTrackOutput(
+            track: videoTrack,
+            outputSettings: [
+                kCVPixelBufferPixelFormatTypeKey as String:
+                    kCVPixelFormatType_32BGRA
+            ]
+        )
+        output.alwaysCopiesSampleData = false
+        guard reader.canAdd(output) else { return false }
+        reader.add(output)
+        guard reader.startReading() else { return false }
+        defer { reader.cancelReading() }
+        return output.copyNextSampleBuffer() != nil
+    }
+
+    private func canCreateCompressionSession(codec: CMVideoCodecType) -> Bool {
+        var session: VTCompressionSession?
+        let status = VTCompressionSessionCreate(
+            allocator: kCFAllocatorDefault,
+            width: 16,
+            height: 16,
+            codecType: codec,
+            encoderSpecification: nil,
+            imageBufferAttributes: nil,
+            compressedDataAllocator: nil,
+            outputCallback: nil,
+            refcon: nil,
+            compressionSessionOut: &session
+        )
+        if let session {
+            VTCompressionSessionInvalidate(session)
+        }
+        return status == noErr
+    }
+}
+
+protocol TemporaryStoragePreflighting: Sendable {
+    func outputURL(
+        for sourceURL: URL,
+        duration: CMTime,
+        conversion: StandardInputConversion
+    ) throws -> URL
+
+    func ownsTemporaryOutput(_ url: URL) -> Bool
+}
+
+struct TemporaryStoragePreflightError: LocalizedError {
+    enum Reason {
+        case unavailableCapacity
+        case insufficientCapacity(required: Int64, available: Int64)
+        case cannotCreateDirectory
+    }
+
+    let reason: Reason
+
+    var errorDescription: String? {
+        switch reason {
+        case .unavailableCapacity:
+            return "Temporary storage capacity could not be determined"
+        case .insufficientCapacity(let required, let available):
+            return "Insufficient temporary storage: requires \(required) bytes, \(available) bytes available"
+        case .cannotCreateDirectory:
+            return "The temporary standardization directory could not be created"
+        }
+    }
+}
+
+struct FileSystemTemporaryStoragePreflighter: TemporaryStoragePreflighting {
+    static let directoryName = "MuxUploadSDK/Standardized"
+    static let filePrefix = "mux-upload-"
+    static let reserveBytes: Int64 = 64 * 1_024 * 1_024
+
+    private let baseDirectory: URL
+
+    init(
+        baseDirectory: URL = FileManager.default.temporaryDirectory
+    ) {
+        self.baseDirectory = baseDirectory
+    }
+
+    func outputURL(
+        for sourceURL: URL,
+        duration: CMTime,
+        conversion: StandardInputConversion
+    ) throws -> URL {
+        let directory = baseDirectory.appendingPathComponent(
+            Self.directoryName,
+            isDirectory: true
+        )
+        do {
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            throw TemporaryStoragePreflightError(reason: .cannotCreateDirectory)
+        }
+
+        let available = try availableCapacity(at: directory)
+        let required = requiredCapacity(
+            sourceURL: sourceURL,
+            duration: duration,
+            conversion: conversion
+        )
+        guard available >= required else {
+            throw TemporaryStoragePreflightError(
+                reason: .insufficientCapacity(required: required, available: available)
+            )
+        }
+
+        return directory.appendingPathComponent(
+            "\(Self.filePrefix)\(UUID().uuidString).mp4"
+        )
+    }
+
+    func ownsTemporaryOutput(_ url: URL) -> Bool {
+        let directory = baseDirectory.appendingPathComponent(
+            Self.directoryName,
+            isDirectory: true
+        ).standardizedFileURL
+        let candidate = url.standardizedFileURL
+        return candidate.deletingLastPathComponent() == directory
+            && candidate.lastPathComponent.hasPrefix(Self.filePrefix)
+    }
+
+    private func availableCapacity(at directory: URL) throws -> Int64 {
+        let values = try directory.resourceValues(forKeys: [
+            .volumeAvailableCapacityForImportantUsageKey,
+            .volumeAvailableCapacityKey
+        ])
+        if let capacity = values.volumeAvailableCapacityForImportantUsage {
+            return capacity
+        }
+        if let capacity = values.volumeAvailableCapacity {
+            return Int64(capacity)
+        }
+        throw TemporaryStoragePreflightError(reason: .unavailableCapacity)
+    }
+
+    private func requiredCapacity(
+        sourceURL: URL,
+        duration: CMTime,
+        conversion: StandardInputConversion
+    ) -> Int64 {
+        let sourceSize = (try? FileManager.default.attributesOfItem(atPath: sourceURL.path)[.size]
+            as? NSNumber)?.int64Value ?? 0
+        let durationSeconds = duration.seconds
+        let tier = conversion.selection.acceptanceTier
+        let videoBitrate = StandardInputPolicyProfile.publishedMux
+            .limits(for: tier)
+            .maximumAverageBitrate
+        let estimatedOutput: Int64
+        if durationSeconds.isFinite, durationSeconds > 0 {
+            let estimated = durationSeconds * Double(videoBitrate + 512_000) / 8
+            estimatedOutput = estimated < Double(Int64.max)
+                ? Int64(estimated.rounded(.up))
+                : Int64.max
+        } else {
+            estimatedOutput = sourceSize
+        }
+        let payload = max(sourceSize, estimatedOutput)
+        let (required, overflow) = payload.addingReportingOverflow(Self.reserveBytes)
+        return overflow ? Int64.max : required
+    }
+
+}

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputOutputValidator.swift
@@ -4,8 +4,8 @@
 
 import Foundation
 
-struct StandardInputTimelineFacts: Equatable {
-    enum AudioVideoStartOffset: Equatable {
+struct StandardInputTimelineFacts: Equatable, Sendable {
+    enum AudioVideoStartOffset: Equatable, Sendable {
         case notApplicable
         case seconds(TimeInterval)
     }
@@ -14,8 +14,8 @@ struct StandardInputTimelineFacts: Equatable {
     var audioVideoStartOffset: StandardInputFact<AudioVideoStartOffset> = .unknown
 }
 
-struct StandardInputOutputValidation: Equatable {
-    enum PlanExpectation: Hashable {
+struct StandardInputOutputValidation: Equatable, Sendable {
+    enum PlanExpectation: Hashable, Sendable {
         case videoCodec
         case dynamicRange
         case displayAspectRatio
@@ -23,7 +23,7 @@ struct StandardInputOutputValidation: Equatable {
         case audioVideoStartOffset
     }
 
-    enum RejectionReason: Equatable {
+    enum RejectionReason: Equatable, Sendable {
         case nonCompliant(Set<StandardInputPolicyEvaluation.Requirement>)
         case insufficientPolicyEvidence(
             Set<StandardInputPolicyEvaluation.Requirement>
@@ -32,7 +32,7 @@ struct StandardInputOutputValidation: Equatable {
         case doesNotMatchPlan(Set<PlanExpectation>)
     }
 
-    enum Disposition: Equatable {
+    enum Disposition: Equatable, Sendable {
         case accepted
         case rejected(RejectionReason)
     }

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPlanner.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-struct StandardInputPlanningCapabilities: Equatable {
+struct StandardInputPlanningCapabilities: Equatable, Sendable {
     /// Capabilities are supplied for the current source and device. This keeps
     /// hardware probing and asset-specific decode checks outside the pure planner.
     var sourceIsDecodable: Bool
@@ -37,15 +37,15 @@ struct StandardInputConversion: Equatable, Sendable {
     let requirementsToRemediate: Set<StandardInputPolicyEvaluation.Requirement>
 }
 
-struct StandardInputPlan: Equatable {
-    enum UploadOriginalReason: Equatable {
+struct StandardInputPlan: Equatable, Sendable {
+    enum UploadOriginalReason: Equatable, Sendable {
         case standardizationNotRequested
         case standardInput
         case noKnownStandardInputViolation
         case preserveHDR(StandardInputDynamicRange)
     }
 
-    enum FallbackReason: Equatable {
+    enum FallbackReason: Equatable, Sendable {
         case insufficientEvidenceForConversion
         case unsupportedConversion(StandardInputConversion)
         case unsupportedHDR(StandardInputDynamicRange)
@@ -56,7 +56,7 @@ struct StandardInputPlan: Equatable {
         )
     }
 
-    enum Action: Equatable {
+    enum Action: Equatable, Sendable {
         case uploadOriginal(UploadOriginalReason)
         case convert(StandardInputConversion)
         case fallback(FallbackReason)

--- a/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardInputPolicy.swift
@@ -44,8 +44,8 @@ struct StandardInputDisplayDimensions: Equatable, Sendable {
     }
 }
 
-struct StandardInputPixelFormat: Hashable {
-    enum ChromaSubsampling: Hashable {
+struct StandardInputPixelFormat: Hashable, Sendable {
+    enum ChromaSubsampling: Hashable, Sendable {
         case yuv420
         case other
     }
@@ -61,14 +61,14 @@ enum StandardInputDynamicRange: Hashable, Sendable {
     case otherHDR
 }
 
-enum StandardInputGOPStructure: Hashable {
+enum StandardInputGOPStructure: Hashable, Sendable {
     case closedWithIDR
     case closedWithoutIDR
     case open
 }
 
-enum StandardInputAudio: Hashable {
-    enum ChannelLayout: Hashable {
+enum StandardInputAudio: Hashable, Sendable {
+    enum ChannelLayout: Hashable, Sendable {
         case mono
         case stereo
         case fivePointOne
@@ -80,13 +80,13 @@ enum StandardInputAudio: Hashable {
     case otherCodec
 }
 
-enum StandardInputEditList: Hashable {
+enum StandardInputEditList: Hashable, Sendable {
     case none
     case simple
     case complex
 }
 
-struct StandardInputMediaFacts: Equatable {
+struct StandardInputMediaFacts: Equatable, Sendable {
     var videoCodec: StandardInputFact<StandardInputVideoCodec> = .unknown
     var displayDimensions: StandardInputFact<StandardInputDisplayDimensions> = .unknown
     var frameRate: StandardInputFact<Double> = .unknown
@@ -239,7 +239,7 @@ extension StandardInputPolicyProfile {
     )
 }
 
-struct StandardInputPolicyEvaluation: Equatable {
+struct StandardInputPolicyEvaluation: Equatable, Sendable {
     enum Requirement: CaseIterable, Hashable, Sendable {
         case videoCodec
         case videoResolution
@@ -254,19 +254,19 @@ struct StandardInputPolicyEvaluation: Equatable {
         case editList
     }
 
-    enum Status: Equatable {
+    enum Status: Equatable, Sendable {
         case compliant
         case nonCompliant
         case unknown
     }
 
-    enum Outcome: Equatable {
+    enum Outcome: Equatable, Sendable {
         case compliant
         case nonCompliant
         case unknown
     }
 
-    struct Check: Equatable {
+    struct Check: Equatable, Sendable {
         let requirement: Requirement
         let status: Status
     }

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizationWorker.swift
@@ -13,26 +13,11 @@ protocol UploadInputStandardizationWorking: AnyObject, Sendable {
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset
 
     func cancel() async
-}
-
-extension UploadInputStandardizationWorking {
-    func standardize(
-        sourceAsset: AVURLAsset,
-        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL
-    ) async throws -> AVURLAsset {
-        try await standardize(
-            sourceAsset: sourceAsset,
-            rescalingDetails: rescalingDetails,
-            conversion: nil,
-            outputURL: outputURL
-        )
-    }
 }
 
 struct StandardizationError: LocalizedError {
@@ -237,7 +222,7 @@ actor UploadInputStandardizationWorker {
     func standardize(
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset {
         try ensureActive()
@@ -349,7 +334,7 @@ actor UploadInputStandardizationWorker {
         audioProperties: AudioProperties?,
         properties: LoadedAssetProperties,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset {
         let renderSize = try Self.renderSize(
@@ -372,10 +357,9 @@ actor UploadInputStandardizationWorker {
         let sourceFormatDescription = properties.formatDescriptions[0]
         let decoderPixelFormat = Self.decoderPixelFormat(
             for: sourceFormatDescription,
-            toneMapsToSDR: conversion?.toneMapsToSDR == true
+            toneMapsToSDR: conversion.toneMapsToSDR
         )
-        let codec = conversion.map(Self.outputCodec(for:))
-            ?? Self.outputCodec(for: sourceFormatDescription.mediaSubType)
+        let codec = Self.outputCodec(for: conversion)
         let encoderConfiguration = Self.encoderConfiguration(
             codec: codec,
             renderSize: renderSize,
@@ -387,7 +371,7 @@ actor UploadInputStandardizationWorker {
             videoTracks: [videoTrack],
             videoSettings: Self.readerVideoSettings(
                 decoderPixelFormat: decoderPixelFormat,
-                toneMapsToSDR: conversion?.toneMapsToSDR == true
+                toneMapsToSDR: conversion.toneMapsToSDR
             )
         )
         videoOutput.alwaysCopiesSampleData = false
@@ -398,7 +382,7 @@ actor UploadInputStandardizationWorker {
             preferredTransform: properties.preferredTransform,
             outputFrameRate: encoderConfiguration.outputFrameRate,
             renderSize: renderSize,
-            toneMapsToSDR: conversion?.toneMapsToSDR == true
+            toneMapsToSDR: conversion.toneMapsToSDR
         )
         guard reader.canAdd(videoOutput) else {
             throw StandardizationError.cannotAddReaderOutput
@@ -409,7 +393,7 @@ actor UploadInputStandardizationWorker {
             codec: codec,
             renderSize: renderSize,
             encoderConfiguration: encoderConfiguration,
-            toneMapsToSDR: conversion?.toneMapsToSDR == true
+            toneMapsToSDR: conversion.toneMapsToSDR
         )
         let compressionPropertiesKey = AVVideoCompressionPropertiesKey
         if !writer.canApply(outputSettings: videoSettings, forMediaType: .video),

--- a/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/UploadInputStandardizer.swift
@@ -15,30 +15,11 @@ protocol UploadInputStandardizing: Sendable {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset
 
     func cancel(id: String, token: UploadInputStandardizationToken) async
-}
-
-extension UploadInputStandardizing {
-    func standardize(
-        id: String,
-        token: UploadInputStandardizationToken,
-        sourceAsset: AVURLAsset,
-        rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        outputURL: URL
-    ) async throws -> AVURLAsset {
-        try await standardize(
-            id: id,
-            token: token,
-            sourceAsset: sourceAsset,
-            rescalingDetails: rescalingDetails,
-            conversion: nil,
-            outputURL: outputURL
-        )
-    }
 }
 
 actor UploadInputStandardizer: UploadInputStandardizing {
@@ -67,7 +48,7 @@ actor UploadInputStandardizer: UploadInputStandardizing {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset {
         let worker = workerFactory(token)

--- a/Sources/MuxUploadSDK/InternalUtilities/UploadInput.swift
+++ b/Sources/MuxUploadSDK/InternalUtilities/UploadInput.swift
@@ -124,9 +124,12 @@ extension UploadInput {
     mutating func processStartNetworkTransport(
         startingTransportStatus: DirectUpload.TransportStatus
     ) {
-        if case UploadInput.Status.underInspection = status {
+        switch status {
+        case .started, .underInspection, .standardizing,
+             .standardizationSucceeded, .standardizationFailed,
+             .awaitingUploadConfirmation:
             status = .uploadInProgress(sourceAsset, uploadInfo, startingTransportStatus)
-        } else {
+        default:
             return
         }
     }

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -8,6 +8,183 @@
 import AVFoundation
 import Foundation
 
+private actor DirectUploadPreparationLifecycle {
+    struct Attempt: Equatable {
+        let id = UUID()
+        let inspectionToken = UploadInputInspectionOperationRegistry.Token()
+        let standardizationToken = UploadInputStandardizationToken()
+    }
+
+    private var activeAttempt: Attempt?
+
+    func begin() -> Attempt? {
+        guard activeAttempt == nil else { return nil }
+        let attempt = Attempt()
+        activeAttempt = attempt
+        return attempt
+    }
+
+    func isActive(_ attempt: Attempt) -> Bool {
+        activeAttempt == attempt
+    }
+
+    func performIfActive(
+        for attempt: Attempt,
+        _ operation: () -> Void
+    ) -> Bool {
+        guard activeAttempt == attempt else { return false }
+        operation()
+        return true
+    }
+
+    func cancel() -> Attempt? {
+        defer { activeAttempt = nil }
+        return activeAttempt
+    }
+
+    func commitTransport(
+        for attempt: Attempt,
+        _ commit: () -> Void
+    ) -> Bool {
+        guard activeAttempt == attempt else { return false }
+        activeAttempt = nil
+        commit()
+        return true
+    }
+}
+
+/// Serializes the short check-and-register portion of transport startup. The
+/// manager's existing URL de-duplication contract depends on those two actions
+/// being atomic across independently-created `DirectUpload` instances.
+private actor DirectUploadTransportCommitCoordinator {
+    static let shared = DirectUploadTransportCommitCoordinator()
+
+    private var isOccupied = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func coordinate(_ operation: () async -> Bool) async -> Bool {
+        await acquire()
+        defer { release() }
+        return await operation()
+    }
+
+    private func acquire() async {
+        if !isOccupied {
+            isOccupied = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            isOccupied = false
+        } else {
+            waiters.removeFirst().resume()
+        }
+    }
+}
+
+/// Preserves the call order of the synchronous public lifecycle API while its
+/// implementation crosses actor boundaries. Preparation work is launched
+/// separately so cancellation can be processed while inspection or conversion
+/// is in flight; the final transport commit returns through this same queue.
+private final class DirectUploadLifecycleCommandQueue: Sendable {
+    private enum Command {
+        case start(forceRestart: Bool)
+        case cancel(notifyCaller: Bool)
+        case commit(
+            videoFile: URL,
+            duration: CMTime?,
+            attempt: DirectUploadPreparationLifecycle.Attempt,
+            continuation: CheckedContinuation<Bool, Never>
+        )
+    }
+
+    private let continuation: AsyncStream<Command>.Continuation
+    private let processor: Task<Void, Never>
+
+    init(owner: DirectUpload) {
+        var continuation: AsyncStream<Command>.Continuation!
+        let stream = AsyncStream<Command> {
+            continuation = $0
+        }
+        self.continuation = continuation
+        self.processor = Task { [weak owner] in
+            for await command in stream {
+                guard let owner else { return }
+                switch command {
+                case .start(let forceRestart):
+                    await owner.processStartCommand(forceRestart: forceRestart)
+                case .cancel(let notifyCaller):
+                    await owner.cancelAsync(notifyCaller: notifyCaller)
+                case .commit(let videoFile, let duration, let attempt, let continuation):
+                    // Worker creation can invoke injected or legacy synchronous
+                    // code. Keep consuming cancellation commands while the
+                    // lifecycle actor arbitrates this commit independently.
+                    Task { [weak owner] in
+                        let didCommit = await owner?.processTransportCommit(
+                            videoFile: videoFile,
+                            duration: duration,
+                            attempt: attempt
+                        ) ?? false
+                        continuation.resume(returning: didCommit)
+                    }
+                }
+            }
+        }
+    }
+
+    deinit {
+        continuation.finish()
+        processor.cancel()
+    }
+
+    func start(forceRestart: Bool) {
+        continuation.yield(.start(forceRestart: forceRestart))
+    }
+
+    func cancel(notifyCaller: Bool) {
+        continuation.yield(.cancel(notifyCaller: notifyCaller))
+    }
+
+    func commit(
+        videoFile: URL,
+        duration: CMTime?,
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async -> Bool {
+        await withCheckedContinuation { resultContinuation in
+            let result = continuation.yield(
+                .commit(
+                    videoFile: videoFile,
+                    duration: duration,
+                    attempt: attempt,
+                    continuation: resultContinuation
+                )
+            )
+            if case .terminated = result {
+                resultContinuation.resume(returning: false)
+            }
+        }
+    }
+}
+
+private enum DirectUploadPreparationError: LocalizedError {
+    case plannerFallback(StandardInputPlan.FallbackReason)
+    case outputRejected(StandardInputOutputValidation)
+
+    var errorDescription: String? {
+        switch self {
+        case .plannerFallback(let reason):
+            return "Standard Input planner selected original-upload fallback: \(reason)"
+        case .outputRejected(let validation):
+            return "Generated Standard Input output was rejected: \(validation.disposition)"
+        }
+    }
+}
+
 /// Indicates whether a finished upload failed due to an error
 /// or succeeded along with details
 public typealias DirectUploadResult = Result<DirectUpload.SuccessDetails, DirectUploadError>
@@ -189,16 +366,13 @@ public final class DirectUpload {
     private let inputInspector: UploadInputInspector
     private let inputInspectionOperations = UploadInputInspectionOperationRegistry()
     private let inputStandardizer: UploadInputStandardizing
-    private let lifecycleLock = NSLock()
-    private var activeAttempt: UploadAttempt?
-    private var inputStandardizationTask: Task<Void, Never>?
+    private let preparationLifecycle = DirectUploadPreparationLifecycle()
+    private let planner: StandardInputPlanner
+    private let outputValidator: StandardInputOutputValidator
+    private let capabilityProvider: StandardInputPlanningCapabilityProviding
+    private let storagePreflighter: TemporaryStoragePreflighting
     private let fileWorkerFactory: FileWorkerFactory
-
-    private struct UploadAttempt: Equatable {
-        let id = UUID()
-        let inspectionToken = UploadInputInspectionOperationRegistry.Token()
-        let standardizationToken = UploadInputStandardizationToken()
-    }
+    private var lifecycleCommands: DirectUploadLifecycleCommandQueue!
 
     typealias FileWorkerFactory = (
         UploadInfo,
@@ -262,6 +436,10 @@ public final class DirectUpload {
         uploadManager: DirectUploadManager,
         inputInspector: AVFoundationUploadInputInspector = .shared,
         inputStandardizer: UploadInputStandardizing = UploadInputStandardizer(),
+        planner: StandardInputPlanner = StandardInputPlanner(),
+        outputValidator: StandardInputOutputValidator = StandardInputOutputValidator(),
+        capabilityProvider: StandardInputPlanningCapabilityProviding = AVFoundationStandardInputPlanningCapabilityProvider(),
+        storagePreflighter: TemporaryStoragePreflighting = FileSystemTemporaryStoragePreflighter(),
         fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
@@ -269,7 +447,12 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         self.inputStandardizer = inputStandardizer
+        self.planner = planner
+        self.outputValidator = outputValidator
+        self.capabilityProvider = capabilityProvider
+        self.storagePreflighter = storagePreflighter
         self.fileWorkerFactory = fileWorkerFactory
+        self.lifecycleCommands = DirectUploadLifecycleCommandQueue(owner: self)
     }
 
     init(
@@ -278,6 +461,10 @@ public final class DirectUpload {
         uploadManager: DirectUploadManager,
         inputInspector: UploadInputInspector,
         inputStandardizer: UploadInputStandardizing = UploadInputStandardizer(),
+        planner: StandardInputPlanner = StandardInputPlanner(),
+        outputValidator: StandardInputOutputValidator = StandardInputOutputValidator(),
+        capabilityProvider: StandardInputPlanningCapabilityProviding = AVFoundationStandardInputPlanningCapabilityProvider(),
+        storagePreflighter: TemporaryStoragePreflighting = FileSystemTemporaryStoragePreflighter(),
         fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
@@ -285,7 +472,12 @@ public final class DirectUpload {
         self.uploadManager = uploadManager
         self.inputInspector = inputInspector
         self.inputStandardizer = inputStandardizer
+        self.planner = planner
+        self.outputValidator = outputValidator
+        self.capabilityProvider = capabilityProvider
+        self.storagePreflighter = storagePreflighter
         self.fileWorkerFactory = fileWorkerFactory
+        self.lifecycleCommands = DirectUploadLifecycleCommandQueue(owner: self)
     }
 
     private static func makeFileWorker(
@@ -300,55 +492,6 @@ public final class DirectUpload {
             file: file,
             startingByte: startingByte
         )
-    }
-
-    private func isActive(_ attempt: UploadAttempt) -> Bool {
-        lifecycleLock.lock()
-        defer { lifecycleLock.unlock() }
-        return activeAttempt == attempt
-    }
-
-    private func registerStandardizationTask(
-        _ task: Task<Void, Never>,
-        for attempt: UploadAttempt
-    ) {
-        lifecycleLock.lock()
-        let shouldKeep = activeAttempt == attempt
-        if shouldKeep {
-            inputStandardizationTask = task
-        }
-        lifecycleLock.unlock()
-
-        if !shouldKeep {
-            task.cancel()
-        }
-    }
-
-    private func clearStandardizationTask(for attempt: UploadAttempt) {
-        lifecycleLock.lock()
-        if activeAttempt == attempt {
-            inputStandardizationTask = nil
-        }
-        lifecycleLock.unlock()
-    }
-
-    /// Mutates input state while lifecycle ownership is locked, then returns
-    /// the corresponding client notification for delivery after unlocking.
-    private func transitionInputWithoutNotifying(
-        _ transition: (inout UploadInput) -> Void
-    ) -> (() -> Void)? {
-        let previousStatus = input.status
-        let statusHandler = inputStatusHandler
-        inputStatusHandler = nil
-        transition(&input)
-        inputStatusHandler = statusHandler
-
-        guard previousStatus != input.status, let statusHandler else {
-            return nil
-        }
-
-        let status = inputStatus
-        return { statusHandler(status) }
     }
 
     internal convenience init(
@@ -453,6 +596,10 @@ public final class DirectUpload {
     /// restarted. If false the upload will resume from where
     /// it left off if paused, otherwise the upload will change.
     public func start(forceRestart: Bool = false) {
+        lifecycleCommands.start(forceRestart: forceRestart)
+    }
+
+    fileprivate func processStartCommand(forceRestart: Bool) async {
         if self.manageBySDK && fileWorker == nil {
             // See if there's anything in progress already
             fileWorker = uploadManager.findChunkedFileUploader(
@@ -470,337 +617,275 @@ public final class DirectUpload {
             fileWorker?.start()
             return
         }
-
-        // Start a new upload
-
-        let attempt = UploadAttempt()
-        lifecycleLock.lock()
-        let canStart: Bool
-        let startNotification: (() -> Void)?
-        if case UploadInput.Status.ready = input.status {
-            activeAttempt = attempt
-            startNotification = transitionInputWithoutNotifying { input in
-                input.status = .started(input.sourceAsset, input.uploadInfo)
+        guard case UploadInput.Status.ready = input.status,
+              let attempt = await preparationLifecycle.begin() else {
+            if forceRestart {
+                await cancelAsync(notifyCaller: false)
             }
-            canStart = true
-        } else {
-            startNotification = nil
-            canStart = false
+            return
         }
-        lifecycleLock.unlock()
-
-        if canStart {
-            startNotification?()
-            startInspection(
-                sourceAsset: input.sourceAsset,
+        guard await preparationLifecycle.isActive(attempt) else { return }
+        input.status = .started(input.sourceAsset, input.uploadInfo)
+        let sourceAsset = input.sourceAsset
+        Task { [weak self] in
+            await self?.startInspection(
+                sourceAsset: sourceAsset,
                 attempt: attempt
             )
-        } else if forceRestart {
-            cancel(notifyCaller: false)
         }
     }
 
     private func startInspection(
         sourceAsset: AVURLAsset,
-        attempt: UploadAttempt
-    ) {
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
         if !uploadInfo.options.inputStandardization.isRequested {
-            startNetworkTransport(
+            await startNetworkTransport(
                 videoFile: sourceAsset.url,
                 attempt: attempt
             )
-        } else {
-            let inputStandardizationStartTime = Date()
-            let reporter = Reporter.shared
-
-            // For consistency report non-std
-            // input size. Should the std size
-            // be reported too?
-            // FIXME: if file size is zero, should
-            // instead throw an error since upload
-            // will likely fail
-            let inputSize = (try? FileManager.default.fileSizeOfItem(
-                atPath: input.sourceAsset.url.absoluteString
-            )) ?? 0
-
-            let operation = UploadInputInspectionOperation {
-                [weak self] inspectionResult, inputDuration, inspectionError in
-                guard let self else { return }
-                guard self.inputInspectionOperations.claimCompletion(
-                    for: attempt.inspectionToken
-                ) else { return }
-                guard self.isActive(attempt) else { return }
-                self.inspectionResult = inspectionResult
-
-                switch (inspectionResult, inspectionError) {
-                case (.none, .none):
-                    // Corner case
-                    self.handleInspectionFailure(
-                        inspectionError: UploadInputInspectionError.inspectionFailure,
-                        inputDuration: inputDuration,
-                        inputSize: inputSize,
-                        inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset,
-                        attempt: attempt
-                    )
-                case (.none, .some(let error)):
-                    self.handleInspectionFailure(
-                        inspectionError: error,
-                        inputDuration: inputDuration,
-                        inputSize: inputSize,
-                        inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset,
-                        attempt: attempt
-                    )
-                case (.some(let result), .none):
-                    if result.isStandardInput {
-
-                        if result.rescalingDetails.needsRescaling {
-                            SDKLogger.logger?.debug(
-                                "Detected Input Needs Rescaling"
-                            )
-
-                            // TODO: inject Date() for testing purposes
-                            let outputFileName = "upload-\(Date().timeIntervalSince1970)"
-
-                            let outputDirectory = FileManager.default.temporaryDirectory
-                            let outputURL = URL(
-                                fileURLWithPath: outputFileName,
-                                relativeTo: outputDirectory
-                            )
-
-                            let task = Task { [weak self] in
-                                guard let self else { return }
-                                do {
-                                    _ = try await self.inputStandardizer.standardize(
-                                        id: self.id,
-                                        token: attempt.standardizationToken,
-                                        sourceAsset: sourceAsset,
-                                        rescalingDetails: result.rescalingDetails,
-                                        outputURL: outputURL
-                                    )
-                                    guard !Task.isCancelled,
-                                          self.isActive(attempt) else { return }
-                                    self.clearStandardizationTask(for: attempt)
-                                    self.startNetworkTransport(
-                                        videoFile: outputURL,
-                                        duration: inputDuration,
-                                        attempt: attempt
-                                    )
-                                } catch is CancellationError {
-                                    return
-                                } catch {
-                                    guard !Task.isCancelled,
-                                          self.isActive(attempt) else { return }
-                                    self.clearStandardizationTask(for: attempt)
-                                    // Request upload confirmation
-                                    // before proceeding. If handler unset,
-                                    // by default do not cancel upload if
-                                    // input standardization fails
-                                    let shouldCancelUpload = self.nonStandardInputHandler?() ?? false
-
-                                    if !shouldCancelUpload {
-                                        self.startNetworkTransport(
-                                            videoFile: sourceAsset.url,
-                                            attempt: attempt
-                                        )
-                                    } else {
-                                        self.cancelPreparation(for: attempt)
-                                    }
-                                }
-                            }
-                            self.registerStandardizationTask(task, for: attempt)
-
-                        } else {
-                            self.startNetworkTransport(
-                                videoFile: sourceAsset.url,
-                                attempt: attempt
-                            )
-                        }
-                    } else {
-                        SDKLogger.logger?.debug(
-                            """
-                            Detected Nonstandard Reasons
-
-                            \(dump(result.nonStandardInputReasons, indent: 4))
-
-                            """
-                        )
-
-                        // TODO: inject Date() for testing purposes
-                        let outputFileName = "upload-\(Date().timeIntervalSince1970)"
-
-                        let outputDirectory = FileManager.default.temporaryDirectory
-                        let outputURL = URL(
-                            fileURLWithPath: outputFileName,
-                            relativeTo: outputDirectory
-                        )
-
-                        let task = Task { [weak self] in
-                            guard let self else { return }
-                            do {
-                                _ = try await self.inputStandardizer.standardize(
-                                    id: self.id,
-                                    token: attempt.standardizationToken,
-                                    sourceAsset: sourceAsset,
-                                    rescalingDetails: result.rescalingDetails,
-                                    outputURL: outputURL
-                                )
-                                guard !Task.isCancelled,
-                                      self.isActive(attempt) else { return }
-                                self.clearStandardizationTask(for: attempt)
-                                reporter.reportUploadInputStandardizationSuccess(
-                                    inputDuration: inputDuration.seconds,
-                                    inputSize: inputSize,
-                                    options: self.uploadInfo.options,
-                                    nonStandardInputReasons: result.nonStandardInputReasons,
-                                    standardizationEndTime: Date(),
-                                    standardizationStartTime: inputStandardizationStartTime,
-                                    uploadURL: self.uploadURL
-                                )
-
-                                self.startNetworkTransport(
-                                    videoFile: outputURL,
-                                    duration: inputDuration,
-                                    attempt: attempt
-                                )
-                            } catch is CancellationError {
-                                return
-                            } catch {
-                                guard !Task.isCancelled,
-                                      self.isActive(attempt) else { return }
-                                self.clearStandardizationTask(for: attempt)
-                                // Request upload confirmation
-                                // before proceeding. If handler unset,
-                                // by default do not cancel upload if
-                                // input standardization fails
-                                let shouldCancelUpload = self.nonStandardInputHandler?() ?? false
-
-                                reporter.reportUploadInputStandardizationFailure(
-                                    errorDescription: error.localizedDescription,
-                                    inputDuration: inputDuration.seconds,
-                                    inputSize: inputSize,
-                                    nonStandardInputReasons: result.nonStandardInputReasons,
-                                    options: self.uploadInfo.options,
-                                    standardizationEndTime: Date(),
-                                    standardizationStartTime: inputStandardizationStartTime,
-                                    uploadCanceled: shouldCancelUpload,
-                                    uploadURL: self.uploadURL
-                                )
-
-                                if !shouldCancelUpload {
-                                    self.startNetworkTransport(
-                                        videoFile: sourceAsset.url,
-                                        attempt: attempt
-                                    )
-                                } else {
-                                    self.cancelPreparation(for: attempt)
-                                }
-                            }
-                        }
-                        self.registerStandardizationTask(task, for: attempt)
-                    }
-                case (.some(_), .some(let error)):
-                    self.handleInspectionFailure(
-                        inspectionError: error,
-                        inputDuration: inputDuration,
-                        inputSize: inputSize,
-                        inputStandardizationStartTime: inputStandardizationStartTime,
-                        sourceAsset: sourceAsset,
-                        attempt: attempt
-                    )
-                }
-            }
-
-            lifecycleLock.lock()
-            guard activeAttempt == attempt else {
-                lifecycleLock.unlock()
-                operation.cancel()
-                return
-            }
-            let inspectionNotification = transitionInputWithoutNotifying { input in
-                input.status = .underInspection(input.sourceAsset, input.uploadInfo)
-            }
-            inputInspectionOperations.register(
-                operation,
-                for: attempt.inspectionToken
-            )
-            lifecycleLock.unlock()
-
-            inspectionNotification?()
-            inputInspector.performInspection(
-                sourceInput: input.sourceAsset,
-                maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
-                operation: operation
-            )
-        }
-    }
-
-    private func handleInspectionFailure(
-        inspectionError: Error,
-        inputDuration: CMTime,
-        inputSize: UInt64,
-        inputStandardizationStartTime: Date,
-        sourceAsset: AVURLAsset,
-        attempt: UploadAttempt
-    ) {
-        guard isActive(attempt) else { return }
-        let reporter = Reporter.shared
-        // Request upload confirmation
-        // before proceeding. If handler unset,
-        // by default do not cancel upload if
-        // input standardization fails
-        let shouldCancelUpload = self.nonStandardInputHandler?() ?? false
-
-        reporter.reportUploadInputStandardizationFailure(
-            errorDescription: "Input inspection failure",
-            inputDuration: inputDuration.seconds,
-            inputSize: inputSize,
-            nonStandardInputReasons: [],
-            options: self.uploadInfo.options,
-            standardizationEndTime: Date(),
-            standardizationStartTime: inputStandardizationStartTime,
-            uploadCanceled: shouldCancelUpload,
-            uploadURL: self.uploadURL
-        )
-
-        if !shouldCancelUpload {
-            self.startNetworkTransport(
-                videoFile: sourceAsset.url,
-                attempt: attempt
-            )
-        } else {
-            cancelPreparation(for: attempt)
-        }
-    }
-
-    private func cancelPreparation(for attempt: UploadAttempt) {
-        lifecycleLock.lock()
-        guard activeAttempt == attempt else {
-            lifecycleLock.unlock()
             return
         }
 
-        activeAttempt = nil
-        let inputStandardizationTask = self.inputStandardizationTask
-        self.inputStandardizationTask = nil
+        let startedAt = Date()
+        let inputSize = (try? FileManager.default.fileSizeOfItem(
+            atPath: sourceAsset.url.path
+        )) ?? 0
+        guard await preparationLifecycle.performIfActive(for: attempt, {
+            input.status = .underInspection(sourceAsset, input.uploadInfo)
+        }) else { return }
+
+        let operation = UploadInputInspectionOperation()
+        await inputInspectionOperations.register(
+            operation,
+            for: attempt.inspectionToken
+        )
+        guard await preparationLifecycle.isActive(attempt) else {
+            await operation.cancel()
+            return
+        }
+        let outcome = await inputInspector.inspect(
+            sourceInput: sourceAsset,
+            maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
+            operation: operation
+        )
+        guard await inputInspectionOperations.claimCompletion(
+            for: attempt.inspectionToken
+        ), await preparationLifecycle.isActive(attempt) else { return }
+        guard let inspection = outcome.result, outcome.error == nil else {
+            await handlePreparationFailure(
+                error: outcome.error ?? UploadInputInspectionError.inspectionFailure,
+                result: outcome.result,
+                duration: outcome.duration,
+                inputSize: inputSize,
+                startedAt: startedAt,
+                sourceAsset: sourceAsset,
+                attempt: attempt
+            )
+            return
+        }
+        inspectionResult = inspection
+
+        let capabilities = await capabilityProvider.capabilities(
+            for: inspection,
+            sourceAsset: sourceAsset
+        )
+        guard await preparationLifecycle.isActive(attempt) else { return }
+        let plan = planner.plan(
+            facts: inspection.mediaFacts,
+            options: uploadInfo.options.inputStandardization,
+            capabilities: capabilities
+        )
+        SDKLogger.logger?.debug("Selected Standard Input plan: \(String(describing: plan.action))")
+        switch plan.action {
+        case .uploadOriginal:
+            await startNetworkTransport(
+                videoFile: sourceAsset.url,
+                attempt: attempt
+            )
+        case .fallback(let reason):
+            await handlePreparationFailure(
+                error: DirectUploadPreparationError.plannerFallback(reason),
+                result: inspection,
+                duration: outcome.duration,
+                inputSize: inputSize,
+                startedAt: startedAt,
+                sourceAsset: sourceAsset,
+                attempt: attempt
+            )
+        case .convert(let conversion):
+            await standardize(
+                sourceAsset: sourceAsset,
+                inspection: inspection,
+                conversion: conversion,
+                duration: outcome.duration,
+                inputSize: inputSize,
+                startedAt: startedAt,
+                attempt: attempt
+            )
+        }
+    }
+
+    private func standardize(
+        sourceAsset: AVURLAsset,
+        inspection: UploadInputFormatInspectionResult,
+        conversion: StandardInputConversion,
+        duration: CMTime,
+        inputSize: UInt64,
+        startedAt: Date,
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
+        let outputURL: URL
+        do {
+            outputURL = try storagePreflighter.outputURL(
+                for: sourceAsset.url,
+                duration: duration,
+                conversion: conversion
+            )
+        } catch {
+            await handlePreparationFailure(
+                error: error,
+                result: inspection,
+                duration: duration,
+                inputSize: inputSize,
+                startedAt: startedAt,
+                sourceAsset: sourceAsset,
+                attempt: attempt
+            )
+            return
+        }
+        var transferredOutputOwnership = false
+        defer {
+            if !transferredOutputOwnership {
+                removeOwnedTemporaryFile(outputURL)
+            }
+        }
+
+        guard await preparationLifecycle.performIfActive(for: attempt, {
+            input.status = .standardizing(sourceAsset, input.uploadInfo)
+        }) else { return }
+        do {
+            let generatedAsset = try await inputStandardizer.standardize(
+                id: id,
+                token: attempt.standardizationToken,
+                sourceAsset: sourceAsset,
+                rescalingDetails: inspection.rescalingDetails,
+                conversion: conversion,
+                outputURL: outputURL
+            )
+            guard await preparationLifecycle.isActive(attempt) else { return }
+
+            let validationOperation = UploadInputInspectionOperation()
+            await inputInspectionOperations.register(
+                validationOperation,
+                for: attempt.inspectionToken
+            )
+            let generatedOutcome = await inputInspector.inspect(
+                sourceInput: generatedAsset,
+                maximumResolution: uploadInfo.options.inputStandardization.maximumResolution,
+                operation: validationOperation
+            )
+            guard await inputInspectionOperations.claimCompletion(
+                for: attempt.inspectionToken
+            ), await preparationLifecycle.isActive(attempt) else { return }
+            guard let generatedInspection = generatedOutcome.result,
+                  generatedOutcome.error == nil else {
+                throw generatedOutcome.error
+                    ?? UploadInputInspectionError.inspectionFailure
+            }
+            let validation = outputValidator.validateGeneratedOutput(
+                facts: generatedInspection.mediaFacts,
+                sourceTimeline: inspection.timelineFacts,
+                outputTimeline: generatedInspection.timelineFacts,
+                for: conversion
+            )
+            guard validation.isAccepted else {
+                throw DirectUploadPreparationError.outputRejected(validation)
+            }
+
+            Reporter.shared.reportUploadInputStandardizationSuccess(
+                inputDuration: duration.seconds,
+                inputSize: inputSize,
+                options: uploadInfo.options,
+                nonStandardInputReasons: inspection.nonStandardInputReasons,
+                standardizationEndTime: Date(),
+                standardizationStartTime: startedAt,
+                uploadURL: uploadURL
+            )
+            guard await preparationLifecycle.performIfActive(for: attempt, {
+                input.status = .standardizationSucceeded(
+                    source: sourceAsset,
+                    standardized: generatedAsset,
+                    uploadInfo: input.uploadInfo
+                )
+            }) else { return }
+            await startNetworkTransport(
+                videoFile: generatedAsset.url,
+                duration: duration,
+                attempt: attempt
+            )
+            transferredOutputOwnership = fileWorker?.inputFileURL == generatedAsset.url
+        } catch is CancellationError {
+            return
+        } catch {
+            guard await preparationLifecycle.isActive(attempt) else { return }
+            await handlePreparationFailure(
+                error: error,
+                result: inspection,
+                duration: duration,
+                inputSize: inputSize,
+                startedAt: startedAt,
+                sourceAsset: sourceAsset,
+                attempt: attempt
+            )
+        }
+    }
+
+    private func handlePreparationFailure(
+        error: Error,
+        result: UploadInputFormatInspectionResult?,
+        duration: CMTime,
+        inputSize: UInt64,
+        startedAt: Date,
+        sourceAsset: AVURLAsset,
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
+        guard await preparationLifecycle.performIfActive(for: attempt, {
+            input.status = .standardizationFailed(sourceAsset, input.uploadInfo)
+        }) else { return }
+        let shouldCancelUpload = nonStandardInputHandler?() ?? false
+        Reporter.shared.reportUploadInputStandardizationFailure(
+            errorDescription: error.localizedDescription,
+            inputDuration: duration.seconds,
+            inputSize: inputSize,
+            nonStandardInputReasons: result?.nonStandardInputReasons ?? [],
+            options: uploadInfo.options,
+            standardizationEndTime: Date(),
+            standardizationStartTime: startedAt,
+            uploadCanceled: shouldCancelUpload,
+            uploadURL: uploadURL
+        )
+        if !shouldCancelUpload {
+            await startNetworkTransport(
+                videoFile: sourceAsset.url,
+                attempt: attempt
+            )
+        } else {
+            await cancelPreparation(for: attempt)
+        }
+    }
+
+    private func cancelPreparation(
+        for attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
+        guard await preparationLifecycle.cancel() == attempt else { return }
+        await inputInspectionOperations.cancel(for: attempt.inspectionToken)
+        await inputStandardizer.cancel(id: id, token: attempt.standardizationToken)
         let fileWorker = self.fileWorker
         self.fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
-        let cancellationNotification = transitionInputWithoutNotifying { input in
-            input.processUploadCancellation()
-        }
-        lifecycleLock.unlock()
-
-        inputStandardizationTask?.cancel()
-        Task {
-            await inputStandardizer.cancel(
-                id: id,
-                token: attempt.standardizationToken
-            )
-        }
         fileWorker?.cancel()
-        cancellationNotification?()
+        input.processUploadCancellation()
     }
 
     func readyForTransport() -> Bool {
@@ -824,98 +909,96 @@ public final class DirectUpload {
 
     private func startNetworkTransport(
         videoFile: URL,
-        attempt: UploadAttempt
-    ) {
-        guard isActive(attempt), readyForTransport() else {
-            SDKLogger.logger?.info("Tried to start network transport before being ready")
-            return
-        }
-        
-        SDKLogger.logger?.info("Starting network transport")
-
-        let completedUnitCount = UInt64(uploadStatus?.progress?.completedUnitCount ?? 0)
-
-        let fileWorker = fileWorkerFactory(
-            input.uploadInfo,
-            videoFile,
-            ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
-            completedUnitCount
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
+        await startNetworkTransport(
+            videoFile: videoFile,
+            duration: nil,
+            attempt: attempt
         )
-
-        lifecycleLock.lock()
-        guard activeAttempt == attempt && readyForTransport() else {
-            lifecycleLock.unlock()
-            fileWorker.cancel()
-            return
-        }
-        fileWorker.addDelegate(
-            withToken: id,
-            InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
-        )
-        self.fileWorker = fileWorker
-        uploadManager.registerUpload(self)
-        let transportStatus = TransportStatus(
-            progress: fileWorker.currentState.progress ?? Progress(),
-            updatedTime: Date().timeIntervalSince1970,
-            startTime: Date().timeIntervalSince1970,
-            isPaused: false
-        )
-        let transportNotification = transitionInputWithoutNotifying { input in
-            input.processStartNetworkTransport(
-                startingTransportStatus: transportStatus
-            )
-        }
-        lifecycleLock.unlock()
-
-        fileWorker.start()
-        transportNotification?()
     }
 
     private func startNetworkTransport(
         videoFile: URL,
-        duration: CMTime,
-        attempt: UploadAttempt
-    ) {
-        guard isActive(attempt), readyForTransport() else {
+        duration: CMTime?,
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async {
+        guard await preparationLifecycle.isActive(attempt), readyForTransport() else {
+            SDKLogger.logger?.info("Tried to start network transport before being ready")
             return
         }
-
-        let completedUnitCount = UInt64(uploadStatus?.progress?.completedUnitCount ?? 0)
-
-        let fileWorker = fileWorkerFactory(
-            input.uploadInfo,
-            videoFile,
-            ChunkedFile(chunkSize: input.uploadInfo.options.transport.chunkSizeInBytes),
-            completedUnitCount
+        _ = await lifecycleCommands.commit(
+            videoFile: videoFile,
+            duration: duration,
+            attempt: attempt
         )
+    }
 
-        lifecycleLock.lock()
-        guard activeAttempt == attempt && readyForTransport() else {
-            lifecycleLock.unlock()
-            fileWorker.cancel()
-            return
-        }
-        fileWorker.addDelegate(
-            withToken: id,
-            InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
-        )
-        self.fileWorker = fileWorker
-        uploadManager.registerUpload(self)
-        let transportStatus = TransportStatus(
-            progress: fileWorker.currentState.progress ?? Progress(),
-            updatedTime: Date().timeIntervalSince1970,
-            startTime: Date().timeIntervalSince1970,
-            isPaused: false
-        )
-        let transportNotification = transitionInputWithoutNotifying { input in
-            input.processStartNetworkTransport(
-                startingTransportStatus: transportStatus
+    fileprivate func processTransportCommit(
+        videoFile: URL,
+        duration: CMTime?,
+        attempt: DirectUploadPreparationLifecycle.Attempt
+    ) async -> Bool {
+        await DirectUploadTransportCommitCoordinator.shared.coordinate {
+            if self.manageBySDK,
+               let existingWorker = self.uploadManager.findChunkedFileUploader(
+                   inputFileURL: self.input.sourceAsset.url
+               ) {
+                return await self.preparationLifecycle.commitTransport(for: attempt) {
+                    SDKLogger.logger?.warning(
+                        "Reusing the active upload for this input file"
+                    )
+                    self.fileWorker = existingWorker
+                    existingWorker.addDelegate(
+                        withToken: self.id,
+                        InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
+                    )
+                    self.handleStateUpdate(existingWorker.currentState)
+                    existingWorker.start()
+                }
+            }
+
+            let completedUnitCount = UInt64(
+                self.uploadStatus?.progress?.completedUnitCount ?? 0
             )
+            let fileWorker = self.fileWorkerFactory(
+                self.input.uploadInfo,
+                videoFile,
+                ChunkedFile(
+                    chunkSize: self.input.uploadInfo.options.transport.chunkSizeInBytes
+                ),
+                completedUnitCount
+            )
+            let didCommit = await self.preparationLifecycle.commitTransport(for: attempt) {
+                guard self.readyForTransport() else { return }
+                SDKLogger.logger?.info("Starting network transport")
+                fileWorker.addDelegate(
+                    withToken: self.id,
+                    InternalUploaderDelegate { [self] state in handleStateUpdate(state) }
+                )
+                self.fileWorker = fileWorker
+                self.uploadManager.registerUpload(self)
+                let now = Date().timeIntervalSince1970
+                let transportStatus = TransportStatus(
+                    progress: fileWorker.currentState.progress ?? Progress(),
+                    updatedTime: now,
+                    startTime: now,
+                    isPaused: false
+                )
+                self.input.processStartNetworkTransport(
+                    startingTransportStatus: transportStatus
+                )
+                if let duration {
+                    fileWorker.start(duration: duration)
+                } else {
+                    fileWorker.start()
+                }
+            }
+            if !didCommit {
+                fileWorker.cancel()
+            }
+            return didCommit
         }
-        lifecycleLock.unlock()
-
-        fileWorker.start(duration: duration)
-        transportNotification?()
     }
     
     
@@ -934,11 +1017,10 @@ public final class DirectUpload {
     /// Any delegates or handlers set prior to this will
     /// receive no further updates after the resultHandler is called
     public func cancel() {
-        self.cancel(notifyCaller: true)
+        lifecycleCommands.cancel(notifyCaller: true)
     }
-    
-    private func cancel(notifyCaller: Bool) {
-        lifecycleLock.lock()
+
+    fileprivate func cancelAsync(notifyCaller: Bool) async {
         let cancellationHandler = notifyCaller && !isUploadComplete() && isUploadStarted()
             ? resultHandler
             : nil
@@ -952,32 +1034,22 @@ public final class DirectUpload {
         progressHandler = nil
         resultHandler = nil
 
-        let cancelledAttempt = activeAttempt
-        activeAttempt = nil
-        let inputStandardizationTask = self.inputStandardizationTask
-        self.inputStandardizationTask = nil
+        let cancelledAttempt = await preparationLifecycle.cancel()
+        if let cancelledAttempt {
+            await inputInspectionOperations.cancel(
+                for: cancelledAttempt.inspectionToken
+            )
+            await inputStandardizer.cancel(
+                id: id,
+                token: cancelledAttempt.standardizationToken
+            )
+        }
         let fileWorker = self.fileWorker
         self.fileWorker = nil
         uploadManager.acknowledgeUpload(id: id)
-        let cancellationNotification = transitionInputWithoutNotifying { input in
-            input.processUploadCancellation()
-        }
-        lifecycleLock.unlock()
-
-        if let cancelledAttempt {
-            inputInspectionOperations.cancel(for: cancelledAttempt.inspectionToken)
-        }
-        inputStandardizationTask?.cancel()
-        if let cancelledAttempt {
-            Task {
-                await inputStandardizer.cancel(
-                    id: id,
-                    token: cancelledAttempt.standardizationToken
-                )
-            }
-        }
         fileWorker?.cancel()
-        cancellationNotification?()
+        removeOwnedTemporaryFile(fileWorker?.inputFileURL)
+        input.processUploadCancellation()
 
         cancellationHandler?(.failure(cancellationError))
     }
@@ -996,10 +1068,17 @@ public final class DirectUpload {
         default: return false
         }
     }
+
+    private func removeOwnedTemporaryFile(_ url: URL?) {
+        guard let url,
+              storagePreflighter.ownsTemporaryOutput(url) else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
     
     private func handleStateUpdate(_ state: ChunkedFileUploader.InternalUploadState) {
         switch state {
         case .success(let result): do {
+            let completedFileURL = fileWorker?.inputFileURL
             let transportStatus = TransportStatus(
                 progress: result.finalProgress,
                 updatedTime: result.finishTime,
@@ -1011,6 +1090,7 @@ public final class DirectUpload {
             resultHandler?(Result<SuccessDetails, DirectUploadError>.success(successDetails))
             fileWorker?.removeDelegate(withToken: id)
             fileWorker = nil
+            removeOwnedTemporaryFile(completedFileURL)
         }
         case .failure(let error): do {
             let parsedError = parseAsUploadError(

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -1093,6 +1093,7 @@ public final class DirectUpload {
             removeOwnedTemporaryFile(completedFileURL)
         }
         case .failure(let error): do {
+            let failedFileURL = fileWorker?.inputFileURL
             let parsedError = parseAsUploadError(
                 lastSeenUploadStatus: input.transportStatus ?? TransportStatus(
                     progress: nil,
@@ -1125,6 +1126,7 @@ public final class DirectUpload {
             }
             fileWorker?.removeDelegate(withToken: id)
             fileWorker = nil
+            removeOwnedTemporaryFile(failedFileURL)
         }
         case .uploading(let update): do {
             let status = TransportStatus(

--- a/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/Options/DirectUploadOptions.swift
@@ -89,7 +89,7 @@ public struct DirectUploadOptions {
     /// Options for adjusments made by ``DirectUpload``
     /// to some inputs to minimize processing time during
     /// ingestion
-    public struct InputStandardization {
+    public struct InputStandardization: Sendable {
 
         /// If requested the SDK will attempt to detect
         /// non-standard input formats and if so detected
@@ -105,7 +105,7 @@ public struct DirectUploadOptions {
         /// on-device output. Configure the matching
         /// `new_asset_settings.max_resolution_tier` separately
         /// when creating the Mux Direct Upload.
-        public enum MaximumResolution {
+        public enum MaximumResolution: Sendable {
             /// By default the standardized input will be
             /// scaled down to 1920x1080 (1080p) from a larger
             /// size. Inputs with smaller dimensions won't be
@@ -132,7 +132,7 @@ public struct DirectUploadOptions {
 
         /// Controls how the SDK handles HDR input during
         /// input standardization.
-        public enum HDRHandling: Codable, Equatable {
+        public enum HDRHandling: Codable, Equatable, Sendable {
             /// Preserve eligible HDR input for server-side
             /// processing. This is the default behavior and
             /// does not guarantee end-to-end HDR playback.

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
@@ -7,7 +7,7 @@ import Foundation
 
 @testable import MuxUploadSDK
 
-class MockUploadInputInspector: UploadInputInspector {
+actor MockUploadInputInspector: UploadInputInspector {
 
     static let alwaysStandard: MockUploadInputInspector = MockUploadInputInspector()
 
@@ -19,52 +19,62 @@ class MockUploadInputInspector: UploadInputInspector {
         mockInspectionError: UploadInputInspectionError.inspectionFailure
     )
 
-    var mockInspectionError: Error?
-    var mockInspectionResult: UploadInputFormatInspectionResult
-    var duration: CMTime
-    var shouldDeferCompletion = false
-    private(set) var operation: UploadInputInspectionOperation?
-
-    init() {
-        self.mockInspectionResult = UploadInputFormatInspectionResult(
-            nonStandardInputReasons: [],
-            rescalingDetails: .init()
-        )
-        self.duration = .zero
-    }
+    private var outcomes: [UploadInputInspectionOutcome]
+    private let shouldDeferCompletion: Bool
+    private var operation: UploadInputInspectionOperation?
+    private var continuation: CheckedContinuation<UploadInputInspectionOutcome, Never>?
 
     init(
-        mockInspectionResult: UploadInputFormatInspectionResult,
-        mockInspectionError: Error? = nil
+        mockInspectionResult: UploadInputFormatInspectionResult = UploadInputFormatInspectionResult(
+            nonStandardInputReasons: [],
+            rescalingDetails: .init()
+        ),
+        mockInspectionError: Error? = nil,
+        duration: CMTime = .zero,
+        shouldDeferCompletion: Bool = false,
+        subsequentResults: [UploadInputFormatInspectionResult] = []
     ) {
-        self.mockInspectionResult = mockInspectionResult
-        self.mockInspectionError = mockInspectionError
-        self.duration = .zero
-    }
-
-    func performInspection(
-        sourceInput: AVAsset,
-        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
-        operation: UploadInputInspectionOperation
-    ) {
-        if shouldDeferCompletion {
-            self.operation = operation
-        } else {
-            operation.complete(
-                mockInspectionResult,
+        self.outcomes = [
+            UploadInputInspectionOutcome(
+                result: mockInspectionResult,
                 duration: duration,
                 error: mockInspectionError
             )
+        ] + subsequentResults.map {
+            UploadInputInspectionOutcome(result: $0, duration: duration, error: nil)
+        }
+        self.shouldDeferCompletion = shouldDeferCompletion
+    }
+
+    func inspect(
+        sourceInput: AVAsset,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution,
+        operation: UploadInputInspectionOperation
+    ) async -> UploadInputInspectionOutcome {
+        if shouldDeferCompletion {
+            self.operation = operation
+            return await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        } else {
+            return nextOutcome()
         }
     }
 
     func completeDeferredInspection() {
-        operation?.complete(
-            mockInspectionResult,
-            duration: duration,
-            error: mockInspectionError
-        )
         operation = nil
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(returning: nextOutcome())
+    }
+
+    func currentOperation() -> UploadInputInspectionOperation? {
+        operation
+    }
+
+    private func nextOutcome() -> UploadInputInspectionOutcome {
+        guard outcomes.count > 1 else { return outcomes[0] }
+        return outcomes.removeFirst()
     }
 
 }

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputInspector.swift
@@ -23,6 +23,9 @@ actor MockUploadInputInspector: UploadInputInspector {
     private let shouldDeferCompletion: Bool
     private var operation: UploadInputInspectionOperation?
     private var continuation: CheckedContinuation<UploadInputInspectionOutcome, Never>?
+    private var inspectionStartWaiters: [
+        CheckedContinuation<UploadInputInspectionOperation, Never>
+    ] = []
 
     init(
         mockInspectionResult: UploadInputFormatInspectionResult = UploadInputFormatInspectionResult(
@@ -53,6 +56,11 @@ actor MockUploadInputInspector: UploadInputInspector {
     ) async -> UploadInputInspectionOutcome {
         if shouldDeferCompletion {
             self.operation = operation
+            let inspectionStartWaiters = self.inspectionStartWaiters
+            self.inspectionStartWaiters.removeAll()
+            inspectionStartWaiters.forEach {
+                $0.resume(returning: operation)
+            }
             return await withCheckedContinuation { continuation in
                 self.continuation = continuation
             }
@@ -68,8 +76,13 @@ actor MockUploadInputInspector: UploadInputInspector {
         continuation?.resume(returning: nextOutcome())
     }
 
-    func currentOperation() -> UploadInputInspectionOperation? {
-        operation
+    func waitForDeferredInspectionStart() async -> UploadInputInspectionOperation {
+        if let operation {
+            return operation
+        }
+        return await withCheckedContinuation { continuation in
+            inspectionStartWaiters.append(continuation)
+        }
     }
 
     private func nextOutcome() -> UploadInputInspectionOutcome {

--- a/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/MockUploadInputStandardizer.swift
@@ -11,15 +11,24 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
     struct Snapshot {
         let standardizeCallCount: Int
         let cancelCallCount: Int
+        let conversion: StandardInputConversion?
+        let outputURL: URL?
     }
 
     private(set) var standardizeCallCount = 0
     private(set) var cancelCallCount = 0
+    private var receivedConversion: StandardInputConversion?
+    private var receivedOutputURL: URL?
 
-    let error: Error
+    let error: Error?
+    let resultURL: URL?
 
-    init(error: Error = StandardizationError.conversionFailure) {
+    init(
+        error: Error? = StandardizationError.conversionFailure,
+        resultURL: URL? = nil
+    ) {
         self.error = error
+        self.resultURL = resultURL
     }
 
     func standardize(
@@ -27,11 +36,14 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
         token: UploadInputStandardizationToken,
         sourceAsset: AVURLAsset,
         rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-        conversion: StandardInputConversion?,
+        conversion: StandardInputConversion,
         outputURL: URL
     ) async throws -> AVURLAsset {
         standardizeCallCount += 1
-        throw error
+        receivedConversion = conversion
+        receivedOutputURL = outputURL
+        if let error { throw error }
+        return AVURLAsset(url: resultURL ?? outputURL)
     }
 
     func cancel(id: String, token: UploadInputStandardizationToken) {
@@ -41,7 +53,9 @@ actor MockUploadInputStandardizer: UploadInputStandardizing {
     func snapshot() -> Snapshot {
         Snapshot(
             standardizeCallCount: standardizeCallCount,
-            cancelCallCount: cancelCallCount
+            cancelCallCount: cancelCallCount,
+            conversion: receivedConversion,
+            outputURL: receivedOutputURL
         )
     }
 }

--- a/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputSampleInspectionTests.swift
+++ b/Tests/MuxUploadSDKTests/InputInspectionTests/UploadInputSampleInspectionTests.swift
@@ -298,31 +298,78 @@ final class UploadInputSampleInspectionTests: XCTestCase {
                         completion.fulfill()
                         return
                     }
-                    let startedAt = CFAbsoluteTimeGetCurrent()
-                    let sampleFacts = AVFoundationUploadInputSampleReader.inspect(
-                        asset: asset,
-                        videoTrack: track,
-                        codec: result?.mediaFacts.videoCodec ?? .unknown
-                    )
-                    let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
-                    XCTAssertEqual(
-                        sampleFacts.maximumGOPBitrate,
-                        result?.mediaFacts.maximumGOPBitrate,
-                        url.lastPathComponent
-                    )
-                    print(
-                        "Catalog real media:",
-                        url.lastPathComponent,
-                        "compressedSampleSeconds=\(String(format: "%.3f", elapsed))",
-                        "maxGOPBytes=\(String(describing: sampleFacts.maximumGOPByteSize.value))",
-                        "maxGOPBitrate=\(String(describing: sampleFacts.maximumGOPBitrate.value))",
-                        "maxKeyframeInterval=\(String(describing: sampleFacts.maximumKeyframeInterval.value))",
-                        "gopStructure=\(String(describing: sampleFacts.gopStructure.value))"
-                    )
-                    completion.fulfill()
+                    Task {
+                        let startedAt = CFAbsoluteTimeGetCurrent()
+                        let sampleFacts = await AVFoundationUploadInputSampleReader.inspect(
+                            asset: asset,
+                            videoTrack: track,
+                            codec: result?.mediaFacts.videoCodec ?? .unknown
+                        )
+                        let elapsed = CFAbsoluteTimeGetCurrent() - startedAt
+                        XCTAssertEqual(
+                            sampleFacts.maximumGOPBitrate,
+                            result?.mediaFacts.maximumGOPBitrate,
+                            url.lastPathComponent
+                        )
+                        print(
+                            "Catalog real media:",
+                            url.lastPathComponent,
+                            "compressedSampleSeconds=\(String(format: "%.3f", elapsed))",
+                            "maxGOPBytes=\(String(describing: sampleFacts.maximumGOPByteSize.value))",
+                            "maxGOPBitrate=\(String(describing: sampleFacts.maximumGOPBitrate.value))",
+                            "maxKeyframeInterval=\(String(describing: sampleFacts.maximumKeyframeInterval.value))",
+                            "gopStructure=\(String(describing: sampleFacts.gopStructure.value))"
+                        )
+                        completion.fulfill()
+                    }
                 }
             }
             wait(for: [completion], timeout: 120)
+        }
+    }
+
+    func testCatalogInspectionCancellationWhileReaderIsRegistered() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let directory = environment["MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY"] else {
+            throw XCTSkip(
+                "Set MUX_UPLOAD_MEDIA_FIXTURE_DIRECTORY for real-media cancellation validation"
+            )
+        }
+        let mediaURLs = try FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: directory),
+            includingPropertiesForKeys: [.fileSizeKey]
+        ).filter { ["mov", "mp4"].contains($0.pathExtension.lowercased()) }
+        let inputURL = try XCTUnwrap(
+            mediaURLs.max {
+                let left = (try? $0.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                let right = (try? $1.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+                return left < right
+            }
+        )
+
+        for _ in 0..<10 {
+            let operation = UploadInputInspectionOperation()
+            let task = Task {
+                await AVFoundationUploadInputInspector().inspect(
+                    sourceInput: AVURLAsset(url: inputURL),
+                    maximumResolution: .preset3840x2160,
+                    operation: operation
+                )
+            }
+            var registeredReader = false
+            for _ in 0..<1_000 {
+                if await operation.hasRegisteredAssetReader {
+                    registeredReader = true
+                    break
+                }
+                try await Task.sleep(nanoseconds: 100_000)
+            }
+            XCTAssertTrue(registeredReader)
+            await operation.cancel()
+
+            let outcome = await task.value
+            XCTAssertNil(outcome.result)
+            XCTAssertTrue(outcome.error is CancellationError)
         }
     }
 

--- a/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
+++ b/Tests/MuxUploadSDKTests/InputStandardizationTests/UploadInputStandardizerTests.swift
@@ -15,7 +15,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         func standardize(
             sourceAsset: AVURLAsset,
             rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-            conversion: StandardInputConversion?,
+            conversion: StandardInputConversion,
             outputURL: URL
         ) async throws -> AVURLAsset {
             receivedConversion = conversion
@@ -35,7 +35,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         func standardize(
             sourceAsset: AVURLAsset,
             rescalingDetails: UploadInputFormatInspectionResult.RescalingDetails,
-            conversion: StandardInputConversion?,
+            conversion: StandardInputConversion,
             outputURL: URL
         ) async throws -> AVURLAsset {
             if isCancelled {
@@ -435,6 +435,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                     url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
                 ),
                 rescalingDetails: .init(),
+                conversion: basicConversion(),
                 outputURL: URL(fileURLWithPath: "/tmp/missing-standardization-output.mp4")
             )
         }
@@ -474,6 +475,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                 token: firstToken,
                 sourceAsset: sourceAsset,
                 rescalingDetails: .init(),
+                conversion: basicConversion(),
                 outputURL: URL(fileURLWithPath: "/tmp/missing-first-output.mp4")
             )
         }
@@ -485,6 +487,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                 token: replacementToken,
                 sourceAsset: sourceAsset,
                 rescalingDetails: .init(),
+                conversion: basicConversion(),
                 outputURL: URL(fileURLWithPath: "/tmp/missing-replacement-output.mp4")
             )
         }
@@ -511,6 +514,7 @@ final class UploadInputStandardizerTests: XCTestCase {
                     url: URL(fileURLWithPath: "/tmp/missing-standardization-input.mp4")
                 ),
                 rescalingDetails: .init(),
+                conversion: basicConversion(),
                 outputURL: URL(fileURLWithPath: "/tmp/missing-standardization-output.mp4")
             )
             XCTFail("Cancelled worker should throw")
@@ -537,6 +541,7 @@ final class UploadInputStandardizerTests: XCTestCase {
             _ = try await worker.standardize(
                 sourceAsset: AVURLAsset(url: inputURL),
                 rescalingDetails: .init(),
+                conversion: basicConversion(),
                 outputURL: outputURL
             )
             XCTFail("Standardization should reject an existing output file")
@@ -563,6 +568,7 @@ final class UploadInputStandardizerTests: XCTestCase {
         let standardizedAsset = try await worker.standardize(
             sourceAsset: AVURLAsset(url: inputURL),
             rescalingDetails: .init(),
+            conversion: basicConversion(),
             outputURL: outputURL
         )
 
@@ -577,6 +583,28 @@ final class UploadInputStandardizerTests: XCTestCase {
         XCTAssertEqual(naturalSize, CGSize(width: 64, height: 64))
         let audioTracks = try await standardizedAsset.loadTracks(withMediaType: .audio)
         XCTAssertTrue(audioTracks.isEmpty)
+    }
+
+    func testPlanningCapabilitiesRequireARealDecodableVideoSample() async throws {
+        let inputURL = try await makeGeneratedH264Asset()
+        defer { try? FileManager.default.removeItem(at: inputURL) }
+        let provider = AVFoundationStandardInputPlanningCapabilityProvider()
+        var inspection = UploadInputFormatInspectionResult()
+        inspection.metadata.videoTrackCount = 1
+
+        let decodable = await provider.capabilities(
+            for: inspection,
+            sourceAsset: AVURLAsset(url: inputURL)
+        )
+        let missing = await provider.capabilities(
+            for: inspection,
+            sourceAsset: AVURLAsset(
+                url: URL(fileURLWithPath: "/tmp/missing-decode-probe-source.mp4")
+            )
+        )
+
+        XCTAssertTrue(decodable.sourceIsDecodable)
+        XCTAssertFalse(missing.sourceIsDecodable)
     }
 
     func testCatalogBackedCodecPreservingMP4AACConversion() async throws {
@@ -758,6 +786,10 @@ final class UploadInputStandardizerTests: XCTestCase {
             _ = try await worker.standardize(
                 sourceAsset: AVURLAsset(url: inputURL),
                 rescalingDetails: .init(),
+                conversion: basicConversion(
+                    sourceCodec: .hevc,
+                    outputCodec: .hevc
+                ),
                 outputURL: outputURL
             )
             XCTFail("Cancelled transfer should throw")
@@ -793,7 +825,11 @@ final class UploadInputStandardizerTests: XCTestCase {
                 maximumDesiredResolutionPreset: maximumResolution,
                 recordedResolution: .init(width: 0, height: 0)
             ),
-            conversion: conversion,
+            conversion: conversion ?? basicConversion(
+                sourceCodec: expectedCodec == .hevc ? .hevc : .h264,
+                outputCodec: expectedCodec == .hevc ? .hevc : .h264,
+                maximumResolution: maximumResolution
+            ),
             outputURL: outputURL
         )
         XCTAssertEqual(standardizedAsset.url, outputURL)
@@ -1140,6 +1176,26 @@ final class UploadInputStandardizerTests: XCTestCase {
             toneMapsToSDR: true,
             selection: StandardInputPolicySelection(
                 maximumResolution: .preset1920x1080
+            ),
+            requirementsToRemediate: []
+        )
+    }
+
+    private func basicConversion(
+        sourceCodec: StandardInputVideoCodec = .h264,
+        outputCodec: StandardInputVideoCodec = .h264,
+        maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution = .preset1920x1080
+    ) -> StandardInputConversion {
+        StandardInputConversion(
+            sourceCodec: sourceCodec,
+            outputCodec: outputCodec,
+            sourceDynamicRange: .sdr,
+            sourceDisplayDimensions: .known(
+                StandardInputDisplayDimensions(width: 64, height: 64)
+            ),
+            toneMapsToSDR: false,
+            selection: StandardInputPolicySelection(
+                maximumResolution: maximumResolution
             ),
             requirementsToRemediate: []
         )

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -651,6 +651,105 @@ class DirectUploadTests: XCTestCase {
         await cancelAndWait(upload)
     }
 
+    func testTransportFailureDeletesOwnedStandardizedOutput() async throws {
+        let outputURL = temporaryOutputURL()
+        FileManager.default.createFile(atPath: outputURL.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        let input = try makeInput(
+            options: DirectUploadOptions(
+                inputStandardization: .init(
+                    maximumResolution: .default,
+                    hdrHandling: .toneMapToSDR
+                )
+            )
+        )
+        let source = inspectionResult(
+            facts: compliantFacts(codec: .hevc, dynamicRange: .hlg, bitDepth: 10)
+        )
+        let generated = inspectionResult(
+            facts: compliantFacts(codec: .hevc, dynamicRange: .sdr, bitDepth: 8)
+        )
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: source,
+                duration: CMTime(seconds: 10, preferredTimescale: 600),
+                subsequentResults: [generated]
+            ),
+            inputStandardizer: MockUploadInputStandardizer(
+                error: nil,
+                resultURL: outputURL
+            ),
+            capabilityProvider: FullyCapablePlanningProvider(),
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL),
+            fileWorkerFactory: makeFailingFileWorker
+        )
+        let failureExpectation = expectation(description: "Transport fails")
+        upload.resultHandler = { result in
+            guard case .failure = result else {
+                return XCTFail("Expected transport failure")
+            }
+            failureExpectation.fulfill()
+        }
+
+        upload.start()
+        await fulfillment(of: [failureExpectation], timeout: 1.0)
+
+        for _ in 0..<100 where FileManager.default.fileExists(atPath: outputURL.path) {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+    }
+
+    func testTransportFailurePreservesOriginalInput() async throws {
+        let sourceURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("direct-upload-source-\(UUID().uuidString).mp4")
+        FileManager.default.createFile(atPath: sourceURL.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: sourceURL) }
+        let input = UploadInput(
+            asset: AVURLAsset(url: sourceURL),
+            info: UploadInfo(
+                uploadURL: try XCTUnwrap(URL(string: "https://example.com/upload")),
+                options: .default
+            )
+        )
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector.alwaysFailing,
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: nil),
+            fileWorkerFactory: makeFailingFileWorker
+        )
+        let failureExpectation = expectation(description: "Transport fails")
+        upload.nonStandardInputHandler = { false }
+        upload.resultHandler = { result in
+            guard case .failure = result else {
+                return XCTFail("Expected transport failure")
+            }
+            failureExpectation.fulfill()
+        }
+
+        upload.start()
+        await fulfillment(of: [failureExpectation], timeout: 1.0)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sourceURL.path))
+    }
+
+    private func makeFailingFileWorker(
+        uploadInfo: UploadInfo,
+        inputFileURL: URL,
+        file: ChunkedFile,
+        startingByte: UInt64
+    ) -> ChunkedFileUploader {
+        FailingChunkedFileUploader(
+            uploadInfo: uploadInfo,
+            inputFileURL: inputFileURL,
+            file: file,
+            startingByte: startingByte
+        )
+    }
+
     private func assertStandardizationFailureBehavior(
         inspectionResult: UploadInputFormatInspectionResult,
         shouldCancel: Bool
@@ -808,6 +907,36 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
+}
+
+private final class FailingChunkedFileUploader: ChunkedFileUploader {
+    private var delegates: [String: ChunkedFileUploaderDelegate] = [:]
+
+    override func addDelegate(
+        withToken token: String,
+        _ delegate: ChunkedFileUploaderDelegate
+    ) {
+        delegates[token] = delegate
+    }
+
+    override func removeDelegate(withToken token: String) {
+        delegates.removeValue(forKey: token)
+    }
+
+    override func start() {
+        fail()
+    }
+
+    override func start(duration: CMTime) {
+        fail()
+    }
+
+    private func fail() {
+        let delegates = Array(delegates.values)
+        for delegate in delegates {
+            delegate.chunkedFileUploader(self, stateUpdated: .failure(DummyError()))
+        }
+    }
 }
 
 private struct FullyCapablePlanningProvider: StandardInputPlanningCapabilityProviding {

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -622,12 +622,16 @@ class DirectUploadTests: XCTestCase {
         )
         let handlerExpectation = expectation(description: "Preflight failure handler runs")
         let transportExpectation = expectation(description: "Original transport starts")
+        var transportedFileURL: URL?
         upload.nonStandardInputHandler = {
             handlerExpectation.fulfill()
             return false
         }
         upload.inputStatusHandler = { status in
-            if case .transportInProgress = status { transportExpectation.fulfill() }
+            if case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
+                transportExpectation.fulfill()
+            }
         }
 
         upload.start()
@@ -635,7 +639,7 @@ class DirectUploadTests: XCTestCase {
 
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
-        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+        XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
         upload.cancel()
     }
 

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -21,7 +21,7 @@ class DirectUploadTests: XCTestCase {
         }
     }
 
-    func testStartStatusUpdate() throws {
+    func testStartStatusUpdate() async throws {
         let upload = DirectUpload(
             uploadURL: URL(string: "https://www.example.com/upload")!,
             inputFileURL: URL(string: "file://var/mobile/Containers/Data/Application/Documents/myvideo.mp4")!
@@ -39,10 +39,8 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
 
-        wait(
-            for: [ex],
-            timeout: 2.0
-        )
+        await fulfillment(of: [ex], timeout: 2.0)
+        await cancelAndWait(upload)
     }
 
     func testImmediateStartThenCancelAlwaysProcessesCancellationLast() async throws {
@@ -103,7 +101,7 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testInputInspectionSuccess() throws {
+    func testInputInspectionSuccess() async throws {
         let input = try UploadInput.mockReadyInput()
 
         let upload = DirectUpload(
@@ -132,11 +130,12 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
 
-        wait(
-            for: [preparingStatusExpectation, uploadInProgressExpecation],
+        await fulfillment(
+            of: [preparingStatusExpectation, uploadInProgressExpecation],
             timeout: 2.0,
             enforceOrder: true
         )
+        await cancelAndWait(upload)
     }
 
     func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() async throws {
@@ -311,10 +310,10 @@ class DirectUploadTests: XCTestCase {
         guard case .preparing = upload.inputStatus else {
             return XCTFail("Expected the old attempt not to advance the new attempt")
         }
-        upload.cancel()
+        await cancelAndWait(upload)
     }
 
-    func testInputInspectionFailure() throws {
+    func testInputInspectionFailure() async throws {
         let input = try UploadInput.mockReadyInput()
 
         let upload = DirectUpload(
@@ -343,11 +342,12 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
 
-        wait(
-            for: [preparingStatusExpectation, uploadInProgressExpecation],
+        await fulfillment(
+            of: [preparingStatusExpectation, uploadInProgressExpecation],
             timeout: 2.0,
             enforceOrder: true
         )
+        await cancelAndWait(upload)
     }
 
     func testNonStandardInputHandlerReturningTrueCancelsUpload() async throws {
@@ -389,6 +389,7 @@ class DirectUploadTests: XCTestCase {
         var handlerCallCount = 0
         let handlerExpectation = expectation(description: "Failure handler runs")
         let transportExpectation = expectation(description: "Original transport starts")
+        var transportedFileURL: URL?
 
         upload.nonStandardInputHandler = {
             handlerCallCount += 1
@@ -396,18 +397,18 @@ class DirectUploadTests: XCTestCase {
             return false
         }
         upload.inputStatusHandler = { status in
-            if case .transportInProgress = status { transportExpectation.fulfill() }
+            if case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
+                transportExpectation.fulfill()
+            }
         }
 
         upload.start()
 
         await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
         XCTAssertEqual(handlerCallCount, 1)
-        guard case .transportInProgress = upload.inputStatus else {
-            return XCTFail("Expected false to upload the original input")
-        }
-        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
-        upload.cancel()
+        XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+        await cancelAndWait(upload)
     }
 
     func testHandlerReturningTrueCancelsAfterRescalingFailure() async throws {
@@ -511,7 +512,7 @@ class DirectUploadTests: XCTestCase {
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
-        upload.cancel()
+        await cancelAndWait(upload)
     }
 
     func testToneMapPlanUsesOnlyValidatedGeneratedOutput() async throws {
@@ -546,8 +547,12 @@ class DirectUploadTests: XCTestCase {
             storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL)
         )
         let transportExpectation = expectation(description: "Generated transport starts")
+        var transportedFileURL: URL?
         upload.inputStatusHandler = { status in
-            if case .transportInProgress = status { transportExpectation.fulfill() }
+            if case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
+                transportExpectation.fulfill()
+            }
         }
 
         upload.start()
@@ -556,8 +561,8 @@ class DirectUploadTests: XCTestCase {
         let snapshot = await standardizer.snapshot()
         XCTAssertEqual(snapshot.standardizeCallCount, 1)
         XCTAssertEqual(snapshot.conversion?.toneMapsToSDR, true)
-        XCTAssertEqual(upload.fileWorker?.inputFileURL, outputURL)
-        upload.cancel()
+        XCTAssertEqual(transportedFileURL, outputURL)
+        await cancelAndWait(upload)
     }
 
     func testRejectedGeneratedOutputFallsBackAndDeletesOwnedOutput() async throws {
@@ -605,7 +610,7 @@ class DirectUploadTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
-        upload.cancel()
+        await cancelAndWait(upload)
     }
 
     func testStoragePreflightFailureFallsBackBeforeStandardization() async throws {
@@ -643,7 +648,7 @@ class DirectUploadTests: XCTestCase {
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
-        upload.cancel()
+        await cancelAndWait(upload)
     }
 
     private func assertStandardizationFailureBehavior(
@@ -668,6 +673,7 @@ class DirectUploadTests: XCTestCase {
         let finalStatusExpectation = expectation(
             description: "Standardization failure reaches its final status"
         )
+        var transportedFileURL: URL?
 
         upload.nonStandardInputHandler = {
             handlerCallCount += 1
@@ -678,6 +684,7 @@ class DirectUploadTests: XCTestCase {
             if shouldCancel, case .ready = status {
                 finalStatusExpectation.fulfill()
             } else if !shouldCancel, case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
                 finalStatusExpectation.fulfill()
             }
         }
@@ -698,12 +705,25 @@ class DirectUploadTests: XCTestCase {
                 return XCTFail("Expected true to cancel and reset the upload to ready")
             }
         } else {
-            guard case .transportInProgress = upload.inputStatus else {
-                return XCTFail("Expected false to upload the original input")
-            }
-            XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
-            upload.cancel()
+            XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+            await cancelAndWait(upload)
         }
+    }
+
+    private func cancelAndWait(_ upload: DirectUpload) async {
+        if case .ready = upload.inputStatus, upload.fileWorker == nil {
+            return
+        }
+        let cancellationExpectation = expectation(
+            description: "Upload cancellation finishes"
+        )
+        upload.inputStatusHandler = { status in
+            if case .ready = status {
+                cancellationExpectation.fulfill()
+            }
+        }
+        upload.cancel()
+        await fulfillment(of: [cancellationExpectation], timeout: 2.0)
     }
 
     private func waitForStandardizer(

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -170,8 +170,7 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
 
-        let pendingOperation = await waitForInspectionOperation(inspector)
-        let operation = try XCTUnwrap(pendingOperation)
+        let operation = await inspector.waitForDeferredInspectionStart()
 
         upload.cancel()
         for _ in 0..<100 where !(await operation.isCancelled) {
@@ -290,7 +289,7 @@ class DirectUploadTests: XCTestCase {
         }
 
         upload.start()
-        _ = await waitForInspectionOperation(inspector)
+        _ = await inspector.waitForDeferredInspectionStart()
 
         Task {
             await inspector.completeDeferredInspection()
@@ -302,7 +301,7 @@ class DirectUploadTests: XCTestCase {
         await fulfillment(of: [cancellationReported], timeout: 1.0)
 
         upload.start()
-        _ = await waitForInspectionOperation(inspector)
+        _ = await inspector.waitForDeferredInspectionStart()
 
         allowWorkerCreation.signal()
         await fulfillment(of: [completionFinished], timeout: 1.0)
@@ -493,12 +492,16 @@ class DirectUploadTests: XCTestCase {
         )
         let transportExpectation = expectation(description: "Original transport starts")
         var failureHandlerCallCount = 0
+        var transportedFileURL: URL?
         upload.nonStandardInputHandler = {
             failureHandlerCallCount += 1
             return false
         }
         upload.inputStatusHandler = { status in
-            if case .transportInProgress = status { transportExpectation.fulfill() }
+            if case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
+                transportExpectation.fulfill()
+            }
         }
 
         upload.start()
@@ -507,7 +510,7 @@ class DirectUploadTests: XCTestCase {
         XCTAssertEqual(failureHandlerCallCount, 0)
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
-        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+        XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
         upload.cancel()
     }
 
@@ -715,18 +718,6 @@ class DirectUploadTests: XCTestCase {
             try? await Task.sleep(nanoseconds: 1_000_000)
         }
         return await standardizer.snapshot()
-    }
-
-    private func waitForInspectionOperation(
-        _ inspector: MockUploadInputInspector
-    ) async -> UploadInputInspectionOperation? {
-        for _ in 0..<100 {
-            if let operation = await inspector.currentOperation() {
-                return operation
-            }
-            try? await Task.sleep(nanoseconds: 1_000_000)
-        }
-        return await inspector.currentOperation()
     }
 
     private func conversionFacts(

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -45,6 +45,64 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
+    func testImmediateStartThenCancelAlwaysProcessesCancellationLast() async throws {
+        for iteration in 0..<100 {
+            let upload = DirectUpload(
+                input: try UploadInput.mockReadyInput(),
+                uploadManager: DirectUploadManager(),
+                inputInspector: MockUploadInputInspector(shouldDeferCompletion: true)
+            )
+            let cancellation = expectation(
+                description: "Cancellation \(iteration)"
+            )
+            upload.resultHandler = { result in
+                if case .failure(let error) = result,
+                   error.kind == .cancelled {
+                    cancellation.fulfill()
+                }
+            }
+
+            upload.start()
+            upload.cancel()
+            await fulfillment(of: [cancellation], timeout: 1)
+
+            XCTAssertNil(upload.fileWorker)
+            guard case .ready = upload.inputStatus else {
+                return XCTFail("A queued cancel must leave the upload ready")
+            }
+        }
+    }
+
+    func testTemporaryStorageOwnershipUsesInjectedBaseDirectory() throws {
+        let baseDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("direct-upload-storage-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: baseDirectory) }
+        let preflighter = FileSystemTemporaryStoragePreflighter(
+            baseDirectory: baseDirectory
+        )
+        let output = try preflighter.outputURL(
+            for: baseDirectory.appendingPathComponent("source.mp4"),
+            duration: .zero,
+            conversion: StandardInputConversion(
+                sourceCodec: .h264,
+                outputCodec: .h264,
+                sourceDynamicRange: .sdr,
+                sourceDisplayDimensions: .known(
+                    .init(width: 64, height: 64)
+                ),
+                toneMapsToSDR: false,
+                selection: .init(maximumResolution: .preset1920x1080),
+                requirementsToRemediate: []
+            )
+        )
+
+        XCTAssertTrue(preflighter.ownsTemporaryOutput(output))
+        XCTAssertFalse(
+            FileSystemTemporaryStoragePreflighter()
+                .ownsTemporaryOutput(output)
+        )
+    }
+
     func testInputInspectionSuccess() throws {
         let input = try UploadInput.mockReadyInput()
 
@@ -83,9 +141,8 @@ class DirectUploadTests: XCTestCase {
 
     func testCancelDuringInspectionCancelsOperationAndSuppressesCompletion() async throws {
         let input = try UploadInput.mockReadyInput()
-        let inspector = MockUploadInputInspector()
+        let inspector = MockUploadInputInspector(shouldDeferCompletion: true)
         let standardizer = MockUploadInputStandardizer()
-        inspector.shouldDeferCompletion = true
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
@@ -113,19 +170,21 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
 
-        guard case .preparing = upload.inputStatus else {
-            return XCTFail("Expected inspection to remain in progress")
-        }
-        let operation = try XCTUnwrap(inspector.operation)
+        let pendingOperation = await waitForInspectionOperation(inspector)
+        let operation = try XCTUnwrap(pendingOperation)
 
         upload.cancel()
-        inspector.completeDeferredInspection()
+        for _ in 0..<100 where !(await operation.isCancelled) {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        await inspector.completeDeferredInspection()
 
-        XCTAssertTrue(operation.isCancelled)
         let standardizerSnapshot = await waitForStandardizer(
             standardizer,
             cancelCallCount: 1
         )
+        let operationWasCancelled = await operation.isCancelled
+        XCTAssertTrue(operationWasCancelled)
         XCTAssertEqual(standardizerSnapshot.cancelCallCount, 1)
         XCTAssertNil(upload.fileWorker)
         guard case .ready = upload.inputStatus else {
@@ -141,14 +200,14 @@ class DirectUploadTests: XCTestCase {
         for _ in 0..<250 {
             let registry = UploadInputInspectionOperationRegistry()
             let token = UploadInputInspectionOperationRegistry.Token()
-            let operation = UploadInputInspectionOperation { _, _, _ in }
-            registry.register(operation, for: token)
+            let operation = UploadInputInspectionOperation()
+            await registry.register(operation, for: token)
 
             let completionTask = Task.detached {
-                registry.claimCompletion(for: token)
+                await registry.claimCompletion(for: token)
             }
             let cancellationTask = Task.detached {
-                registry.cancel(for: token)
+                await registry.cancel(for: token)
             }
             let completionClaimed = await completionTask.value
             let cancellationClaimed = await cancellationTask.value
@@ -158,46 +217,45 @@ class DirectUploadTests: XCTestCase {
                 cancellationClaimed,
                 "Exactly one concurrent caller must claim the active inspection"
             )
+            let operationWasCancelled = await operation.isCancelled
             XCTAssertEqual(
-                operation.isCancelled,
+                operationWasCancelled,
                 cancellationClaimed,
                 "Cancellation must reach the operation only when it wins the claim"
             )
         }
     }
 
-    func testCancellingPreviousInspectionDoesNotCancelReplacement() {
+    func testCancellingPreviousInspectionDoesNotCancelReplacement() async {
         let registry = UploadInputInspectionOperationRegistry()
         let previousToken = UploadInputInspectionOperationRegistry.Token()
         let replacementToken = UploadInputInspectionOperationRegistry.Token()
-        let previousOperation = UploadInputInspectionOperation { _, _, _ in }
-        let replacementOperation = UploadInputInspectionOperation { _, _, _ in }
+        let previousOperation = UploadInputInspectionOperation()
+        let replacementOperation = UploadInputInspectionOperation()
 
-        registry.register(previousOperation, for: previousToken)
-        registry.register(replacementOperation, for: replacementToken)
+        await registry.register(previousOperation, for: previousToken)
+        await registry.register(replacementOperation, for: replacementToken)
 
-        XCTAssertFalse(registry.cancel(for: previousToken))
-        XCTAssertTrue(previousOperation.isCancelled)
-        XCTAssertFalse(replacementOperation.isCancelled)
-        XCTAssertTrue(registry.cancel(for: replacementToken))
-        XCTAssertTrue(replacementOperation.isCancelled)
+        let staleCancellationClaimed = await registry.cancel(for: previousToken)
+        let previousWasCancelled = await previousOperation.isCancelled
+        let replacementWasInitiallyCancelled = await replacementOperation.isCancelled
+        let replacementCancellationClaimed = await registry.cancel(for: replacementToken)
+        let replacementWasCancelled = await replacementOperation.isCancelled
+        XCTAssertFalse(staleCancellationClaimed)
+        XCTAssertTrue(previousWasCancelled)
+        XCTAssertFalse(replacementWasInitiallyCancelled)
+        XCTAssertTrue(replacementCancellationClaimed)
+        XCTAssertTrue(replacementWasCancelled)
     }
 
-    func testCancelAndRestartInvalidateClaimedInspectionTransportTransition() throws {
+    func testCancelAndRestartInvalidateClaimedInspectionTransportTransition() async throws {
         let input = try UploadInput.mockReadyInput()
-        let inspector = MockUploadInputInspector()
-        inspector.shouldDeferCompletion = true
+        let inspector = MockUploadInputInspector(shouldDeferCompletion: true)
         let factoryEntered = expectation(
             description: "Old attempt began worker creation"
         )
         let completionFinished = expectation(
             description: "Inspection completion finished"
-        )
-        let cancellationAttempted = expectation(
-            description: "Cancellation was invoked"
-        )
-        let cancellationFinished = expectation(
-            description: "Cancellation finished"
         )
         let cancellationReported = expectation(
             description: "Cancellation was reported after cleanup"
@@ -232,31 +290,22 @@ class DirectUploadTests: XCTestCase {
         }
 
         upload.start()
+        _ = await waitForInspectionOperation(inspector)
 
-        DispatchQueue.global().async {
-            inspector.completeDeferredInspection()
+        Task {
+            await inspector.completeDeferredInspection()
             completionFinished.fulfill()
         }
-        wait(for: [factoryEntered], timeout: 1.0)
+        await fulfillment(of: [factoryEntered], timeout: 1.0)
 
-        DispatchQueue.global().async {
-            cancellationAttempted.fulfill()
-            upload.cancel()
-            cancellationFinished.fulfill()
-        }
-        wait(for: [cancellationAttempted], timeout: 1.0)
-        wait(
-            for: [cancellationFinished, cancellationReported],
-            timeout: 1.0
-        )
+        upload.cancel()
+        await fulfillment(of: [cancellationReported], timeout: 1.0)
 
         upload.start()
-        guard case .preparing = upload.inputStatus else {
-            return XCTFail("Expected the new attempt to remain under inspection")
-        }
+        _ = await waitForInspectionOperation(inspector)
 
         allowWorkerCreation.signal()
-        wait(for: [completionFinished], timeout: 1.0)
+        await fulfillment(of: [completionFinished], timeout: 1.0)
 
         XCTAssertNil(upload.fileWorker)
         XCTAssertTrue(uploadManager.allManagedDirectUploads().isEmpty)
@@ -302,7 +351,7 @@ class DirectUploadTests: XCTestCase {
         )
     }
 
-    func testNonStandardInputHandlerReturningTrueCancelsUpload() throws {
+    func testNonStandardInputHandlerReturningTrueCancelsUpload() async throws {
         let input = try UploadInput.mockReadyInput()
         let upload = DirectUpload(
             input: input,
@@ -310,21 +359,28 @@ class DirectUploadTests: XCTestCase {
             inputInspector: MockUploadInputInspector.alwaysFailing
         )
         var handlerCallCount = 0
+        let handlerExpectation = expectation(description: "Failure handler runs")
+        let readyExpectation = expectation(description: "Upload resets to ready")
 
         upload.nonStandardInputHandler = {
             handlerCallCount += 1
+            handlerExpectation.fulfill()
             return true
+        }
+        upload.inputStatusHandler = { status in
+            if case .ready = status { readyExpectation.fulfill() }
         }
 
         upload.start()
 
+        await fulfillment(of: [handlerExpectation, readyExpectation], timeout: 1.0)
         XCTAssertEqual(handlerCallCount, 1)
         guard case .ready = upload.inputStatus else {
             return XCTFail("Expected true to cancel and reset the upload to ready")
         }
     }
 
-    func testNonStandardInputHandlerReturningFalseUploadsOriginal() throws {
+    func testNonStandardInputHandlerReturningFalseUploadsOriginal() async throws {
         let input = try UploadInput.mockReadyInput()
         let upload = DirectUpload(
             input: input,
@@ -332,14 +388,21 @@ class DirectUploadTests: XCTestCase {
             inputInspector: MockUploadInputInspector.alwaysFailing
         )
         var handlerCallCount = 0
+        let handlerExpectation = expectation(description: "Failure handler runs")
+        let transportExpectation = expectation(description: "Original transport starts")
 
         upload.nonStandardInputHandler = {
             handlerCallCount += 1
+            handlerExpectation.fulfill()
             return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status { transportExpectation.fulfill() }
         }
 
         upload.start()
 
+        await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
         XCTAssertEqual(handlerCallCount, 1)
         guard case .transportInProgress = upload.inputStatus else {
             return XCTFail("Expected false to upload the original input")
@@ -352,6 +415,11 @@ class DirectUploadTests: XCTestCase {
         try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [],
+                mediaFacts: conversionFacts(
+                    codec: .h264,
+                    dimensions: .init(width: 3840, height: 2160)
+                ),
+                metadata: UploadInputMetadataInspection(videoTrackCount: 1),
                 rescalingDetails: .init(
                     maximumDesiredResolutionPreset: .default,
                     recordedResolution: .init(width: 3840, height: 2160)
@@ -365,6 +433,11 @@ class DirectUploadTests: XCTestCase {
         try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [],
+                mediaFacts: conversionFacts(
+                    codec: .h264,
+                    dimensions: .init(width: 3840, height: 2160)
+                ),
+                metadata: UploadInputMetadataInspection(videoTrackCount: 1),
                 rescalingDetails: .init(
                     maximumDesiredResolutionPreset: .default,
                     recordedResolution: .init(width: 3840, height: 2160)
@@ -378,6 +451,8 @@ class DirectUploadTests: XCTestCase {
         try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [.videoCodec],
+                mediaFacts: conversionFacts(codec: .other),
+                metadata: UploadInputMetadataInspection(videoTrackCount: 1),
                 rescalingDetails: .init()
             ),
             shouldCancel: true
@@ -388,10 +463,180 @@ class DirectUploadTests: XCTestCase {
         try await assertStandardizationFailureBehavior(
             inspectionResult: UploadInputFormatInspectionResult(
                 nonStandardInputReasons: [.videoCodec],
+                mediaFacts: conversionFacts(codec: .other),
+                metadata: UploadInputMetadataInspection(videoTrackCount: 1),
                 rescalingDetails: .init()
             ),
             shouldCancel: false
         )
+    }
+
+    func testPlannerPreservesEligibleHLGWithoutStandardizationOrFailureCallback() async throws {
+        let input = try makeInput(
+            options: DirectUploadOptions(
+                inputStandardization: .init(
+                    maximumResolution: .preset3840x2160,
+                    hdrHandling: .preserve
+                )
+            )
+        )
+        let standardizer = MockUploadInputStandardizer()
+        let inspection = inspectionResult(
+            facts: compliantFacts(codec: .hevc, dynamicRange: .hlg, bitDepth: 10)
+        )
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(mockInspectionResult: inspection),
+            inputStandardizer: standardizer,
+            capabilityProvider: FullyCapablePlanningProvider()
+        )
+        let transportExpectation = expectation(description: "Original transport starts")
+        var failureHandlerCallCount = 0
+        upload.nonStandardInputHandler = {
+            failureHandlerCallCount += 1
+            return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status { transportExpectation.fulfill() }
+        }
+
+        upload.start()
+        await fulfillment(of: [transportExpectation], timeout: 1.0)
+
+        XCTAssertEqual(failureHandlerCallCount, 0)
+        let standardizerSnapshot = await standardizer.snapshot()
+        XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
+        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+        upload.cancel()
+    }
+
+    func testToneMapPlanUsesOnlyValidatedGeneratedOutput() async throws {
+        let outputURL = temporaryOutputURL()
+        FileManager.default.createFile(atPath: outputURL.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: outputURL) }
+        let input = try makeInput(
+            options: DirectUploadOptions(
+                inputStandardization: .init(
+                    maximumResolution: .default,
+                    hdrHandling: .toneMapToSDR
+                )
+            )
+        )
+        let source = inspectionResult(
+            facts: compliantFacts(codec: .hevc, dynamicRange: .hlg, bitDepth: 10)
+        )
+        let generated = inspectionResult(
+            facts: compliantFacts(codec: .hevc, dynamicRange: .sdr, bitDepth: 8)
+        )
+        let standardizer = MockUploadInputStandardizer(error: nil, resultURL: outputURL)
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: source,
+                duration: CMTime(seconds: 10, preferredTimescale: 600),
+                subsequentResults: [generated]
+            ),
+            inputStandardizer: standardizer,
+            capabilityProvider: FullyCapablePlanningProvider(),
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL)
+        )
+        let transportExpectation = expectation(description: "Generated transport starts")
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status { transportExpectation.fulfill() }
+        }
+
+        upload.start()
+        await fulfillment(of: [transportExpectation], timeout: 1.0)
+
+        let snapshot = await standardizer.snapshot()
+        XCTAssertEqual(snapshot.standardizeCallCount, 1)
+        XCTAssertEqual(snapshot.conversion?.toneMapsToSDR, true)
+        XCTAssertEqual(upload.fileWorker?.inputFileURL, outputURL)
+        upload.cancel()
+    }
+
+    func testRejectedGeneratedOutputFallsBackAndDeletesOwnedOutput() async throws {
+        let outputURL = temporaryOutputURL()
+        FileManager.default.createFile(atPath: outputURL.path, contents: Data([0]))
+        let input = try makeInput(options: .default)
+        let source = inspectionResult(
+            facts: conversionFacts(codec: .other)
+        )
+        var rejectedFacts = compliantFacts(codec: .h264, dynamicRange: .sdr, bitDepth: 8)
+        rejectedFacts.averageBitrate = .known(50_000_000)
+        let standardizer = MockUploadInputStandardizer(error: nil, resultURL: outputURL)
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: source,
+                duration: CMTime(seconds: 10, preferredTimescale: 600),
+                subsequentResults: [inspectionResult(facts: rejectedFacts)]
+            ),
+            inputStandardizer: standardizer,
+            capabilityProvider: FullyCapablePlanningProvider(),
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL)
+        )
+        let handlerExpectation = expectation(description: "Validation failure handler runs")
+        let transportExpectation = expectation(description: "Original transport starts")
+        var transportedFileURL: URL?
+        upload.nonStandardInputHandler = {
+            handlerExpectation.fulfill()
+            return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status {
+                transportedFileURL = upload.videoFile
+                transportExpectation.fulfill()
+            }
+        }
+
+        upload.start()
+        await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
+
+        for _ in 0..<100 where FileManager.default.fileExists(atPath: outputURL.path) {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
+        XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+        upload.cancel()
+    }
+
+    func testStoragePreflightFailureFallsBackBeforeStandardization() async throws {
+        let input = try makeInput(options: .default)
+        let standardizer = MockUploadInputStandardizer()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: inspectionResult(
+                    facts: conversionFacts(codec: .other)
+                )
+            ),
+            inputStandardizer: standardizer,
+            capabilityProvider: FullyCapablePlanningProvider(),
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: nil)
+        )
+        let handlerExpectation = expectation(description: "Preflight failure handler runs")
+        let transportExpectation = expectation(description: "Original transport starts")
+        upload.nonStandardInputHandler = {
+            handlerExpectation.fulfill()
+            return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status { transportExpectation.fulfill() }
+        }
+
+        upload.start()
+        await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
+
+        let standardizerSnapshot = await standardizer.snapshot()
+        XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
+        XCTAssertEqual(upload.fileWorker?.inputFileURL, input.sourceAsset.url)
+        upload.cancel()
     }
 
     private func assertStandardizationFailureBehavior(
@@ -406,7 +651,8 @@ class DirectUploadTests: XCTestCase {
             inputInspector: MockUploadInputInspector(
                 mockInspectionResult: inspectionResult
             ),
-            inputStandardizer: standardizer
+            inputStandardizer: standardizer,
+            capabilityProvider: FullyCapablePlanningProvider()
         )
         var handlerCallCount = 0
         let handlerExpectation = expectation(
@@ -467,4 +713,120 @@ class DirectUploadTests: XCTestCase {
         return await standardizer.snapshot()
     }
 
+    private func waitForInspectionOperation(
+        _ inspector: MockUploadInputInspector
+    ) async -> UploadInputInspectionOperation? {
+        for _ in 0..<100 {
+            if let operation = await inspector.currentOperation() {
+                return operation
+            }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return await inspector.currentOperation()
+    }
+
+    private func conversionFacts(
+        codec: StandardInputVideoCodec,
+        dimensions: StandardInputDisplayDimensions = .init(width: 1920, height: 1080)
+    ) -> StandardInputMediaFacts {
+        StandardInputMediaFacts(
+            videoCodec: .known(codec),
+            displayDimensions: .known(dimensions),
+            dynamicRange: .known(.sdr)
+        )
+    }
+
+    private func compliantFacts(
+        codec: StandardInputVideoCodec,
+        dynamicRange: StandardInputDynamicRange,
+        bitDepth: Int
+    ) -> StandardInputMediaFacts {
+        StandardInputMediaFacts(
+            videoCodec: .known(codec),
+            displayDimensions: .known(.init(width: 1920, height: 1080)),
+            frameRate: .known(30),
+            averageBitrate: .known(7_000_000),
+            maximumGOPBitrate: .known(8_000_000),
+            maximumGOPByteSize: .known(1_000_000),
+            maximumKeyframeInterval: .known(5),
+            gopStructure: .known(.closedWithIDR),
+            pixelFormat: .known(.init(bitDepth: bitDepth, chromaSubsampling: .yuv420)),
+            dynamicRange: .known(dynamicRange),
+            audio: .known(.none),
+            editList: .known(.none)
+        )
+    }
+
+    private func inspectionResult(
+        facts: StandardInputMediaFacts
+    ) -> UploadInputFormatInspectionResult {
+        UploadInputFormatInspectionResult(
+            mediaFacts: facts,
+            metadata: UploadInputMetadataInspection(videoTrackCount: 1),
+            timelineFacts: StandardInputTimelineFacts(
+                duration: .known(10),
+                audioVideoStartOffset: .known(.notApplicable)
+            ),
+            rescalingDetails: .init()
+        )
+    }
+
+    private func makeInput(options: DirectUploadOptions) throws -> UploadInput {
+        UploadInput(
+            asset: AVURLAsset(url: URL(fileURLWithPath: "/tmp/direct-upload-source.mp4")),
+            info: UploadInfo(
+                uploadURL: try XCTUnwrap(URL(string: "https://example.com/upload")),
+                options: options
+            )
+        )
+    }
+
+    private func temporaryOutputURL() -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(FileSystemTemporaryStoragePreflighter.directoryName)
+        try? FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        return directory.appendingPathComponent(
+            "\(FileSystemTemporaryStoragePreflighter.filePrefix)\(UUID().uuidString).mp4"
+        )
+    }
+
+}
+
+private struct FullyCapablePlanningProvider: StandardInputPlanningCapabilityProviding {
+    func capabilities(
+        for inspection: UploadInputFormatInspectionResult,
+        sourceAsset: AVAsset
+    ) async -> StandardInputPlanningCapabilities {
+        StandardInputPlanningCapabilities(
+            sourceIsDecodable: true,
+            encodableVideoCodecs: [.h264, .hevc],
+            remediableRequirements: Set(StandardInputPolicyEvaluation.Requirement.allCases),
+            toneMappableDynamicRanges: [.hlg, .pq],
+            preservableHDRDynamicRanges: [.hlg, .pq]
+        )
+    }
+}
+
+private struct FixedTemporaryStoragePreflighter: TemporaryStoragePreflighting {
+    let outputURL: URL?
+
+    func outputURL(
+        for sourceURL: URL,
+        duration: CMTime,
+        conversion: StandardInputConversion
+    ) throws -> URL {
+        guard let outputURL else { throw DummyError() }
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        return outputURL
+    }
+
+    func ownsTemporaryOutput(_ url: URL) -> Bool {
+        url == outputURL
+    }
 }

--- a/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerTests.swift
+++ b/Tests/MuxUploadSDKTests/UploadManagerTests/UploadManagerTests.swift
@@ -20,7 +20,7 @@ extension DirectUploadOptions {
 
 class UploadManagerTests: XCTestCase {
 
-    func testUploadManagerURLDeduplication() throws {
+    func testUploadManagerURLDeduplication() async throws {
 
         let uploadManager = DirectUploadManager()
 
@@ -56,6 +56,10 @@ class UploadManagerTests: XCTestCase {
 
         upload.start(forceRestart: false)
         duplicateUpload.start(forceRestart: false)
+
+        for _ in 0..<100 where uploadManager.allManagedDirectUploads().isEmpty {
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
 
         XCTAssertEqual(
             uploadManager.allManagedDirectUploads().count,


### PR DESCRIPTION
## Summary

- integrate inspection, planning, conversion, generated-output validation, fallback, and transport startup into `DirectUpload`
- replace lock-based inspection and preparation lifecycle coordination with actors and an ordered async command boundary
- preserve completion-versus-cancellation arbitration and attempt-scoped stale-cancellation protection
- add storage preflight and owned temporary-output cleanup
- require explicit conversion intent and probe real source decodability before planning conversion
- keep AVFoundation sample transfer isolated and serialize reader cancellation with sample consumption

## Impact

Eligible inputs can now pass through, convert with the planned codec/HDR behavior, or fall back to the original upload according to the existing confirmation handler contract. Generated output is re-inspected and validated before transport. Cancellation cannot advance a stale attempt or delete files outside the configured temporary-output provider.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the core upload preparation path, concurrency model, and media I/O/cancellation behavior; incorrect lifecycle or validation could upload wrong files or leak/delete temp outputs.
> 
> **Overview**
> **DirectUpload** preparation is reworked around **Standard Input planning** instead of separate rescale-only and non-standard conversion branches. After inspection, the SDK probes device/source **capabilities**, runs **`StandardInputPlanner`**, then either uploads the original, converts with an explicit **`StandardInputConversion`**, or fails into the existing **`nonStandardInputHandler`** fallback path.
> 
> **Conversion** always receives a non-optional conversion plan; generated files are **re-inspected** and validated with **`StandardInputOutputValidator`** (including new **timeline facts** from **`StandardInputTimelineInspector`**) before transport. **Temporary storage preflight** reserves space and **owned standardized outputs** are deleted on cancel, validation failure, or transport failure.
> 
> **Concurrency** moves from locks to **actors** for inspection operations/registry and preparation lifecycle, plus an ordered **`DirectUploadLifecycleCommandQueue`** and **`DirectUploadTransportCommitCoordinator`** so start/cancel/commit stay serialized and URL de-duplication stays atomic. **`AVFoundationUploadInputInspector`** and sample/timeline readers are **async**, with reader cancellation coordinated on the consuming task rather than concurrent **`cancelReading()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c47e2ffa4798e651b8d84fb861fe853a587008dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->