### PR TITLE
NAT-491: Add standardization diagnostic logging

### DIFF
--- a/Sources/MuxUploadSDK/InputStandardization/StandardizationDiagnostics.swift
+++ b/Sources/MuxUploadSDK/InputStandardization/StandardizationDiagnostics.swift
@@ -1,0 +1,422 @@
+//
+//  StandardizationDiagnostics.swift
+//
+
+import Foundation
+
+protocol StandardizationDiagnosticLogging: Sendable {
+    func log(_ diagnostic: StandardizationDiagnostic) async
+}
+
+struct SDKStandardizationDiagnosticLogger: StandardizationDiagnosticLogging {
+    func log(_ diagnostic: StandardizationDiagnostic) async {
+        SDKLogger.logStandardizationDiagnostic(diagnostic)
+    }
+}
+
+/// A closed diagnostic payload whose rendered form is safe for public OSLog output.
+/// Keep associated values typed and controlled: never add caller-supplied strings,
+/// URLs, errors, paths, credentials, headers, or tokens.
+enum StandardizationDiagnostic: Equatable, Sendable {
+    enum InspectionRole: String, Sendable {
+        case source
+        case generatedOutput = "generated_output"
+    }
+
+    enum FailureCategory: String, Sendable {
+        case inspection
+        case capability
+        case planning
+        case storage
+        case conversion
+        case outputInspection = "output_inspection"
+        case outputValidation = "output_validation"
+    }
+
+    enum FailureReason: String, Sendable {
+        case inspectionFailed = "inspection_failed"
+        case insufficientEvidence = "insufficient_evidence"
+        case unsupportedConversion = "unsupported_conversion"
+        case unsupportedHDR = "unsupported_hdr"
+        case hdrPreservationUnavailable = "hdr_preservation_unavailable"
+        case nonStandardHDR = "non_standard_hdr"
+        case storagePreflightFailed = "storage_preflight_failed"
+        case conversionFailed = "conversion_failed"
+        case outputInspectionFailed = "output_inspection_failed"
+        case outputNonCompliant = "output_non_compliant"
+        case insufficientOutputPolicyEvidence = "insufficient_output_policy_evidence"
+        case insufficientOutputPlanEvidence = "insufficient_output_plan_evidence"
+        case outputDoesNotMatchPlan = "output_does_not_match_plan"
+    }
+
+    case inspection(
+        role: InspectionRole,
+        facts: StandardInputMediaFacts,
+        legacyReasons: [UploadInputFormatInspectionResult.NonstandardInputReason]
+    )
+    case plan(
+        StandardInputPlan,
+        facts: StandardInputMediaFacts,
+        options: DirectUploadOptions.InputStandardization
+    )
+    case conversionCompleted(
+        StandardInputConversion,
+        durationMilliseconds: Int
+    )
+    case outputValidation(StandardInputOutputValidation)
+    case failure(
+        category: FailureCategory,
+        reason: FailureReason,
+        conversion: StandardInputConversion?,
+        durationMilliseconds: Int?
+    )
+
+    var message: String {
+        // Every rendered value must come from a closed vocabulary or sanitized
+        // numeric media fact. This message is logged with `privacy: .public`.
+        // Never interpolate caller-supplied strings or error descriptions here.
+        switch self {
+        case .inspection(let role, let facts, let legacyReasons):
+            let codecKey = role == .source ? "source_codec" : "output_codec"
+            return fields([
+                "event=inspection_completed",
+                "role=\(role.rawValue)",
+                "\(codecKey)=\(codec(facts.videoCodec))",
+                "dimensions=\(dimensions(facts.displayDimensions))",
+                "frame_rate=\(finite(facts.frameRate))",
+                "average_bitrate=\(integer(facts.averageBitrate))",
+                "maximum_gop_bitrate=\(integer(facts.maximumGOPBitrate))",
+                "maximum_gop_byte_size=\(integer(facts.maximumGOPByteSize))",
+                "maximum_keyframe_interval=\(finite(facts.maximumKeyframeInterval))",
+                "gop_structure=\(gopStructure(facts.gopStructure))",
+                "pixel_format=\(pixelFormat(facts.pixelFormat))",
+                "dynamic_range=\(dynamicRange(facts.dynamicRange))",
+                "audio=\(audio(facts.audio))",
+                "edit_list=\(editList(facts.editList))",
+                "legacy_nonstandard_reasons=\(list(legacyReasons.map(\.description)))"
+            ])
+        case .plan(let plan, let facts, let options):
+            let action = planAction(
+                plan.action,
+                sourceCodec: facts.videoCodec.value
+            )
+            return fields([
+                "event=plan_selected",
+                "plan=\(action.name)",
+                "plan_reason=\(action.reason)",
+                "source_codec=\(action.sourceCodec)",
+                "output_codec=\(action.outputCodec)",
+                "resolution_tier=\(resolutionTier(options.maximumResolution))",
+                "hdr_handling=\(hdrHandling(options.hdrHandling))",
+                "hdr_decision=\(hdrDecision(plan.action))",
+                "policy_outcome=\(policyOutcome(plan.evaluation.outcome))",
+                "noncompliant_requirements=\(requirements(plan.evaluation.nonCompliantRequirements))",
+                "unknown_requirements=\(requirements(plan.evaluation.unknownRequirements))"
+            ])
+        case .conversionCompleted(let conversion, let durationMilliseconds):
+            return fields([
+                "event=conversion_completed",
+                "source_codec=\(codec(conversion.sourceCodec))",
+                "output_codec=\(codec(conversion.outputCodec))",
+                "resolution_tier=\(resolutionTier(conversion.selection))",
+                "hdr_action=\(conversion.toneMapsToSDR ? "tone_map_to_sdr" : "preserve")",
+                "conversion_duration_ms=\(max(0, durationMilliseconds))"
+            ])
+        case .outputValidation(let validation):
+            return fields([
+                "event=output_validation_completed",
+                "result=\(validationResult(validation.disposition))",
+                "policy_outcome=\(policyOutcome(validation.evaluation.outcome))"
+            ])
+        case .failure(let category, let reason, let conversion, let durationMilliseconds):
+            var values = [
+                "event=standardization_failure",
+                "failure_category=\(category.rawValue)",
+                "failure_reason=\(reason.rawValue)"
+            ]
+            if let conversion {
+                values.append("source_codec=\(codec(conversion.sourceCodec))")
+                values.append("output_codec=\(codec(conversion.outputCodec))")
+                values.append("resolution_tier=\(resolutionTier(conversion.selection))")
+                values.append(
+                    "hdr_action=\(conversion.toneMapsToSDR ? "tone_map_to_sdr" : "preserve")"
+                )
+            }
+            if let durationMilliseconds {
+                values.append("conversion_duration_ms=\(max(0, durationMilliseconds))")
+            }
+            return fields(values)
+        }
+    }
+
+    static func plannerFailure(
+        _ reason: StandardInputPlan.FallbackReason
+    ) -> (FailureCategory, FailureReason) {
+        switch reason {
+        case .insufficientEvidenceForConversion:
+            return (.planning, .insufficientEvidence)
+        case .unsupportedConversion:
+            return (.capability, .unsupportedConversion)
+        case .unsupportedHDR:
+            return (.planning, .unsupportedHDR)
+        case .hdrPreservationUnavailable:
+            return (.capability, .hdrPreservationUnavailable)
+        case .nonStandardHDR:
+            return (.planning, .nonStandardHDR)
+        }
+    }
+
+    static func validationFailure(
+        _ validation: StandardInputOutputValidation
+    ) -> FailureReason {
+        guard case .rejected(let reason) = validation.disposition else {
+            return .outputDoesNotMatchPlan
+        }
+        switch reason {
+        case .nonCompliant:
+            return .outputNonCompliant
+        case .insufficientPolicyEvidence:
+            return .insufficientOutputPolicyEvidence
+        case .insufficientPlanEvidence:
+            return .insufficientOutputPlanEvidence
+        case .doesNotMatchPlan:
+            return .outputDoesNotMatchPlan
+        }
+    }
+
+    private func fields(_ values: [String]) -> String {
+        (["standard_input"] + values).joined(separator: " ")
+    }
+
+    private func planAction(
+        _ action: StandardInputPlan.Action,
+        sourceCodec: StandardInputVideoCodec?
+    ) -> (name: String, reason: String, sourceCodec: String, outputCodec: String) {
+        let sourceCodecDescription = sourceCodec.map(codec) ?? "unknown"
+        switch action {
+        case .uploadOriginal(let reason):
+            return (
+                "upload_original",
+                uploadOriginalReason(reason),
+                sourceCodecDescription,
+                sourceCodecDescription
+            )
+        case .convert(let conversion):
+            return (
+                "convert",
+                conversion.toneMapsToSDR ? "tone_map_to_sdr" : "remediate_noncompliance",
+                codec(conversion.sourceCodec),
+                codec(conversion.outputCodec)
+            )
+        case .fallback(let reason):
+            return (
+                "fallback",
+                Self.plannerFailure(reason).1.rawValue,
+                sourceCodecDescription,
+                sourceCodecDescription
+            )
+        }
+    }
+
+    private func uploadOriginalReason(
+        _ reason: StandardInputPlan.UploadOriginalReason
+    ) -> String {
+        switch reason {
+        case .standardizationNotRequested:
+            return "standardization_not_requested"
+        case .standardInput:
+            return "standard_input"
+        case .noKnownStandardInputViolation:
+            return "no_known_violation"
+        case .preserveHDR(.hlg):
+            return "preserve_hlg"
+        case .preserveHDR(.pq):
+            return "preserve_pq"
+        case .preserveHDR(.sdr):
+            return "invalid_preserve_sdr"
+        case .preserveHDR(.otherHDR):
+            return "invalid_preserve_other_hdr"
+        }
+    }
+
+    private func hdrDecision(_ action: StandardInputPlan.Action) -> String {
+        switch action {
+        case .uploadOriginal(.preserveHDR(.hlg)):
+            return "preserve_hlg_for_mux_processing"
+        case .uploadOriginal(.preserveHDR(.pq)):
+            return "preserve_pq_for_compatible_server_processing"
+        case .convert(let conversion) where conversion.toneMapsToSDR:
+            return "tone_map_to_sdr"
+        case .fallback:
+            return "fallback_to_original"
+        default:
+            return "not_applicable"
+        }
+    }
+
+    private func codec(_ fact: StandardInputFact<StandardInputVideoCodec>) -> String {
+        fact.value.map(codec) ?? "unknown"
+    }
+
+    private func codec(_ codec: StandardInputVideoCodec) -> String {
+        switch codec {
+        case .h264: return "h264"
+        case .hevc: return "hevc"
+        case .other: return "other"
+        }
+    }
+
+    private func dimensions(
+        _ fact: StandardInputFact<StandardInputDisplayDimensions>
+    ) -> String {
+        guard let value = fact.value else { return "unknown" }
+        return "\(value.width)x\(value.height)"
+    }
+
+    private func integer(_ fact: StandardInputFact<Int64>) -> String {
+        fact.value.map(String.init) ?? "unknown"
+    }
+
+    private func finite(_ fact: StandardInputFact<Double>) -> String {
+        guard let value = fact.value, value.isFinite else { return "unknown" }
+        return String(format: "%.3f", value)
+    }
+
+    private func gopStructure(
+        _ fact: StandardInputFact<StandardInputGOPStructure>
+    ) -> String {
+        switch fact.value {
+        case .closedWithIDR?: return "closed_with_idr"
+        case .closedWithoutIDR?: return "closed_without_idr"
+        case .open?: return "open"
+        case nil: return "unknown"
+        }
+    }
+
+    private func pixelFormat(
+        _ fact: StandardInputFact<StandardInputPixelFormat>
+    ) -> String {
+        guard let value = fact.value else { return "unknown" }
+        let chroma = value.chromaSubsampling == .yuv420 ? "yuv420" : "other"
+        return "\(value.bitDepth)bit_\(chroma)"
+    }
+
+    private func dynamicRange(
+        _ fact: StandardInputFact<StandardInputDynamicRange>
+    ) -> String {
+        fact.value.map(dynamicRange) ?? "unknown"
+    }
+
+    private func dynamicRange(_ value: StandardInputDynamicRange) -> String {
+        switch value {
+        case .sdr: return "sdr"
+        case .hlg: return "hlg"
+        case .pq: return "pq"
+        case .otherHDR: return "other_hdr"
+        }
+    }
+
+    private func audio(_ fact: StandardInputFact<StandardInputAudio>) -> String {
+        switch fact.value {
+        case .none?: return "none"
+        case .aac(.mono)?: return "aac_mono"
+        case .aac(.stereo)?: return "aac_stereo"
+        case .aac(.fivePointOne)?: return "aac_5_1"
+        case .aac(.other)?: return "aac_other"
+        case .otherCodec?: return "other_codec"
+        case nil: return "unknown"
+        }
+    }
+
+    private func editList(_ fact: StandardInputFact<StandardInputEditList>) -> String {
+        switch fact.value {
+        case .none?: return "none"
+        case .simple?: return "simple"
+        case .complex?: return "complex"
+        case nil: return "unknown"
+        }
+    }
+
+    private func resolutionTier(
+        _ maximumResolution: DirectUploadOptions.InputStandardization.MaximumResolution
+    ) -> String {
+        switch maximumResolution {
+        case .preset1280x720: return "720p"
+        case .default, .preset1920x1080: return "1080p"
+        case .preset2560x1440: return "1440p"
+        case .preset3840x2160: return "2160p"
+        }
+    }
+
+    private func resolutionTier(_ selection: StandardInputPolicySelection) -> String {
+        switch (
+            selection.generatedOutputDimensions.width,
+            selection.generatedOutputDimensions.height
+        ) {
+        case (1280, 720): return "720p"
+        case (1920, 1080): return "1080p"
+        case (2560, 1440): return "1440p"
+        case (3840, 2160): return "2160p"
+        default: return "unknown"
+        }
+    }
+
+    private func hdrHandling(
+        _ value: DirectUploadOptions.InputStandardization.HDRHandling
+    ) -> String {
+        switch value {
+        case .preserve: return "preserve"
+        case .toneMapToSDR: return "tone_map_to_sdr"
+        }
+    }
+
+    private func policyOutcome(_ outcome: StandardInputPolicyEvaluation.Outcome) -> String {
+        switch outcome {
+        case .compliant: return "compliant"
+        case .nonCompliant: return "non_compliant"
+        case .unknown: return "unknown"
+        }
+    }
+
+    private func requirements(
+        _ values: [StandardInputPolicyEvaluation.Requirement]
+    ) -> String {
+        list(values.map(requirement).sorted())
+    }
+
+    private func requirement(
+        _ value: StandardInputPolicyEvaluation.Requirement
+    ) -> String {
+        switch value {
+        case .videoCodec: return "video_codec"
+        case .videoResolution: return "video_resolution"
+        case .frameRate: return "frame_rate"
+        case .averageBitrate: return "average_bitrate"
+        case .maximumGOPBitrate: return "maximum_gop_bitrate"
+        case .keyframeInterval: return "keyframe_interval"
+        case .gopStructure: return "gop_structure"
+        case .pixelFormat: return "pixel_format"
+        case .dynamicRange: return "dynamic_range"
+        case .audio: return "audio"
+        case .editList: return "edit_list"
+        }
+    }
+
+    private func validationResult(
+        _ disposition: StandardInputOutputValidation.Disposition
+    ) -> String {
+        switch disposition {
+        case .accepted: return "accepted"
+        case .rejected(.nonCompliant): return "rejected_non_compliant"
+        case .rejected(.insufficientPolicyEvidence):
+            return "rejected_insufficient_policy_evidence"
+        case .rejected(.insufficientPlanEvidence):
+            return "rejected_insufficient_plan_evidence"
+        case .rejected(.doesNotMatchPlan): return "rejected_plan_mismatch"
+        }
+    }
+
+    private func list(_ values: [String]) -> String {
+        values.isEmpty ? "none" : values.sorted().joined(separator: ",")
+    }
+}

--- a/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/DirectUpload.swift
@@ -371,6 +371,7 @@ public final class DirectUpload {
     private let outputValidator: StandardInputOutputValidator
     private let capabilityProvider: StandardInputPlanningCapabilityProviding
     private let storagePreflighter: TemporaryStoragePreflighting
+    private let standardizationDiagnosticLogger: StandardizationDiagnosticLogging
     private let fileWorkerFactory: FileWorkerFactory
     private var lifecycleCommands: DirectUploadLifecycleCommandQueue!
 
@@ -440,6 +441,7 @@ public final class DirectUpload {
         outputValidator: StandardInputOutputValidator = StandardInputOutputValidator(),
         capabilityProvider: StandardInputPlanningCapabilityProviding = AVFoundationStandardInputPlanningCapabilityProvider(),
         storagePreflighter: TemporaryStoragePreflighting = FileSystemTemporaryStoragePreflighter(),
+        standardizationDiagnosticLogger: StandardizationDiagnosticLogging = SDKStandardizationDiagnosticLogger(),
         fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
@@ -451,6 +453,7 @@ public final class DirectUpload {
         self.outputValidator = outputValidator
         self.capabilityProvider = capabilityProvider
         self.storagePreflighter = storagePreflighter
+        self.standardizationDiagnosticLogger = standardizationDiagnosticLogger
         self.fileWorkerFactory = fileWorkerFactory
         self.lifecycleCommands = DirectUploadLifecycleCommandQueue(owner: self)
     }
@@ -465,6 +468,7 @@ public final class DirectUpload {
         outputValidator: StandardInputOutputValidator = StandardInputOutputValidator(),
         capabilityProvider: StandardInputPlanningCapabilityProviding = AVFoundationStandardInputPlanningCapabilityProvider(),
         storagePreflighter: TemporaryStoragePreflighting = FileSystemTemporaryStoragePreflighter(),
+        standardizationDiagnosticLogger: StandardizationDiagnosticLogging = SDKStandardizationDiagnosticLogger(),
         fileWorkerFactory: @escaping FileWorkerFactory = DirectUpload.makeFileWorker
     ) {
         self.input = input
@@ -476,6 +480,7 @@ public final class DirectUpload {
         self.outputValidator = outputValidator
         self.capabilityProvider = capabilityProvider
         self.storagePreflighter = storagePreflighter
+        self.standardizationDiagnosticLogger = standardizationDiagnosticLogger
         self.fileWorkerFactory = fileWorkerFactory
         self.lifecycleCommands = DirectUploadLifecycleCommandQueue(owner: self)
     }
@@ -672,7 +677,24 @@ public final class DirectUpload {
         guard await inputInspectionOperations.claimCompletion(
             for: attempt.inspectionToken
         ), await preparationLifecycle.isActive(attempt) else { return }
+        if let result = outcome.result {
+            await standardizationDiagnosticLogger.log(
+                .inspection(
+                    role: .source,
+                    facts: result.mediaFacts,
+                    legacyReasons: result.nonStandardInputReasons
+                )
+            )
+        }
         guard let inspection = outcome.result, outcome.error == nil else {
+            await standardizationDiagnosticLogger.log(
+                .failure(
+                    category: .inspection,
+                    reason: .inspectionFailed,
+                    conversion: nil,
+                    durationMilliseconds: nil
+                )
+            )
             await handlePreparationFailure(
                 error: outcome.error ?? UploadInputInspectionError.inspectionFailure,
                 result: outcome.result,
@@ -696,7 +718,13 @@ public final class DirectUpload {
             options: uploadInfo.options.inputStandardization,
             capabilities: capabilities
         )
-        SDKLogger.logger?.debug("Selected Standard Input plan: \(String(describing: plan.action))")
+        await standardizationDiagnosticLogger.log(
+            .plan(
+                plan,
+                facts: inspection.mediaFacts,
+                options: uploadInfo.options.inputStandardization
+            )
+        )
         switch plan.action {
         case .uploadOriginal:
             await startNetworkTransport(
@@ -704,6 +732,15 @@ public final class DirectUpload {
                 attempt: attempt
             )
         case .fallback(let reason):
+            let failure = StandardizationDiagnostic.plannerFailure(reason)
+            await standardizationDiagnosticLogger.log(
+                .failure(
+                    category: failure.0,
+                    reason: failure.1,
+                    conversion: nil,
+                    durationMilliseconds: nil
+                )
+            )
             await handlePreparationFailure(
                 error: DirectUploadPreparationError.plannerFallback(reason),
                 result: inspection,
@@ -743,6 +780,14 @@ public final class DirectUpload {
                 conversion: conversion
             )
         } catch {
+            await standardizationDiagnosticLogger.log(
+                .failure(
+                    category: .storage,
+                    reason: .storagePreflightFailed,
+                    conversion: conversion,
+                    durationMilliseconds: nil
+                )
+            )
             await handlePreparationFailure(
                 error: error,
                 result: inspection,
@@ -764,6 +809,9 @@ public final class DirectUpload {
         guard await preparationLifecycle.performIfActive(for: attempt, {
             input.status = .standardizing(sourceAsset, input.uploadInfo)
         }) else { return }
+        let conversionStartedAt = ProcessInfo.processInfo.systemUptime
+        var conversionDurationMilliseconds: Int?
+        var diagnosticFailureWasLogged = false
         do {
             let generatedAsset = try await inputStandardizer.standardize(
                 id: id,
@@ -772,6 +820,16 @@ public final class DirectUpload {
                 rescalingDetails: inspection.rescalingDetails,
                 conversion: conversion,
                 outputURL: outputURL
+            )
+            guard await preparationLifecycle.isActive(attempt) else { return }
+            conversionDurationMilliseconds = Self.milliseconds(
+                since: conversionStartedAt
+            )
+            await standardizationDiagnosticLogger.log(
+                .conversionCompleted(
+                    conversion,
+                    durationMilliseconds: conversionDurationMilliseconds ?? 0
+                )
             )
             guard await preparationLifecycle.isActive(attempt) else { return }
 
@@ -790,16 +848,55 @@ public final class DirectUpload {
             ), await preparationLifecycle.isActive(attempt) else { return }
             guard let generatedInspection = generatedOutcome.result,
                   generatedOutcome.error == nil else {
+                if let result = generatedOutcome.result {
+                    await standardizationDiagnosticLogger.log(
+                        .inspection(
+                            role: .generatedOutput,
+                            facts: result.mediaFacts,
+                            legacyReasons: result.nonStandardInputReasons
+                        )
+                    )
+                }
+                diagnosticFailureWasLogged = true
+                await standardizationDiagnosticLogger.log(
+                    .failure(
+                        category: .outputInspection,
+                        reason: .outputInspectionFailed,
+                        conversion: conversion,
+                        durationMilliseconds: conversionDurationMilliseconds
+                    )
+                )
                 throw generatedOutcome.error
                     ?? UploadInputInspectionError.inspectionFailure
             }
+            await standardizationDiagnosticLogger.log(
+                .inspection(
+                    role: .generatedOutput,
+                    facts: generatedInspection.mediaFacts,
+                    legacyReasons: generatedInspection.nonStandardInputReasons
+                )
+            )
             let validation = outputValidator.validateGeneratedOutput(
                 facts: generatedInspection.mediaFacts,
                 sourceTimeline: inspection.timelineFacts,
                 outputTimeline: generatedInspection.timelineFacts,
                 for: conversion
             )
+            await standardizationDiagnosticLogger.log(
+                .outputValidation(validation)
+            )
             guard validation.isAccepted else {
+                diagnosticFailureWasLogged = true
+                await standardizationDiagnosticLogger.log(
+                    .failure(
+                        category: .outputValidation,
+                        reason: StandardizationDiagnostic.validationFailure(
+                            validation
+                        ),
+                        conversion: conversion,
+                        durationMilliseconds: conversionDurationMilliseconds
+                    )
+                )
                 throw DirectUploadPreparationError.outputRejected(validation)
             }
 
@@ -829,6 +926,17 @@ public final class DirectUpload {
             return
         } catch {
             guard await preparationLifecycle.isActive(attempt) else { return }
+            if !diagnosticFailureWasLogged {
+                await standardizationDiagnosticLogger.log(
+                    .failure(
+                        category: .conversion,
+                        reason: .conversionFailed,
+                        conversion: conversion,
+                        durationMilliseconds: conversionDurationMilliseconds
+                            ?? Self.milliseconds(since: conversionStartedAt)
+                    )
+                )
+            }
             await handlePreparationFailure(
                 error: error,
                 result: inspection,
@@ -839,6 +947,16 @@ public final class DirectUpload {
                 attempt: attempt
             )
         }
+    }
+
+    private static func milliseconds(since start: TimeInterval) -> Int {
+        let milliseconds = (
+            ProcessInfo.processInfo.systemUptime - start
+        ) * 1_000
+        guard milliseconds.isFinite, milliseconds > 0 else { return 0 }
+        return milliseconds >= Double(Int.max)
+            ? Int.max
+            : Int(milliseconds.rounded())
     }
 
     private func handlePreparationFailure(

--- a/Sources/MuxUploadSDK/PublicAPI/SDKLogger.swift
+++ b/Sources/MuxUploadSDK/PublicAPI/SDKLogger.swift
@@ -30,3 +30,11 @@ public extension SDKLogger {
     }
 
 }
+
+extension SDKLogger {
+    static func logStandardizationDiagnostic(
+        _ diagnostic: StandardizationDiagnostic
+    ) {
+        logger?.info("\(diagnostic.message, privacy: .public)")
+    }
+}

--- a/Tests/MuxUploadSDKTests/Helpers/RecordingStandardizationDiagnosticLogger.swift
+++ b/Tests/MuxUploadSDKTests/Helpers/RecordingStandardizationDiagnosticLogger.swift
@@ -1,0 +1,17 @@
+//
+//  RecordingStandardizationDiagnosticLogger.swift
+//
+
+@testable import MuxUploadSDK
+
+actor RecordingStandardizationDiagnosticLogger: StandardizationDiagnosticLogging {
+    private var recordedDiagnostics: [StandardizationDiagnostic] = []
+
+    func log(_ diagnostic: StandardizationDiagnostic) {
+        recordedDiagnostics.append(diagnostic)
+    }
+
+    func messages() -> [String] {
+        recordedDiagnostics.map(\.message)
+    }
+}

--- a/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
+++ b/Tests/MuxUploadSDKTests/PublicAPITests/DirectUploadTests.swift
@@ -315,11 +315,13 @@ class DirectUploadTests: XCTestCase {
 
     func testInputInspectionFailure() async throws {
         let input = try UploadInput.mockReadyInput()
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
 
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
-            inputInspector: MockUploadInputInspector.alwaysFailing
+            inputInspector: MockUploadInputInspector.alwaysFailing,
+            standardizationDiagnosticLogger: diagnostics
         )
 
         let preparingStatusExpectation = XCTestExpectation(
@@ -347,6 +349,11 @@ class DirectUploadTests: XCTestCase {
             timeout: 2.0,
             enforceOrder: true
         )
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("failure_category=inspection")
+                && $0.contains("failure_reason=inspection_failed")
+        }))
         await cancelAndWait(upload)
     }
 
@@ -481,6 +488,7 @@ class DirectUploadTests: XCTestCase {
             )
         )
         let standardizer = MockUploadInputStandardizer()
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
         let inspection = inspectionResult(
             facts: compliantFacts(codec: .hevc, dynamicRange: .hlg, bitDepth: 10)
         )
@@ -489,7 +497,8 @@ class DirectUploadTests: XCTestCase {
             uploadManager: DirectUploadManager(),
             inputInspector: MockUploadInputInspector(mockInspectionResult: inspection),
             inputStandardizer: standardizer,
-            capabilityProvider: FullyCapablePlanningProvider()
+            capabilityProvider: FullyCapablePlanningProvider(),
+            standardizationDiagnosticLogger: diagnostics
         )
         let transportExpectation = expectation(description: "Original transport starts")
         var failureHandlerCallCount = 0
@@ -507,12 +516,72 @@ class DirectUploadTests: XCTestCase {
 
         upload.start()
         await fulfillment(of: [transportExpectation], timeout: 1.0)
+        await cancelAndWait(upload)
 
         XCTAssertEqual(failureHandlerCallCount, 0)
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=plan_selected")
+                && $0.contains("source_codec=hevc")
+                && $0.contains("output_codec=hevc")
+                && $0.contains("resolution_tier=2160p")
+                && $0.contains("hdr_handling=preserve")
+                && $0.contains("hdr_decision=preserve_hlg_for_mux_processing")
+        }))
+        XCTAssertFalse(messages.contains(where: {
+            $0.contains("event=standardization_failure")
+        }))
+    }
+
+    func testPlannerPreservesEligiblePQWithDistinctServerProcessingDiagnostic() async throws {
+        let input = try makeInput(
+            options: DirectUploadOptions(
+                inputStandardization: .init(
+                    maximumResolution: .preset3840x2160,
+                    hdrHandling: .preserve
+                )
+            )
+        )
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: inspectionResult(
+                    facts: compliantFacts(
+                        codec: .hevc,
+                        dynamicRange: .pq,
+                        bitDepth: 10
+                    )
+                )
+            ),
+            capabilityProvider: FullyCapablePlanningProvider(),
+            standardizationDiagnosticLogger: diagnostics
+        )
+        let transportExpectation = expectation(description: "Original transport starts")
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status {
+                transportExpectation.fulfill()
+            }
+        }
+
+        upload.start()
+        await fulfillment(of: [transportExpectation], timeout: 1.0)
         await cancelAndWait(upload)
+
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("dynamic_range=pq")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("hdr_decision=preserve_pq_for_compatible_server_processing")
+        }))
+        XCTAssertFalse(messages.contains(where: {
+            $0.contains("event=standardization_failure")
+        }))
     }
 
     func testToneMapPlanUsesOnlyValidatedGeneratedOutput() async throws {
@@ -534,6 +603,7 @@ class DirectUploadTests: XCTestCase {
             facts: compliantFacts(codec: .hevc, dynamicRange: .sdr, bitDepth: 8)
         )
         let standardizer = MockUploadInputStandardizer(error: nil, resultURL: outputURL)
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
@@ -544,7 +614,8 @@ class DirectUploadTests: XCTestCase {
             ),
             inputStandardizer: standardizer,
             capabilityProvider: FullyCapablePlanningProvider(),
-            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL)
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL),
+            standardizationDiagnosticLogger: diagnostics
         )
         let transportExpectation = expectation(description: "Generated transport starts")
         var transportedFileURL: URL?
@@ -562,6 +633,31 @@ class DirectUploadTests: XCTestCase {
         XCTAssertEqual(snapshot.standardizeCallCount, 1)
         XCTAssertEqual(snapshot.conversion?.toneMapsToSDR, true)
         XCTAssertEqual(transportedFileURL, outputURL)
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=inspection_completed role=source")
+                && $0.contains("source_codec=hevc")
+                && $0.contains("dynamic_range=hlg")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=plan_selected plan=convert")
+                && $0.contains("source_codec=hevc")
+                && $0.contains("output_codec=hevc")
+                && $0.contains("resolution_tier=1080p")
+                && $0.contains("hdr_handling=tone_map_to_sdr")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=conversion_completed")
+                && $0.contains("conversion_duration_ms=")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=inspection_completed role=generated_output")
+                && $0.contains("output_codec=hevc")
+                && $0.contains("dynamic_range=sdr")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=output_validation_completed result=accepted")
+        }))
         await cancelAndWait(upload)
     }
 
@@ -575,6 +671,7 @@ class DirectUploadTests: XCTestCase {
         var rejectedFacts = compliantFacts(codec: .h264, dynamicRange: .sdr, bitDepth: 8)
         rejectedFacts.averageBitrate = .known(50_000_000)
         let standardizer = MockUploadInputStandardizer(error: nil, resultURL: outputURL)
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
@@ -585,7 +682,8 @@ class DirectUploadTests: XCTestCase {
             ),
             inputStandardizer: standardizer,
             capabilityProvider: FullyCapablePlanningProvider(),
-            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL)
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: outputURL),
+            standardizationDiagnosticLogger: diagnostics
         )
         let handlerExpectation = expectation(description: "Validation failure handler runs")
         let transportExpectation = expectation(description: "Original transport starts")
@@ -610,12 +708,18 @@ class DirectUploadTests: XCTestCase {
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: outputURL.path))
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("failure_category=output_validation")
+                && $0.contains("failure_reason=output_non_compliant")
+        }))
         await cancelAndWait(upload)
     }
 
     func testStoragePreflightFailureFallsBackBeforeStandardization() async throws {
         let input = try makeInput(options: .default)
         let standardizer = MockUploadInputStandardizer()
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
         let upload = DirectUpload(
             input: input,
             uploadManager: DirectUploadManager(),
@@ -626,7 +730,8 @@ class DirectUploadTests: XCTestCase {
             ),
             inputStandardizer: standardizer,
             capabilityProvider: FullyCapablePlanningProvider(),
-            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: nil)
+            storagePreflighter: FixedTemporaryStoragePreflighter(outputURL: nil),
+            standardizationDiagnosticLogger: diagnostics
         )
         let handlerExpectation = expectation(description: "Preflight failure handler runs")
         let transportExpectation = expectation(description: "Original transport starts")
@@ -648,6 +753,109 @@ class DirectUploadTests: XCTestCase {
         let standardizerSnapshot = await standardizer.snapshot()
         XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
         XCTAssertEqual(transportedFileURL, input.sourceAsset.url)
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("failure_category=storage")
+                && $0.contains("failure_reason=storage_preflight_failed")
+        }))
+        await cancelAndWait(upload)
+    }
+
+    func testUnsupportedConversionLogsCapabilityFailureAndFallsBack() async throws {
+        let input = try makeInput(options: .default)
+        let standardizer = MockUploadInputStandardizer()
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: inspectionResult(
+                    facts: conversionFacts(codec: .other)
+                )
+            ),
+            inputStandardizer: standardizer,
+            capabilityProvider: NoConversionPlanningProvider(),
+            standardizationDiagnosticLogger: diagnostics
+        )
+        let handlerExpectation = expectation(description: "Failure handler runs")
+        let transportExpectation = expectation(description: "Original transport starts")
+        upload.nonStandardInputHandler = {
+            handlerExpectation.fulfill()
+            return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status {
+                transportExpectation.fulfill()
+            }
+        }
+
+        upload.start()
+        await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
+
+        let standardizerSnapshot = await standardizer.snapshot()
+        XCTAssertEqual(standardizerSnapshot.standardizeCallCount, 0)
+        let messages = await diagnostics.messages()
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("event=plan_selected plan=fallback")
+                && $0.contains("plan_reason=unsupported_conversion")
+        }))
+        XCTAssertTrue(messages.contains(where: {
+            $0.contains("failure_category=capability")
+                && $0.contains("failure_reason=unsupported_conversion")
+        }))
+        await cancelAndWait(upload)
+    }
+
+    func testConversionFailureDiagnosticDoesNotExposeUncontrolledErrorOrCredentials() async throws {
+        let uploadURL = try XCTUnwrap(URL(
+            string: "https://upload.example.com/private?token=UPLOAD_SECRET"
+        ))
+        let input = UploadInput(
+            asset: AVURLAsset(
+                url: URL(fileURLWithPath: "/private/customer/SECRET_SOURCE.mov")
+            ),
+            info: UploadInfo(uploadURL: uploadURL, options: .default)
+        )
+        let diagnostics = RecordingStandardizationDiagnosticLogger()
+        let rawError = SensitiveDiagnosticError(
+            description: "Authorization: Bearer HEADER_SECRET at \(uploadURL.absoluteString) from /private/customer/SECRET_SOURCE.mov"
+        )
+        let upload = DirectUpload(
+            input: input,
+            uploadManager: DirectUploadManager(),
+            inputInspector: MockUploadInputInspector(
+                mockInspectionResult: inspectionResult(
+                    facts: conversionFacts(codec: .other)
+                )
+            ),
+            inputStandardizer: MockUploadInputStandardizer(error: rawError),
+            capabilityProvider: FullyCapablePlanningProvider(),
+            standardizationDiagnosticLogger: diagnostics
+        )
+        let handlerExpectation = expectation(description: "Failure handler runs")
+        let transportExpectation = expectation(description: "Original transport starts")
+        upload.nonStandardInputHandler = {
+            handlerExpectation.fulfill()
+            return false
+        }
+        upload.inputStatusHandler = { status in
+            if case .transportInProgress = status {
+                transportExpectation.fulfill()
+            }
+        }
+
+        upload.start()
+        await fulfillment(of: [handlerExpectation, transportExpectation], timeout: 1.0)
+
+        let message = (await diagnostics.messages()).joined(separator: "\n")
+        XCTAssertTrue(message.contains("failure_category=conversion"))
+        XCTAssertTrue(message.contains("failure_reason=conversion_failed"))
+        XCTAssertTrue(message.contains("conversion_duration_ms="))
+        XCTAssertFalse(message.contains("UPLOAD_SECRET"))
+        XCTAssertFalse(message.contains("HEADER_SECRET"))
+        XCTAssertFalse(message.contains("upload.example.com"))
+        XCTAssertFalse(message.contains("/private/customer"))
+        XCTAssertFalse(message.contains("Authorization"))
         await cancelAndWait(upload)
     }
 
@@ -939,6 +1147,14 @@ private final class FailingChunkedFileUploader: ChunkedFileUploader {
     }
 }
 
+private struct SensitiveDiagnosticError: LocalizedError {
+    let description: String
+
+    var errorDescription: String? {
+        description
+    }
+}
+
 private struct FullyCapablePlanningProvider: StandardInputPlanningCapabilityProviding {
     func capabilities(
         for inspection: UploadInputFormatInspectionResult,
@@ -949,6 +1165,21 @@ private struct FullyCapablePlanningProvider: StandardInputPlanningCapabilityProv
             encodableVideoCodecs: [.h264, .hevc],
             remediableRequirements: Set(StandardInputPolicyEvaluation.Requirement.allCases),
             toneMappableDynamicRanges: [.hlg, .pq],
+            preservableHDRDynamicRanges: [.hlg, .pq]
+        )
+    }
+}
+
+private struct NoConversionPlanningProvider: StandardInputPlanningCapabilityProviding {
+    func capabilities(
+        for inspection: UploadInputFormatInspectionResult,
+        sourceAsset: AVAsset
+    ) async -> StandardInputPlanningCapabilities {
+        StandardInputPlanningCapabilities(
+            sourceIsDecodable: false,
+            encodableVideoCodecs: [],
+            remediableRequirements: [],
+            toneMappableDynamicRanges: [],
             preservableHDRDynamicRanges: [.hlg, .pq]
         )
     }


### PR DESCRIPTION
## Summary

- add structured SDKLogger diagnostics for source and generated-output inspection, selected plans, codecs, resolution tier, HDR decisions, conversion duration, output validation, and categorized failures
- distinguish intentional HLG and PQ preservation, including the compatible server-processing decision, without emitting failure diagnostics
- keep publicly rendered diagnostics credential-safe through closed typed payloads; never render raw errors, URLs, file paths, headers, tokens, or credentials
- preserve existing lifecycle, fallback, cancellation, stale-attempt, and temporary-output ownership behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes along the existing preparation path; upload lifecycle, fallbacks, and cancellation behavior are unchanged aside from extra async log calls.
> 
> **Overview**
> Adds **structured OSLog diagnostics** across the input standardization pipeline, replacing the ad-hoc debug plan log with injectable `StandardizationDiagnosticLogging`.
> 
> `DirectUpload` now emits typed events for source/generated inspection, plan selection (codec, resolution tier, HDR handling/decisions), conversion completion with duration, output validation, and categorized failures (inspection, capability, storage, conversion, output inspection/validation). Intentional HLG/PQ preservation is reflected in plan/HDR fields **without** `standardization_failure` events.
> 
> Diagnostics are built from **closed vocabularies and sanitized media facts** only—no raw errors, URLs, paths, or credentials in public log lines. Tests use a recording logger and assert expected fields plus that sensitive strings stay out of messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 947a85cf82bbf93c70da0d43e035d5f613bb37dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->